### PR TITLE
add support for NodeSelector/Tolerations

### DIFF
--- a/charts/kafka-operator/templates/operator-kafka-crd.yaml
+++ b/charts/kafka-operator/templates/operator-kafka-crd.yaml
@@ -50,6 +50,10 @@ spec:
                     type: string
                   nodeAffinity:
                     type: object
+                  nodeSelector:
+                    type: object
+                  tolerations:
+                    type: object
                   resourceReqs:
                     type: object
                   storageConfigs:

--- a/config/crds/banzaicloud_v1alpha1_kafkacluster.yaml
+++ b/config/crds/banzaicloud_v1alpha1_kafkacluster.yaml
@@ -44,6 +44,10 @@ spec:
                     type: string
                   nodeAffinity:
                     type: object
+                  nodeSelector:
+                    type: object
+                  tolerations:
+                    type: object
                   resourceReqs:
                     type: object
                   storageConfigs:

--- a/config/samples/banzaicloud_v1alpha1_kafkacluster.yaml
+++ b/config/samples/banzaicloud_v1alpha1_kafkacluster.yaml
@@ -39,6 +39,10 @@ spec:
           cpu: "200m"
       # nodeAffinity can be specified, operator populates this value if new pvc added later to brokers
       # nodeAffinity:
+      # nodeSelector can be specified, which set the pod to fit on a node
+      # nodeSelector:
+      # tolerations can be specified, which set the pod's tolerations
+      # tolerations:
       # config parameter can be used to pass any Kafka config https://kafka.apache.org/documentation/#brokerconfigs
       # expect listener specific configs, security based configs, log dir related configs
       # we recommend to disable automatic topic creation, enabling it may result ineffective CC topic

--- a/pkg/apis/banzaicloud/v1alpha1/kafkacluster_types.go
+++ b/pkg/apis/banzaicloud/v1alpha1/kafkacluster_types.go
@@ -51,6 +51,8 @@ type BrokerConfig struct {
 	Image            string                       `json:"image,omitempty"`
 	Id               int32                        `json:"id"`
 	NodeAffinity     *corev1.NodeAffinity         `json:"nodeAffinity,omitempty"`
+	NodeSelector     map[string]string            `json:"nodeSelector,omitempty"`
+	Tolerations      []corev1.Toleration          `json:"tolerations,omitempty"`
 	Config           string                       `json:"config,omitempty"`
 	StorageConfigs   []StorageConfig              `json:"storageConfigs"`
 	Resources        *corev1.ResourceRequirements `json:"resourceReqs,omitempty"`

--- a/pkg/resources/kafka/pod.go
+++ b/pkg/resources/kafka/pod.go
@@ -200,6 +200,12 @@ func (r *Reconciler) pod(broker banzaicloudv1alpha1.BrokerConfig, pvcs []corev1.
 	if broker.NodeAffinity != nil {
 		pod.Spec.Affinity.NodeAffinity = broker.NodeAffinity
 	}
+	if broker.NodeSelector != nil {
+		pod.Spec.NodeSelector = broker.NodeSelector
+	}
+	if broker.Tolerations != nil {
+		pod.Spec.Tolerations = broker.Tolerations
+	}
 	return pod
 }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no|yes
| New feature?    | yes
| API breaks?     | no|yes
| Deprecations?   | no|yes
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
This PR will add support for pod `NodeSelector` and `Tolerations`

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
In some environments (multi-tenant kubernetes clusters) worker groups would be configured for different workload. To control scheduling on these kubernetes worker groups, taints and node labels could be configured for specific worker groups (like hardware spec). To allow kafka cluster to be deployed by the operator on specific worker groups, then `NodeSelector` and `Tolerations` will be needed.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [x] CRDs definitions
