### PR TITLE
Fix typo when generating JVMPerfOpts for Kafka

### DIFF
--- a/pkg/apis/banzaicloud/v1alpha1/kafkacluster_types.go
+++ b/pkg/apis/banzaicloud/v1alpha1/kafkacluster_types.go
@@ -183,7 +183,7 @@ func (bConfig *BrokerConfig) GetKafkaHeapOpts() string {
 
 // GetKafkaPerfJmvOpts returns the broker specific Perf JVM settings
 func (bConfig *BrokerConfig) GetKafkaPerfJmvOpts() string {
-	if bConfig.KafkaHeapOpts != "" {
+	if bConfig.KafkaJVMPerfOpts != "" {
 		return bConfig.KafkaJVMPerfOpts
 	}
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |yes|
| New feature?    |no|
| API breaks?     |no|
| Deprecations?   |no|
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
This PR fixes the misused variable to the correct one which caused to remove JVMPerfOpts from Kafka if the JVM heap size was set.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)