### PR TITLE
Use 0.5.2 release in the helm chart

### DIFF
--- a/charts/kafka-operator/Chart.yaml
+++ b/charts/kafka-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: kafka-operator
-version: 0.0.10
+version: 0.0.11
 description: kafka-operator manages Kafka deployments on Kubernetes
 sources:
   - https://github.com/banzaicloud/kafka-operator
-appVersion: 0.5.1
+appVersion: 0.5.2

--- a/charts/kafka-operator/values.yaml
+++ b/charts/kafka-operator/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 operator:
   image:
     repository: banzaicloud/kafka-operator
-    tag: 0.5.1
+    tag: 0.5.2
     pullPolicy: IfNotPresent
   resources:
     limits:


### PR DESCRIPTION
Bump chart to use 0.5.2 release