### PR TITLE
Prune/imagePullSecrets

### DIFF
--- a/charts/kafka-operator/Chart.yaml
+++ b/charts/kafka-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kafka-operator
-version: 0.2.0
+version: 0.2.1
 description: kafka-operator manages Kafka deployments on Kubernetes
 sources:
   - https://github.com/banzaicloud/kafka-operator

--- a/charts/kafka-operator/templates/authproxy-rbac.yaml
+++ b/charts/kafka-operator/templates/authproxy-rbac.yaml
@@ -1,6 +1,12 @@
 {{- if and .Values.rbac.enabled .Values.prometheusMetrics.enabled .Values.prometheusMetrics.authProxy.enabled }}
 apiVersion: v1
 kind: ServiceAccount
+{{- if .Values.imagePullSecrets }}
+imagePullSecrets:
+{{- range .Values.imagePullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- end }}
 metadata:
   name: {{ include "kafka-operator.fullname" . }}-authproxy
   labels:

--- a/charts/kafka-operator/templates/operator-deployment.yaml
+++ b/charts/kafka-operator/templates/operator-deployment.yaml
@@ -19,7 +19,7 @@ spec:
       app.kubernetes.io/name: {{ include "kafka-operator.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
       app.kubernetes.io/component: operator
-  replicas: 1
+  replicas: {{ .Values.replicaCount }}
   template:
     metadata:
       labels:

--- a/charts/kafka-operator/templates/operator-rbac.yaml
+++ b/charts/kafka-operator/templates/operator-rbac.yaml
@@ -1,6 +1,12 @@
 {{- if .Values.rbac.enabled }}
 apiVersion: v1
 kind: ServiceAccount
+{{- if .Values.imagePullSecrets }}
+imagePullSecrets:
+{{- range .Values.imagePullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- end }}
 metadata:
   name: {{ include "kafka-operator.fullname" . }}-operator
   labels:

--- a/charts/kafka-operator/values.yaml
+++ b/charts/kafka-operator/values.yaml
@@ -4,6 +4,10 @@
 
 replicaCount: 1
 
+# Lists the secrets you need to use to pull kafka-operator image from a private registry.
+imagePullSecrets: []
+  # - private-registry-key
+
 operator:
   image:
     repository: banzaicloud/kafka-operator


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | none
| License         | Apache 2.0


### What's in this PR?
This PR add support for setting a imagePullSecrets in the Helm Chart to deploy the Kafka Operator from a private repository.
The `imagePullSecrets` is added to the `ServiceAccount`

### Why?
Because Private Docker repo needs control...

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

Also, make use of the `replicaCount` value to set the number of replicas of the Operator.