### PR TITLE
Use Broker Internal FQDN for Certificate CN - Improve CR Garbage collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,26 @@ The operator installs the 2.1.0 version of Apache Kafka, and can run on Minikube
 
 As a pre-requisite it needs a Kubernetes cluster (you can create one using [Pipeline](https://github.com/banzaicloud/pipeline)). Also, Kafka requires Zookeeper so you need to first have a Zookeeper cluster if you don't already have one.
 
-> We believe in the `separation of concerns` principle, thus the Kafka operator does not install nor manage Zookeeper. If you would like to have a fully automated and managed experience of Apache Kafka on Kubernetes please try it with [Pipeline](https://github.com/banzaicloud/pipeline).
+The operator also uses `cert-manager` for issuing certificates to users and brokers, so you'll need to have it setup in case you haven't already.
+
+> We believe in the `separation of concerns` principle, thus the Kafka operator does not install nor manage Zookeeper or cert-manager. If you would like to have a fully automated and managed experience of Apache Kafka on Kubernetes please try it with [Pipeline](https://github.com/banzaicloud/pipeline).
+
+#### Install cert-manager
+
+```bash
+# Add the jetstack helm repo
+helm repo add jetstack https://charts.jetstack.io
+
+# pre-create cert-manager namespace and CRDs per their installation instructions
+kubectl create ns cert-manager
+kubectl label namespace cert-manager certmanager.k8s.io/disable-validation=true
+kubectl apply -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.10/deploy/manifests/00-crds.yaml
+
+# Install cert-manager into the cluster
+# --set webhook.enabled=false may not be required for you, but avoids issues with
+# certificates not being able to be issued due to the webhook not working.
+helm install --name cert-manager --namespace cert-manager --version v0.10.0 --set webhook.enabled=false jetstack/cert-manager
+```
 
 ##### Install Zookeeper
 

--- a/docs/ssl.md
+++ b/docs/ssl.md
@@ -1,3 +1,24 @@
+## Setting up cert-manager
+
+`kafka-operator` assumes you have `cert-manager` set up in your Kubernetes cluster for issuing certificates.
+You can set it up easily with a few commands and their helm chart.
+
+```bash
+# Add the jetstack helm repo
+helm repo add jetstack https://charts.jetstack.io
+helm repo update
+
+# pre-create cert-manager namespace and CRDs per their installation instructions
+kubectl create ns cert-manager
+kubectl label namespace cert-manager certmanager.k8s.io/disable-validation=true
+kubectl apply -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.10/deploy/manifests/00-crds.yaml
+
+# Install cert-manager into the cluster
+# --set webhook.enabled=false may not be required for you, but avoids issues with
+# certificates not being able to be issued due to the webhook not working.
+helm install --name cert-manager --namespace cert-manager --version v0.10.0 --set webhook.enabled=false jetstack/cert-manager
+```
+
 ## Securing Kafka With SSL
 
 The `kafka-operator` makes securing your Kafka cluster with SSL simple.

--- a/docs/ssl.md
+++ b/docs/ssl.md
@@ -1,24 +1,3 @@
-## Setting up cert-manager
-
-`kafka-operator` assumes you have `cert-manager` set up in your Kubernetes cluster for issuing certificates.
-You can set it up easily with a few commands and their helm chart.
-
-```bash
-# Add the jetstack helm repo
-helm repo add jetstack https://charts.jetstack.io
-helm repo update
-
-# pre-create cert-manager namespace and CRDs per their installation instructions
-kubectl create ns cert-manager
-kubectl label namespace cert-manager certmanager.k8s.io/disable-validation=true
-kubectl apply -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.10/deploy/manifests/00-crds.yaml
-
-# Install cert-manager into the cluster
-# --set webhook.enabled=false may not be required for you, but avoids issues with
-# certificates not being able to be issued due to the webhook not working.
-helm install --name cert-manager --namespace cert-manager --version v0.10.0 --set webhook.enabled=false jetstack/cert-manager
-```
-
 ## Securing Kafka With SSL
 
 The `kafka-operator` makes securing your Kafka cluster with SSL simple.

--- a/pkg/resources/pki/pki.go
+++ b/pkg/resources/pki/pki.go
@@ -101,9 +101,9 @@ func (r *Reconciler) Reconcile(log logr.Logger) error {
 
 		// Grab ownership of all secrets we created through cert-manager
 		secretNames := []types.NamespacedName{
-			types.NamespacedName{Name: fmt.Sprintf(brokerCACertTemplate, r.KafkaCluster.Name), Namespace: "cert-manager"},
-			types.NamespacedName{Name: fmt.Sprintf(brokerServerCertTemplate, r.KafkaCluster.Name), Namespace: r.KafkaCluster.Namespace},
-			types.NamespacedName{Name: fmt.Sprintf(BrokerControllerTemplate, r.KafkaCluster.Name), Namespace: r.KafkaCluster.Namespace},
+			{Name: fmt.Sprintf(brokerCACertTemplate, r.KafkaCluster.Name), Namespace: "cert-manager"},
+			{Name: fmt.Sprintf(brokerServerCertTemplate, r.KafkaCluster.Name), Namespace: r.KafkaCluster.Namespace},
+			{Name: fmt.Sprintf(BrokerControllerTemplate, r.KafkaCluster.Name), Namespace: r.KafkaCluster.Namespace},
 		}
 
 		for _, o := range secretNames {


### PR DESCRIPTION

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?

Just a few last minute catches from the previous Topic/User CRD PR. Some older libraries won't check the SANs of the broker certificates when doing SSL verification. That's really their problem more than ours, but this makes the CN match to the full FQDN of the internal service so at least that will work for them (as opposed to nothing before).

I also make sure to cleanup all secrets made through the `pki` resource. This saves you from weird behavior while spinning clusters up and down for testing where old certificates were getting reused.  

Also added a small section to the installation instructions on how to setup `cert-manager` if they had not done so already. 

### Why?

Mostly just makes testing easier, but also good to fully garbage collect everything we create as part of a `KafkaCluster`. The SSL thing was more an annoyance when I was playing with an end-to-end test and couldn't figure out why it didn't like the certificates. 

Also, the helm chart will fail with what might be a cryptic error for novice users if `cert-manager` is not present, so thought would be a good idea to include instructions on that. 

### Checklist

- [X] Implementation tested
- [X] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [X] Logging code meets the guideline
- [X] User guide and development docs updated
