### PR TITLE
Use generated headless service name for Cruise Control

### DIFF
--- a/pkg/resources/cruisecontrol/configmap.go
+++ b/pkg/resources/cruisecontrol/configmap.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/banzaicloud/kafka-operator/pkg/resources/kafka"
 	"github.com/banzaicloud/kafka-operator/pkg/resources/templates"
 	"github.com/banzaicloud/kafka-operator/pkg/util"
 	"github.com/go-logr/logr"
@@ -38,7 +39,7 @@ func (r *Reconciler) configMap(log logr.Logger) runtime.Object {
     # Configuration for the metadata client.
     # =======================================
     # The Kafka cluster to control.
-    bootstrap.servers=kafka-headless:29092
+    bootstrap.servers=%s:%d
     # The maximum interval in milliseconds between two metadata refreshes.
     #metadata.max.age.ms=300000
     # Client id for the Cruise Control. It is used for the metadata client.
@@ -220,7 +221,7 @@ func (r *Reconciler) configMap(log logr.Logger) runtime.Object {
     webserver.accesslog.path=access.log
     # HTTP Request Log retention days
     webserver.accesslog.retention.days=14
-`, strings.Join(r.KafkaCluster.Spec.ZKAddresses, ",")) +
+`, fmt.Sprintf(kafka.HeadlessServiceTemplate, r.KafkaCluster.Name), r.KafkaCluster.Spec.ListenersConfig.InternalListeners[0].ContainerPort, strings.Join(r.KafkaCluster.Spec.ZKAddresses, ",")) +
 				generateSSLConfig(&r.KafkaCluster.Spec.ListenersConfig),
 			"capacity.json": `
 {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |yes|
| New feature?    |no|
| API breaks?     |no|
| Deprecations?   |no|
| Related tickets | fixes #67 
| License         | Apache 2.0


### What's in this PR?
This PR removes the hard coded Kafka-headless service address from CC Configmap.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline

### Todo
I just created an issue about free CC configuration
#68 