### PR TITLE
Bump chart to use 0.5.3 version of the operator

### DIFF
--- a/charts/kafka-operator/Chart.yaml
+++ b/charts/kafka-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: kafka-operator
-version: 0.0.11
+version: 0.0.12
 description: kafka-operator manages Kafka deployments on Kubernetes
 sources:
   - https://github.com/banzaicloud/kafka-operator
-appVersion: 0.5.2
+appVersion: 0.5.3

--- a/charts/kafka-operator/values.yaml
+++ b/charts/kafka-operator/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 operator:
   image:
     repository: banzaicloud/kafka-operator
-    tag: 0.5.2
+    tag: 0.5.3
     pullPolicy: IfNotPresent
   resources:
     limits:


### PR DESCRIPTION
Bump helm chart version to 0.0.12 to use 0.5.3 release
