### PR TITLE
add exists check for __CruiseControlMetrics topic

### DIFF
--- a/pkg/resources/cruisecontrol/topicManager.go
+++ b/pkg/resources/cruisecontrol/topicManager.go
@@ -32,6 +32,13 @@ func generateCCTopic(cluster *v1beta1.KafkaCluster, client client.Client, log lo
 	}
 	defer broker.Close()
 
+	topic, err := broker.GetTopic("__CruiseControlMetrics")
+
+	// topic exists
+	if err == nil && topic != nil {
+		return nil
+	}
+
 	return broker.CreateTopic(&kafkaclient.CreateTopicOptions{
 		Name:              "__CruiseControlMetrics",
 		Partitions:        12,


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
after creating a new cluster I got error that the controller is not possible to create the __CruiseControlMetrics topic. After checking the boker logs I found out that the topic was already. I tryed to create new clusters multible times I got always the same error so I added a check if the topic already exists.


### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [ ] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [ ] Logging code meets the guideline
- [ ] User guide and development docs updated (if needed)

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [ ] If the PR is not complete but you want to discuss the approach, list what remains to be done here
