### PR TITLE
Move readOnly config out from brokerConfigGroups

### DIFF
--- a/api/v1alpha1/kafkacluster_types.go
+++ b/api/v1alpha1/kafkacluster_types.go
@@ -65,6 +65,7 @@ type RollingUpgradeConfig struct {
 type Broker struct {
 	Id                int32         `json:"id"`
 	BrokerConfigGroup string        `json:"brokerConfigGroup,omitempty"`
+	ReadOnlyConfig    string        `json:"readOnlyConfig,omitempty"`
 	BrokerConfig      *BrokerConfig `json:"brokerConfig,omitempty"`
 }
 
@@ -72,7 +73,6 @@ type Broker struct {
 type BrokerConfig struct {
 	Image              string                        `json:"image,omitempty"`
 	NodeAffinity       *corev1.NodeAffinity          `json:"nodeAffinity,omitempty"`
-	ReadOnlyConfig     string                        `json:"readOnlyConfig,omitempty"`
 	Config             string                        `json:"config,omitempty"`
 	StorageConfigs     []StorageConfig               `json:"storageConfigs,omitempty"`
 	ServiceAccountName string                        `json:"serviceAccountName,omitempty"`

--- a/config/crd/bases/banzaicloud.banzaicloud.io_kafkaclusters.yaml
+++ b/config/crd/bases/banzaicloud.banzaicloud.io_kafkaclusters.yaml
@@ -263,8 +263,6 @@ spec:
                     additionalProperties:
                       type: string
                     type: object
-                  readOnlyConfig:
-                    type: string
                   resourceRequirements:
                     description: ResourceRequirements describes the compute resource
                       requirements.
@@ -705,8 +703,6 @@ spec:
                         additionalProperties:
                           type: string
                         type: object
-                      readOnlyConfig:
-                        type: string
                       resourceRequirements:
                         description: ResourceRequirements describes the compute resource
                           requirements.
@@ -917,6 +913,8 @@ spec:
                   id:
                     format: int32
                     type: integer
+                  readOnlyConfig:
+                    type: string
                 required:
                 - id
                 type: object

--- a/pkg/resources/kafka/configmap.go
+++ b/pkg/resources/kafka/configmap.go
@@ -176,7 +176,7 @@ func getInternalListeners(iListeners []banzaicloudv1alpha1.InternalListenerConfi
 func (r Reconciler) generateBrokerConfig(id int32, brokerConfig *banzaicloudv1alpha1.BrokerConfig, superUsers []string, loadBalancerIP string, log logr.Logger) string {
 	parsedReadOnlyClusterConfig := util.ParsePropertiesFormat(r.KafkaCluster.Spec.ReadOnlyConfig)
 
-	parsedReadOnlyBrokerConfig := util.ParsePropertiesFormat(brokerConfig.ReadOnlyConfig)
+	parsedReadOnlyBrokerConfig := util.ParsePropertiesFormat(r.KafkaCluster.Spec.Brokers[id].ReadOnlyConfig)
 
 	if err := mergo.Merge(&parsedReadOnlyBrokerConfig, parsedReadOnlyClusterConfig); err != nil {
 		log.Error(err, "error occurred during merging readonly configs")

--- a/pkg/resources/kafka/configmap_test.go
+++ b/pkg/resources/kafka/configmap_test.go
@@ -126,9 +126,9 @@ zookeeper.connect=example.zk:2181`,
 							ReadOnlyConfig:    test.readOnlyConfig,
 							ClusterWideConfig: test.clusterWideConfig,
 							Brokers: []v1alpha1.Broker{{
-								Id: 0,
+								Id:             0,
+								ReadOnlyConfig: test.perBrokerReadOnlyConfig,
 								BrokerConfig: &v1alpha1.BrokerConfig{
-									ReadOnlyConfig: test.perBrokerReadOnlyConfig,
 									Config:         test.perBrokerConfig,
 									StorageConfigs: test.perBrokerStorageConfig,
 								},


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |yes
| New feature?    |no
| API breaks?     |yes
| Deprecations?   |no
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
This PR moves readOnly config from BrokerConfigGroups

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline
