### PR TITLE
Fix CruiseControl resource names to be able to run multiple kafka clu…

### DIFF
--- a/internal/alertmanager/currentalert/process.go
+++ b/internal/alertmanager/currentalert/process.go
@@ -59,7 +59,7 @@ func downScale(labels model.LabelSet, client client.Client) error {
 		return err
 	}
 
-	brokerId, err := scale.GetBrokerIDWithLeastPartition(string(labels["namespace"]), cr.Spec.CruiseControlConfig.CruiseControlEndpoint)
+	brokerId, err := scale.GetBrokerIDWithLeastPartition(string(labels["namespace"]), cr.Spec.CruiseControlConfig.CruiseControlEndpoint, cr.Name)
 	if err != nil {
 		return err
 	}

--- a/pkg/k8sutil/resource.go
+++ b/pkg/k8sutil/resource.go
@@ -134,7 +134,7 @@ func Reconcile(log logr.Logger, client runtimeClient.Client, desired runtime.Obj
 					}
 				}
 				if current.(*corev1.Pod).Status.Phase == corev1.PodRunning && brokerState.GracefulActionState.CruiseControlState == banzaicloudv1alpha1.GracefulUpdateRequired {
-					scaleErr := scale.UpScaleCluster(desired.(*corev1.Pod).Labels["brokerId"], desired.(*corev1.Pod).Namespace, cr.Spec.CruiseControlConfig.CruiseControlEndpoint)
+					scaleErr := scale.UpScaleCluster(desired.(*corev1.Pod).Labels["brokerId"], desired.(*corev1.Pod).Namespace, cr.Spec.CruiseControlConfig.CruiseControlEndpoint, cr.Name)
 					if scaleErr != nil {
 						log.Error(err, "graceful upscale failed, or cluster just started")
 						statusErr := updateGracefulScaleStatus(client, brokerId, cr,

--- a/pkg/resources/cruisecontrol/configmap.go
+++ b/pkg/resources/cruisecontrol/configmap.go
@@ -30,7 +30,7 @@ import (
 
 func (r *Reconciler) configMap(log logr.Logger) runtime.Object {
 	configMap := &corev1.ConfigMap{
-		ObjectMeta: templates.ObjectMeta(configAndVolumeName, labelSelector, r.KafkaCluster),
+		ObjectMeta: templates.ObjectMeta(fmt.Sprintf(configAndVolumeNameTemplate, r.KafkaCluster.Name), labelSelector, r.KafkaCluster),
 		Data: map[string]string{
 			"cruisecontrol.properties": r.KafkaCluster.Spec.CruiseControlConfig.Config + fmt.Sprintf(`
     # The Kafka cluster to control.

--- a/pkg/resources/cruisecontrol/cruisecontrol.go
+++ b/pkg/resources/cruisecontrol/cruisecontrol.go
@@ -15,6 +15,8 @@
 package cruisecontrol
 
 import (
+	"fmt"
+
 	banzaicloudv1alpha1 "github.com/banzaicloud/kafka-operator/pkg/apis/banzaicloud/v1alpha1"
 	"github.com/banzaicloud/kafka-operator/pkg/k8sutil"
 	"github.com/banzaicloud/kafka-operator/pkg/resources"
@@ -24,17 +26,17 @@ import (
 )
 
 const (
-	componentName          = "cruisecontrol"
-	serviceName            = "cruisecontrol-svc"
-	configAndVolumeName    = "cruisecontrol-config"
-	modconfigAndVolumeName = "cruisecontrol-modconfig"
-	deploymentName         = "cruisecontrol"
-	keystoreVolume         = "ks-files"
-	keystoreVolumePath     = "/var/run/secrets/java.io/keystores"
-	pemFilesVolume         = "pem-files"
-	jmxVolumePath          = "/opt/jmx-exporter/"
-	jmxVolumeName          = "jmx-jar-data"
-	metricsPort            = 9020
+	componentNameTemplate       = "%s-cruisecontrol"
+	serviceNameTemplate         = "%s-cruisecontrol-svc"
+	configAndVolumeNameTemplate = "%s-cruisecontrol-config"
+	modconfigAndVolumeName      = "cruisecontrol-modconfig"
+	deploymentNameTemplate      = "%s-cruisecontrol"
+	keystoreVolume              = "ks-files"
+	keystoreVolumePath          = "/var/run/secrets/java.io/keystores"
+	pemFilesVolume              = "pem-files"
+	jmxVolumePath               = "/opt/jmx-exporter/"
+	jmxVolumeName               = "jmx-jar-data"
+	metricsPort                 = 9020
 )
 
 var labelSelector = map[string]string{
@@ -58,7 +60,7 @@ func New(client client.Client, cluster *banzaicloudv1alpha1.KafkaCluster) *Recon
 
 // Reconcile implements the reconcile logic for CC
 func (r *Reconciler) Reconcile(log logr.Logger) error {
-	log = log.WithValues("component", componentName)
+	log = log.WithValues("component", fmt.Sprintf(componentNameTemplate, r.KafkaCluster.Name))
 
 	log.V(1).Info("Reconciling")
 

--- a/pkg/resources/cruisecontrol/service.go
+++ b/pkg/resources/cruisecontrol/service.go
@@ -15,6 +15,8 @@
 package cruisecontrol
 
 import (
+	"fmt"
+
 	"github.com/banzaicloud/kafka-operator/pkg/resources/templates"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -24,7 +26,7 @@ import (
 
 func (r *Reconciler) service(log logr.Logger) runtime.Object {
 	return &corev1.Service{
-		ObjectMeta: templates.ObjectMeta(serviceName, labelSelector, r.KafkaCluster),
+		ObjectMeta: templates.ObjectMeta(fmt.Sprintf(serviceNameTemplate, r.KafkaCluster.Name), labelSelector, r.KafkaCluster),
 		Spec: corev1.ServiceSpec{
 			Selector: labelSelector,
 			Ports: []corev1.ServicePort{

--- a/pkg/resources/kafka/kafka.go
+++ b/pkg/resources/kafka/kafka.go
@@ -167,7 +167,7 @@ func (r *Reconciler) Reconcile(log logr.Logger) error {
 			deletedBrokers = append(deletedBrokers, pod)
 		}
 		for _, broker := range deletedBrokers {
-			err = scale.DownsizeCluster(broker.Labels["brokerId"], broker.Namespace, r.KafkaCluster.Spec.CruiseControlConfig.CruiseControlEndpoint)
+			err = scale.DownsizeCluster(broker.Labels["brokerId"], broker.Namespace, r.KafkaCluster.Spec.CruiseControlConfig.CruiseControlEndpoint, r.KafkaCluster.Name)
 			if err != nil {
 				log.Error(err, "graceful downscale failed.")
 			}


### PR DESCRIPTION
…sters on single namespace

| Q               | A
| --------------- | ---
| Bug fix?        |yes|
| New feature?    |no|
| API breaks?     |no|
| Deprecations?   |no|
| Related tickets | fixes #101
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Fix CC resource names to be able to run multiple Kafka Cluster in a single namespace.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)