### PR TITLE
Fix Storage Config

### DIFF
--- a/pkg/resources/kafka/configmap.go
+++ b/pkg/resources/kafka/configmap.go
@@ -55,7 +55,9 @@ metric.reporters=com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlM
 cruise.control.metrics.reporter.bootstrap.servers={{ .CruiseControlBootstrapServers }}
 broker.id={{ .Id }}
 
-{{ .StorageConfig }}
+{{ if .StorageConfig }}
+log.dirs={{ .StorageConfig }}
+{{ end }}
 
 {{ .AdvertisedListenersConfig }}
 
@@ -119,7 +121,7 @@ func generateStorageConfig(sConfig []banzaicloudv1alpha1.StorageConfig) string {
 	for _, storage := range sConfig {
 		mountPaths = append(mountPaths, storage.MountPath+`/kafka`)
 	}
-	return fmt.Sprintf("log.dirs=%s\n", strings.Join(mountPaths, ","))
+	return strings.Join(mountPaths, ",")
 }
 
 func generateListenerSpecificConfig(l *banzaicloudv1alpha1.ListenersConfig, log logr.Logger) string {

--- a/pkg/resources/kafka/configmap.go
+++ b/pkg/resources/kafka/configmap.go
@@ -119,7 +119,7 @@ func generateStorageConfig(sConfig []banzaicloudv1alpha1.StorageConfig) string {
 	for _, storage := range sConfig {
 		mountPaths = append(mountPaths, storage.MountPath+`/kafka`)
 	}
-	return strings.Join(mountPaths, ",")
+	return fmt.Sprintf("log.dirs=%s\n", strings.Join(mountPaths, ","))
 }
 
 func generateListenerSpecificConfig(l *banzaicloudv1alpha1.ListenersConfig, log logr.Logger) string {

--- a/pkg/resources/kafka/configmap_test.go
+++ b/pkg/resources/kafka/configmap_test.go
@@ -30,6 +30,7 @@ func TestGenerateBrokerConfig(t *testing.T) {
 		perBrokerReadOnlyConfig string
 		perBrokerConfig         string
 		expectedConfig          string
+		perBrokerStorageConfig  []v1alpha1.StorageConfig
 	}{
 		{
 			testName:                "basicConfig",
@@ -42,6 +43,28 @@ broker.id=0
 cruise.control.metrics.reporter.bootstrap.servers=PLAINTEXT://kafka-0.kafka.svc.cluster.local:9092
 listener.security.protocol.map=PLAINTEXT:PLAINTEXT
 listeners=PLAINTEXT://:9092
+metric.reporters=com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporter
+security.inter.broker.protocol=PLAINTEXT
+super.users=
+zookeeper.connect=example.zk:2181`,
+		},
+		{
+			testName:                "basicConfigWithCustomStorage",
+			readOnlyConfig:          ``,
+			clusterWideConfig:       ``,
+			perBrokerConfig:         ``,
+			perBrokerReadOnlyConfig: ``,
+			perBrokerStorageConfig: []v1alpha1.StorageConfig{
+				{
+					MountPath: "/kafka-logs",
+				},
+			},
+			expectedConfig: `advertised.listeners=PLAINTEXT://kafka-0.kafka.svc.cluster.local:9092
+broker.id=0
+cruise.control.metrics.reporter.bootstrap.servers=PLAINTEXT://kafka-0.kafka.svc.cluster.local:9092
+listener.security.protocol.map=PLAINTEXT:PLAINTEXT
+listeners=PLAINTEXT://:9092
+log.dirs=/kafka-logs/kafka
 metric.reporters=com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporter
 security.inter.broker.protocol=PLAINTEXT
 super.users=
@@ -137,6 +160,7 @@ zookeeper.connect=example.zk:2181`,
 								BrokerConfig: &v1alpha1.BrokerConfig{
 									ReadOnlyConfig: test.perBrokerReadOnlyConfig,
 									Config:         test.perBrokerConfig,
+									StorageConfigs: test.perBrokerStorageConfig,
 								},
 							},
 							},


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no|yes
| API breaks?     | no|yes
| Deprecations?   | no|yes
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | Apache 2.0


### What's in this PR?
This PR fix the configuration of kafka logs. 


### Why?
The current implementation is not configuring the `kafka.logs` property making the cluster use the default directory which is `/tmp/kafka-logs`. The line added was borrowed from master branch


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Implementation tested
- [ ] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [ ] Logging code meets the guideline
- [ ] User guide and development docs updated (if needed)

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [ ] If the PR is not complete but you want to discuss the approach, list what remains to be done here
