### PR TITLE
FIX: generate target depends on vendor packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ vet:
 	go vet ./...
 
 # Generate code
-generate:
+generate: vendor
 ifndef GOPATH
 	$(error GOPATH not defined, please define GOPATH. Run "go help gopath" to learn more about GOPATH)
 endif


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | Not this time (I'm lazy)
| License         | Apache 2.0


### What's in this PR?
Build fix on freshly checked out instance.



### Why?
'make' on fresh checkout fails due to missing vendor folder.
Added vendor as a dependency for the generate target to fix the issue.

