### PR TITLE
added imagepullsecret to the CRD/pod creation

### DIFF
--- a/charts/kafka-operator/templates/operator-kafka-crd.yaml
+++ b/charts/kafka-operator/templates/operator-kafka-crd.yaml
@@ -53,7 +53,9 @@ spec:
                   nodeSelector:
                     type: object
                   tolerations:
-                    type: object
+                    items:
+                      type: object
+                    type: array
                   resourceReqs:
                     type: object
                   storageConfigs:
@@ -97,6 +99,10 @@ spec:
               type: object
             headlessServiceEnabled:
               type: boolean
+            imagePullSecrets:
+              items:
+                type: object
+              type: array
             listenersConfig:
               properties:
                 externalListeners:

--- a/config/crds/banzaicloud_v1alpha1_kafkacluster.yaml
+++ b/config/crds/banzaicloud_v1alpha1_kafkacluster.yaml
@@ -28,6 +28,8 @@ spec:
           type: object
         spec:
           properties:
+            brokerConfigGroups:
+              type: object
             brokerConfigs:
               items:
                 properties:
@@ -46,8 +48,6 @@ spec:
                     type: object
                   nodeSelector:
                     type: object
-                  tolerations:
-                    type: object
                   resourceReqs:
                     type: object
                   storageConfigs:
@@ -62,13 +62,15 @@ spec:
                       - pvcSpec
                       type: object
                     type: array
+                  tolerations:
+                    items:
+                      type: object
+                    type: array
                 required:
                 - id
                 - storageConfigs
                 type: object
               type: array
-            brokerConfigGroups:
-              type: object
             cruiseControlConfig:
               properties:
                 capacityConfig:
@@ -91,6 +93,10 @@ spec:
               type: object
             headlessServiceEnabled:
               type: boolean
+            imagePullSecrets:
+              items:
+                type: object
+              type: array
             listenersConfig:
               properties:
                 externalListeners:

--- a/pkg/apis/banzaicloud/v1alpha1/kafkacluster_types.go
+++ b/pkg/apis/banzaicloud/v1alpha1/kafkacluster_types.go
@@ -28,17 +28,18 @@ import (
 
 // KafkaClusterSpec defines the desired state of KafkaCluster
 type KafkaClusterSpec struct {
-	HeadlessServiceEnabled bool                     `json:"headlessServiceEnabled"`
-	ListenersConfig        ListenersConfig          `json:"listenersConfig"`
-	ZKAddresses            []string                 `json:"zkAddresses"`
-	RackAwareness          *RackAwareness           `json:"rackAwareness,omitempty"`
-	BrokerConfigs          []BrokerConfig           `json:"brokerConfigs"`
-	BrokerConfigGroups     map[string]*BrokerConfig `json:"brokerConfigGroups,omitempty"`
-	OneBrokerPerNode       bool                     `json:"oneBrokerPerNode"`
-	CruiseControlConfig    CruiseControlConfig      `json:"cruiseControlConfig"`
-	EnvoyConfig            EnvoyConfig              `json:"envoyConfig,omitempty"`
-	ServiceAccount         string                   `json:"serviceAccount"`
-	MonitoringConfig       MonitoringConfig         `json:"monitoringConfig,omitempty"`
+	HeadlessServiceEnabled bool                          `json:"headlessServiceEnabled"`
+	ListenersConfig        ListenersConfig               `json:"listenersConfig"`
+	ZKAddresses            []string                      `json:"zkAddresses"`
+	RackAwareness          *RackAwareness                `json:"rackAwareness,omitempty"`
+	BrokerConfigs          []BrokerConfig                `json:"brokerConfigs"`
+	BrokerConfigGroups     map[string]*BrokerConfig      `json:"brokerConfigGroups,omitempty"`
+	OneBrokerPerNode       bool                          `json:"oneBrokerPerNode"`
+	CruiseControlConfig    CruiseControlConfig           `json:"cruiseControlConfig"`
+	EnvoyConfig            EnvoyConfig                   `json:"envoyConfig,omitempty"`
+	ServiceAccount         string                        `json:"serviceAccount"`
+	ImagePullSecrets       []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
+	MonitoringConfig       MonitoringConfig              `json:"monitoringConfig,omitempty"`
 }
 
 // KafkaClusterStatus defines the observed state of KafkaCluster
@@ -156,6 +157,11 @@ func (spec *KafkaClusterSpec) GetServiceAccount() string {
 		return spec.ServiceAccount
 	}
 	return "default"
+}
+
+//GetImagePullSecrets returns the list of Secrets needed to pull Containers images from private repositories
+func (spec *KafkaClusterSpec) GetImagePullSecrets() []corev1.LocalObjectReference {
+	return spec.ImagePullSecrets
 }
 
 // GetResources returns the broker specific Kubernetes resource

--- a/pkg/apis/banzaicloud/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/banzaicloud/v1alpha1/zz_generated.deepcopy.go
@@ -266,6 +266,11 @@ func (in *KafkaClusterSpec) DeepCopyInto(out *KafkaClusterSpec) {
 	}
 	out.CruiseControlConfig = in.CruiseControlConfig
 	out.EnvoyConfig = in.EnvoyConfig
+	if in.ImagePullSecrets != nil {
+		in, out := &in.ImagePullSecrets, &out.ImagePullSecrets
+		*out = make([]v1.LocalObjectReference, len(*in))
+		copy(*out, *in)
+	}
 	out.MonitoringConfig = in.MonitoringConfig
 	return
 }

--- a/pkg/resources/cruisecontrol/deployment.go
+++ b/pkg/resources/cruisecontrol/deployment.go
@@ -59,6 +59,8 @@ func (r *Reconciler) deployment(log logr.Logger) runtime.Object {
 					Annotations: util.MonitoringAnnotations(metricsPort),
 				},
 				Spec: corev1.PodSpec{
+					ServiceAccountName:            r.KafkaCluster.Spec.GetServiceAccount(),
+					ImagePullSecrets:              r.KafkaCluster.Spec.GetImagePullSecrets(),
 					TerminationGracePeriodSeconds: util.Int64Pointer(30),
 					InitContainers: append(initContainers, []corev1.Container{
 						{

--- a/pkg/resources/envoy/deployment.go
+++ b/pkg/resources/envoy/deployment.go
@@ -62,6 +62,8 @@ func (r *Reconciler) deployment(log logr.Logger) runtime.Object {
 					Labels: labelSelector,
 				},
 				Spec: corev1.PodSpec{
+					ServiceAccountName: r.KafkaCluster.Spec.GetServiceAccount(),
+					ImagePullSecrets:   r.KafkaCluster.Spec.GetImagePullSecrets(),
 					Containers: []corev1.Container{
 						{
 							Name:  "envoy",

--- a/pkg/resources/kafka/pod.go
+++ b/pkg/resources/kafka/pod.go
@@ -188,6 +188,7 @@ func (r *Reconciler) pod(broker banzaicloudv1alpha1.BrokerConfig, pvcs []corev1.
 			TerminationGracePeriodSeconds: util.Int64Pointer(60),
 			DNSPolicy:                     corev1.DNSClusterFirst,
 			ServiceAccountName:            r.KafkaCluster.Spec.GetServiceAccount(),
+			ImagePullSecrets:              r.KafkaCluster.Spec.GetImagePullSecrets(),
 			SecurityContext:               &corev1.PodSecurityContext{},
 			Priority:                      util.Int32Pointer(0),
 			SchedulerName:                 "default-scheduler",


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes https://github.com/banzaicloud/kafka-operator/issues/106
| License         | Apache 2.0


### What's in this PR?
Added `ImagePullSecrets` parameter to the `KafkaCluster` CRD so we can define the secrets needed to pull the Container image from a private repository.


### Why?
see Issue https://github.com/banzaicloud/kafka-operator/issues/106

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Implementation tested
- [ ] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [ ] Logging code meets the guideline
- [ ] User guide and development docs updated (if needed)

