### PR TITLE
fix port int convertation

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -74,7 +74,7 @@ func MergeLabels(l map[string]string, l2 map[string]string) map[string]string {
 func MonitoringAnnotations(port int) map[string]string {
 	return map[string]string{
 		"prometheus.io/scrape": "true",
-		"prometheus.io/port":   string(port),
+		"prometheus.io/port":   strconv.Itoa(port),
 	}
 }
 

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -29,3 +29,10 @@ empty.config=
 	}
 
 }
+
+func TestMonitoringAnnotations(t *testing.T) {
+	annotations := MonitoringAnnotations(8888)
+	if annotations["prometheus.io/port"] != "8888" {
+		t.Error("Error port not converted correctly")
+	}
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets |
| License         | Apache 2.0


### What's in this PR?
currently the prometheus scrape port annotation contains some funny ascii char, this PR fixes the this problem.


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Implementation tested
- [ ] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [ ] Logging code meets the guideline
- [ ] User guide and development docs updated (if needed)

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [ ] If the PR is not complete but you want to discuss the approach, list what remains to be done here
