### PR TITLE
Configure node affinity based on the available failure domain selectors only, document minikube lb limitation

### DIFF
--- a/docs/developer.md
+++ b/docs/developer.md
@@ -30,3 +30,12 @@ Create CR and let the operator set up Kafka in your cluster (you can change the 
 > Remember you need Zookeeper server to run Kafka
 
 `kubectl create -n kafka -f config/samples/banzaicloud_v1alpha1_kafkacluster.yaml`
+
+#### Limitations on minikube
+
+Minikube does not have a load balancer implementation, thus our envoy service will not get an external IP and the operator will get stuck at this point.
+
+A possible solution to overcome this problem is to use https://github.com/elsonrodriguez/minikube-lb-patch. The operator will be able to proceed if you run the following command:
+```go
+kubectl run minikube-lb-patch --replicas=1 --image=elsonrodriguez/minikube-lb-patch:0.1 --namespace=kube-system
+``` 

--- a/pkg/k8sutil/cr.go
+++ b/pkg/k8sutil/cr.go
@@ -28,7 +28,7 @@ import (
 )
 
 func updateCrWithNodeAffinity(current *corev1.Pod, cr *banzaicloudv1alpha1.KafkaCluster, client runtimeClient.Client) error {
-	failureDomainSelectors, err :=  failureDomainSelectors(current.Spec.NodeName, client)
+	failureDomainSelectors, err := failureDomainSelectors(current.Spec.NodeName, client)
 	if err != nil {
 		return emperror.WrapWith(err, "determining Node selector failed")
 	}

--- a/pkg/k8sutil/zoneandregion.go
+++ b/pkg/k8sutil/zoneandregion.go
@@ -41,10 +41,10 @@ func failureDomainSelectors(nodeName string, client runtimeClient.Client) ([]cor
 		for key, val := range labels {
 			defaultFailureDomainSelector.MatchExpressions =
 				append(defaultFailureDomainSelector.MatchExpressions, corev1.NodeSelectorRequirement{
-						Key:      key,
-						Operator: corev1.NodeSelectorOpIn,
-						Values:   []string{val},
-					})
+					Key:      key,
+					Operator: corev1.NodeSelectorOpIn,
+					Values:   []string{val},
+				})
 		}
 		terms = append(terms, defaultFailureDomainSelector)
 	}

--- a/pkg/k8sutil/zoneandregion.go
+++ b/pkg/k8sutil/zoneandregion.go
@@ -27,22 +27,28 @@ const (
 	regionLabel = "failure-domain.beta.kubernetes.io/region"
 )
 
-// NodeZoneAndRegion holds information about Zone and Region
-type NodeZoneAndRegion struct {
-	Zone   string
-	Region string
-}
-
-func determineNodeZoneAndRegion(nodeName string, client runtimeClient.Client) (*NodeZoneAndRegion, error) {
+func failureDomainSelectors(nodeName string, client runtimeClient.Client) ([]corev1.NodeSelectorTerm, error) {
+	terms := []corev1.NodeSelectorTerm{}
 
 	labels, err := getSpecificNodeLabels(nodeName, client, []string{zoneLabel, regionLabel})
 	if err != nil {
 		return nil, err
 	}
-	return &NodeZoneAndRegion{
-		Zone:   labels[zoneLabel],
-		Region: labels[regionLabel],
-	}, nil
+
+	if len(labels) > 0 {
+		defaultFailureDomainSelector := corev1.NodeSelectorTerm{}
+
+		for key, val := range labels {
+			defaultFailureDomainSelector.MatchExpressions =
+				append(defaultFailureDomainSelector.MatchExpressions, corev1.NodeSelectorRequirement{
+						Key:      key,
+						Operator: corev1.NodeSelectorOpIn,
+						Values:   []string{val},
+					})
+		}
+		terms = append(terms, defaultFailureDomainSelector)
+	}
+	return terms, nil
 }
 
 func getSpecificNodeLabels(nodeName string, client runtimeClient.Client, filter []string) (map[string]string, error) {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #76
| License         | Apache 2.0


### What's in this PR?
Configures node affinity based on the available failure domain selectors only to avoid failing on nonexistent labels on the node.
Document load balancer limitation on minikube and how to overcome it.

### Why?
To allow flawless minikube experience and to avoid because of missing failure domain labels in general.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
