### PR TITLE
Save typeMeta when updating the CR

### DIFF
--- a/pkg/k8sutil/cr.go
+++ b/pkg/k8sutil/cr.go
@@ -139,9 +139,12 @@ func GetCr(name, namespace string, client runtimeClient.Client) (*banzaicloudv1a
 }
 
 func updateCr(cr *banzaicloudv1alpha1.KafkaCluster, client runtimeClient.Client) error {
+	typeMeta := cr.TypeMeta
 	err := client.Update(context.TODO(), cr)
 	if err != nil {
 		return err
 	}
+	// update loses the typeMeta of the config that's used later when setting ownerrefs
+	cr.TypeMeta = typeMeta
 	return nil
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |yes|
| New feature?    |no|
| API breaks?     |no|
| Deprecations?   |no|
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

This PR fixes a minor glitch which introduced the following error:
```
failed to reconcile resource: updating resource failed: ConfigMap \"kafka-config\" is invalid: [metadata.ownerReferences.apiVersion: Invalid value: \"\": version must not be empty, metadata.ownerReferences.kind: Invalid value: \"\": kind must not be empty]"
```

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)