### PR TITLE
add support for broker classes

### DIFF
--- a/charts/kafka-operator/templates/operator-kafka-crd.yaml
+++ b/charts/kafka-operator/templates/operator-kafka-crd.yaml
@@ -69,6 +69,8 @@ spec:
                   - storageConfigs
                 type: object
               type: array
+            brokerConfigGroups:
+              type: object
             cruiseControlConfig:
               properties:
                 capacityConfig:

--- a/config/crds/banzaicloud_v1alpha1_kafkacluster.yaml
+++ b/config/crds/banzaicloud_v1alpha1_kafkacluster.yaml
@@ -63,6 +63,8 @@ spec:
                 - storageConfigs
                 type: object
               type: array
+            brokerConfigGroups:
+              type: object
             cruiseControlConfig:
               properties:
                 capacityConfig:

--- a/config/samples/banzaicloud_v1alpha1_kafkacluster.yaml
+++ b/config/samples/banzaicloud_v1alpha1_kafkacluster.yaml
@@ -104,6 +104,22 @@ spec:
             resources:
               requests:
                 storage: 10Gi
+  # brokerConfigGroups specifies multiple broker configs with unique name
+  brokerConfigGroups:
+    # Specify desired group name (eg., 'default_group')
+    default_group:
+      # brokerConfig spec
+      image: "wurstmeister/kafka:2.12-2.1.0"
+      config: |
+        auto.create.topics.enable=false
+      storageConfigs:
+        - mountPath: "/kafka-logs"
+          pvcSpec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 10Gi
   # listenersConfig specifies kafka's listener specific configs
   listenersConfig:
     # externalListeners specifies settings required to access kafka externally

--- a/config/samples/example-prometheus-alerts.yaml
+++ b/config/samples/example-prometheus-alerts.yaml
@@ -12,6 +12,8 @@ prometheus:
           annotations:
             description: 'broker {{ $labels.brokerId }} overloaded (current value is: {{ $value }})'
             summary: 'broker overloaded'
+            # If brokerConfigGroup is defined it will override scaled broker config
+            # brokerConfigGroup: 'default_group'
             storageClass: 'standard'
             mountPath: '/kafkalog'
             diskSize: '2G'

--- a/internal/alertmanager/currentalert/process.go
+++ b/internal/alertmanager/currentalert/process.go
@@ -86,12 +86,12 @@ func upScale(labels model.LabelSet, annotations model.LabelSet, client client.Cl
 
 	var brokerConfig *banzaicloudv1alpha1.BrokerConfig
 
-	brokerClass := string(annotations["brokerClass"])
+	brokerConfigGroupName := string(annotations["brokerConfigGroup"])
 
-	if brokerClassConfig, ok := cr.Spec.BrokerClasses[brokerClass]; ok {
+	if brokerConfigGroup, ok := cr.Spec.BrokerConfigGroups[brokerConfigGroupName]; ok {
 
-		brokerClassConfig.Id = biggestId + 1
-		brokerConfig = brokerClassConfig
+		brokerConfig = brokerConfigGroup
+		brokerConfig.Id = biggestId + 1
 
 	} else {
 

--- a/pkg/apis/banzaicloud/v1alpha1/kafkacluster_types.go
+++ b/pkg/apis/banzaicloud/v1alpha1/kafkacluster_types.go
@@ -28,17 +28,17 @@ import (
 
 // KafkaClusterSpec defines the desired state of KafkaCluster
 type KafkaClusterSpec struct {
-	HeadlessServiceEnabled bool                         `json:"headlessServiceEnabled"`
-	ListenersConfig        ListenersConfig              `json:"listenersConfig"`
-	ZKAddresses            []string                     `json:"zkAddresses"`
-	RackAwareness          *RackAwareness               `json:"rackAwareness,omitempty"`
-	BrokerConfigs          []BrokerConfig               `json:"brokerConfigs"`
-	BrokerClasses          map[string]*BrokerConfig     `json:"brokerClasses"`
-	OneBrokerPerNode       bool                         `json:"oneBrokerPerNode"`
-	CruiseControlConfig    CruiseControlConfig          `json:"cruiseControlConfig"`
-	EnvoyConfig            EnvoyConfig                  `json:"envoyConfig,omitempty"`
-	ServiceAccount         string                       `json:"serviceAccount"`
-	MonitoringConfig       MonitoringConfig             `json:"monitoringConfig,omitempty"`
+	HeadlessServiceEnabled bool                     `json:"headlessServiceEnabled"`
+	ListenersConfig        ListenersConfig          `json:"listenersConfig"`
+	ZKAddresses            []string                 `json:"zkAddresses"`
+	RackAwareness          *RackAwareness           `json:"rackAwareness,omitempty"`
+	BrokerConfigs          []BrokerConfig           `json:"brokerConfigs"`
+	BrokerClasses          map[string]*BrokerConfig `json:"brokerClasses"`
+	OneBrokerPerNode       bool                     `json:"oneBrokerPerNode"`
+	CruiseControlConfig    CruiseControlConfig      `json:"cruiseControlConfig"`
+	EnvoyConfig            EnvoyConfig              `json:"envoyConfig,omitempty"`
+	ServiceAccount         string                   `json:"serviceAccount"`
+	MonitoringConfig       MonitoringConfig         `json:"monitoringConfig,omitempty"`
 }
 
 // KafkaClusterStatus defines the observed state of KafkaCluster

--- a/pkg/apis/banzaicloud/v1alpha1/kafkacluster_types.go
+++ b/pkg/apis/banzaicloud/v1alpha1/kafkacluster_types.go
@@ -33,7 +33,7 @@ type KafkaClusterSpec struct {
 	ZKAddresses            []string                 `json:"zkAddresses"`
 	RackAwareness          *RackAwareness           `json:"rackAwareness,omitempty"`
 	BrokerConfigs          []BrokerConfig           `json:"brokerConfigs"`
-	BrokerClasses          map[string]*BrokerConfig `json:"brokerClasses, omitempty"`
+	BrokerConfigGroups     map[string]*BrokerConfig `json:"brokerConfigGroups,omitempty"`
 	OneBrokerPerNode       bool                     `json:"oneBrokerPerNode"`
 	CruiseControlConfig    CruiseControlConfig      `json:"cruiseControlConfig"`
 	EnvoyConfig            EnvoyConfig              `json:"envoyConfig,omitempty"`

--- a/pkg/apis/banzaicloud/v1alpha1/kafkacluster_types.go
+++ b/pkg/apis/banzaicloud/v1alpha1/kafkacluster_types.go
@@ -28,16 +28,17 @@ import (
 
 // KafkaClusterSpec defines the desired state of KafkaCluster
 type KafkaClusterSpec struct {
-	HeadlessServiceEnabled bool                `json:"headlessServiceEnabled"`
-	ListenersConfig        ListenersConfig     `json:"listenersConfig"`
-	ZKAddresses            []string            `json:"zkAddresses"`
-	RackAwareness          *RackAwareness      `json:"rackAwareness,omitempty"`
-	BrokerConfigs          []BrokerConfig      `json:"brokerConfigs"`
-	OneBrokerPerNode       bool                `json:"oneBrokerPerNode"`
-	CruiseControlConfig    CruiseControlConfig `json:"cruiseControlConfig"`
-	EnvoyConfig            EnvoyConfig         `json:"envoyConfig,omitempty"`
-	ServiceAccount         string              `json:"serviceAccount"`
-	MonitoringConfig       MonitoringConfig    `json:"monitoringConfig,omitempty"`
+	HeadlessServiceEnabled bool                         `json:"headlessServiceEnabled"`
+	ListenersConfig        ListenersConfig              `json:"listenersConfig"`
+	ZKAddresses            []string                     `json:"zkAddresses"`
+	RackAwareness          *RackAwareness               `json:"rackAwareness,omitempty"`
+	BrokerConfigs          []BrokerConfig               `json:"brokerConfigs"`
+	BrokerClasses          map[string]*BrokerConfig     `json:"brokerClasses"`
+	OneBrokerPerNode       bool                         `json:"oneBrokerPerNode"`
+	CruiseControlConfig    CruiseControlConfig          `json:"cruiseControlConfig"`
+	EnvoyConfig            EnvoyConfig                  `json:"envoyConfig,omitempty"`
+	ServiceAccount         string                       `json:"serviceAccount"`
+	MonitoringConfig       MonitoringConfig             `json:"monitoringConfig,omitempty"`
 }
 
 // KafkaClusterStatus defines the observed state of KafkaCluster

--- a/pkg/apis/banzaicloud/v1alpha1/kafkacluster_types.go
+++ b/pkg/apis/banzaicloud/v1alpha1/kafkacluster_types.go
@@ -33,7 +33,7 @@ type KafkaClusterSpec struct {
 	ZKAddresses            []string                 `json:"zkAddresses"`
 	RackAwareness          *RackAwareness           `json:"rackAwareness,omitempty"`
 	BrokerConfigs          []BrokerConfig           `json:"brokerConfigs"`
-	BrokerClasses          map[string]*BrokerConfig `json:"brokerClasses"`
+	BrokerClasses          map[string]*BrokerConfig `json:"brokerClasses, omitempty"`
 	OneBrokerPerNode       bool                     `json:"oneBrokerPerNode"`
 	CruiseControlConfig    CruiseControlConfig      `json:"cruiseControlConfig"`
 	EnvoyConfig            EnvoyConfig              `json:"envoyConfig,omitempty"`

--- a/pkg/apis/banzaicloud/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/banzaicloud/v1alpha1/zz_generated.deepcopy.go
@@ -235,6 +235,21 @@ func (in *KafkaClusterSpec) DeepCopyInto(out *KafkaClusterSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.BrokerConfigGroups != nil {
+		in, out := &in.BrokerConfigGroups, &out.BrokerConfigGroups
+		*out = make(map[string]*BrokerConfig, len(*in))
+		for key, val := range *in {
+			var outVal *BrokerConfig
+			if val == nil {
+				(*out)[key] = nil
+			} else {
+				in, out := &val, &outVal
+				*out = new(BrokerConfig)
+				(*in).DeepCopyInto(*out)
+			}
+			(*out)[key] = outVal
+		}
+	}
 	out.CruiseControlConfig = in.CruiseControlConfig
 	out.EnvoyConfig = in.EnvoyConfig
 	out.MonitoringConfig = in.MonitoringConfig


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no|yes
| New feature?    | yes
| API breaks?     | no|yes
| Deprecations?   | no|yes
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
This PR add support for defined brokers spec (`brokerclasses`) to be used in scaling kafka cluster. The current implementation use many annotations in the alert definitions which is not supporting all broker config like CPU/Memory resources. Instead of these annotations, a single annotation of alerts could be used (`brokerClass`). Further the classes could be defined in `KafkaCluster` spec. The current implementation will also be kept for compatibility.

Also the prometheus namespace label (`kubernetes_namespace`) is replaced with (`namespace`) which is more common for latest prometheus/ prometheus-operator. The `ServiceMonitor` CRD by default will re-label `__meta_kubernetes_namespace` to `namespace`.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [x] Modify CRD
- [x] Modify prometheus config 