### PR TITLE
Add support for Kafka 2.2+ and simplify some configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ If you are willing to kickstart your managed Apache Kafka experience on 5 cloud 
 
 ## Installation
 
-The operator installs the 2.1.0 version of Apache Kafka, and can run on Minikube v0.33.1+ and Kubernetes 1.12.0+.
+The operator installs the 2.3.0 version of Apache Kafka, and can run on Minikube v0.33.1+ and Kubernetes 1.12.0+.
 
 As a pre-requisite it needs a Kubernetes cluster (you can create one using [Pipeline](https://github.com/banzaicloud/pipeline)). Also, Kafka requires Zookeeper so you need to first have a Zookeeper cluster if you don't already have one.
 

--- a/api/v1beta1/kafkacluster_types.go
+++ b/api/v1beta1/kafkacluster_types.go
@@ -159,6 +159,7 @@ type InternalListenerConfig struct {
 	Name                            string `json:"name"`
 	UsedForInnerBrokerCommunication bool   `json:"usedForInnerBrokerCommunication"`
 	ContainerPort                   int32  `json:"containerPort"`
+	UsedForControllerCommunication  bool   `json:"usedForControllerCommunication,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -191,7 +192,7 @@ func (cConfig *CruiseControlConfig) GetInitContainerImage() string {
 	if cConfig.InitContainerImage != "" {
 		return cConfig.InitContainerImage
 	}
-	return "wurstmeister/kafka:2.12-2.1.0"
+	return "wurstmeister/kafka:2.12-2.3.0"
 }
 
 //GetLoadBalancerSourceRanges returns LoadBalancerSourceRanges to use for Envoy generated LoadBalancer

--- a/charts/kafka-operator/templates/operator-kafka-crd.yaml
+++ b/charts/kafka-operator/templates/operator-kafka-crd.yaml
@@ -40,6 +40,10 @@ spec:
               additionalProperties:
                 description: BrokerConfig defines the broker configuration
                 properties:
+                  brokerAnnotations:
+                    additionalProperties:
+                      type: string
+                    type: object
                   config:
                     type: string
                   image:
@@ -470,6 +474,10 @@ spec:
                   brokerConfig:
                     description: BrokerConfig defines the broker configuration
                     properties:
+                      brokerAnnotations:
+                        additionalProperties:
+                          type: string
+                        type: object
                       config:
                         type: string
                       image:
@@ -1148,6 +1156,8 @@ spec:
                         type: string
                       type:
                         type: string
+                      usedForControllerCommunication:
+                        type: boolean
                       usedForInnerBrokerCommunication:
                         type: boolean
                     required:

--- a/config/crd/bases/kafka.banzaicloud.io_kafkaclusters.yaml
+++ b/config/crd/bases/kafka.banzaicloud.io_kafkaclusters.yaml
@@ -1152,6 +1152,8 @@ spec:
                         type: string
                       type:
                         type: string
+                      usedForControllerCommunication:
+                        type: boolean
                       usedForInnerBrokerCommunication:
                         type: boolean
                     required:

--- a/config/samples/banzaicloud_v1beta1_kafkacluster.yaml
+++ b/config/samples/banzaicloud_v1beta1_kafkacluster.yaml
@@ -23,7 +23,7 @@ spec:
   oneBrokerPerNode: false
   # Specify the Kafka Broker related settings
   # clusterImage can specify the whole kafkacluster image in one place
-  #clusterImage: "wurstmeister/kafka:2.12-2.1.0"
+  #clusterImage: "wurstmeister/kafka:2.12-2.3.0"
   # readOnlyConfig specifies the read-only type kafka config cluster wide, all these will be merged with broker specified
   # readOnly configurations, so it can be overwritten per broker.
   #clusterWideConfig specifies the cluster-wide kafka config cluster wide, all these can be overridden per-broker
@@ -60,7 +60,7 @@ spec:
         auto.create.topics.enable=false
       brokerConfig:
         # Docker image used by the operator to create the Broker with id 0
-        #image: "wurstmeister/kafka:2.12-2.1.0"
+        #image: "wurstmeister/kafka:2.12-2.3.0"
         # resourceRequirements works exactly like Container resources, the user can specify the limit and the requests
         # through this property
         #resourceRequirements:
@@ -108,7 +108,7 @@ spec:
           #      resources:
           #        requests:
           #          storage: 3Gi
-    - image: "wurstmeister/kafka:2.12-2.1.0"
+    - image: "wurstmeister/kafka:2.12-2.3.0"
       id: 1
       config: |
         auto.create.topics.enable=false
@@ -124,7 +124,7 @@ spec:
       readOnlyConfig: |
         auto.create.topics.enable=false
       brokerConfig:
-        image: "wurstmeister/kafka:2.12-2.1.0"
+        image: "wurstmeister/kafka:2.12-2.3.0"
         storageConfigs:
           - mountPath: "/kafka-logs"
             pvcSpec:

--- a/config/samples/example-prometheus-alerts.yaml
+++ b/config/samples/example-prometheus-alerts.yaml
@@ -17,7 +17,7 @@ prometheus:
             storageClass: 'standard'
             mountPath: '/kafkalog'
             diskSize: '2G'
-            image: 'wurstmeister/kafka:2.12-2.1.0'
+            image: 'wurstmeister/kafka:2.12-2.3.0'
             command: 'upScale'
         - alert: BrokerUnderReplicated
           expr: kafka_server_replicamanager_underreplicatedpartitions > 0
@@ -30,7 +30,7 @@ prometheus:
             storageClass: 'standard'
             mountPath: '/kafkalog'
             diskSize: '2G'
-            image: 'wurstmeister/kafka:2.12-2.1.0'
+            image: 'wurstmeister/kafka:2.12-2.3.0'
             command: 'upScale'
         - alert: PartitionCountHigh
           expr: max(kafka_server_replicamanager_partitioncount)  by (kubernetes_namespace, kafka_cr) > 100
@@ -43,7 +43,7 @@ prometheus:
             storageClass: 'standard'
             mountPath: '/kafkalog'
             diskSize: '2G'
-            image: 'wurstmeister/kafka:2.12-2.1.0'
+            image: 'wurstmeister/kafka:2.12-2.3.0'
             command: 'upScale'
         - alert: PartitionCountLow
           expr: min(kafka_server_replicamanager_partitioncount)  by (kubernetes_namespace, kafka_cr) < 40

--- a/config/samples/kafkacluster-prometheus.yaml
+++ b/config/samples/kafkacluster-prometheus.yaml
@@ -82,7 +82,7 @@ spec:
         storageClass: 'standard'
         mountPath: '/kafkalog'
         diskSize: '2G'
-        image: 'wurstmeister/kafka:2.12-2.1.0'
+        image: 'wurstmeister/kafka:2.12-2.3.0'
         command: 'upScale'
     - alert: BrokerUnderReplicated
       expr: kafka_server_replicamanager_underreplicatedpartitions > 0
@@ -95,7 +95,7 @@ spec:
         storageClass: 'standard'
         mountPath: '/kafkalog'
         diskSize: '2G'
-        image: 'wurstmeister/kafka:2.12-2.1.0'
+        image: 'wurstmeister/kafka:2.12-2.3.0'
         command: 'upScale'
     - alert: PartitionCountHigh
       expr: max(kafka_server_replicamanager_partitioncount)  by (namespace, kafka_cr) > 100
@@ -108,7 +108,7 @@ spec:
         storageClass: 'standard'
         mountPath: '/kafkalog'
         diskSize: '2G'
-        image: 'wurstmeister/kafka:2.12-2.1.0'
+        image: 'wurstmeister/kafka:2.12-2.3.0'
         command: 'upScale'
     - alert: PartitionCountLow
       expr: min(kafka_server_replicamanager_partitioncount)  by (namespace, kafka_cr) < 40

--- a/config/samples/kafkacluster_with_external_ssl.yaml
+++ b/config/samples/kafkacluster_with_external_ssl.yaml
@@ -9,7 +9,7 @@ spec:
   zkAddresses:
     - "example-zookeepercluster-client.zookeeper:2181"
   oneBrokerPerNode: false
-  clusterImage: "wurstmeister/kafka:2.12-2.1.0"
+  clusterImage: "wurstmeister/kafka:2.12-2.3.0"
   readOnlyConfig: |
     auto.create.topics.enable=false
   brokers:
@@ -56,6 +56,11 @@ spec:
         name: "plaintext"
         containerPort: 29092
         usedForInnerBrokerCommunication: true
+      - type: "plaintext"
+        name: "controller"
+        containerPort: 29093
+        usedForInnerBrokerCommunication: false
+        usedForControllerCommunication: true
     sslSecrets:
       tlsSecretName: "test-kafka-operator"
       jksPasswordName: "test-kafka-operator-pass"

--- a/config/samples/kafkacluster_with_ssl_groups.yaml
+++ b/config/samples/kafkacluster_with_ssl_groups.yaml
@@ -14,7 +14,7 @@ spec:
       - "failure-domain.beta.kubernetes.io/region"
       - "failure-domain.beta.kubernetes.io/zone"
   oneBrokerPerNode: false
-  clusterImage: "wurstmeister/kafka:2.12-2.1.0"
+  clusterImage: "wurstmeister/kafka:2.12-2.3.0"
   readOnlyConfig: |
     auto.create.topics.enable=false
     authorizer.class.name=kafka.security.auth.SimpleAclAuthorizer
@@ -44,6 +44,11 @@ spec:
         name: "ssl"
         containerPort: 29092
         usedForInnerBrokerCommunication: true
+      - type: "ssl"
+        name: "controller"
+        containerPort: 29093
+        usedForInnerBrokerCommunication: false
+        usedForControllerCommunication: true
     sslSecrets:
       tlsSecretName: "test-kafka-operator"
       jksPasswordName: "test-kafka-operator-pass"

--- a/config/samples/kafkacluster_without_ssl.yaml
+++ b/config/samples/kafkacluster_without_ssl.yaml
@@ -9,7 +9,7 @@ spec:
   zkAddresses:
     - "example-zookeepercluster-client.zookeeper:2181"
   oneBrokerPerNode: false
-  clusterImage: "wurstmeister/kafka:2.12-2.1.0"
+  clusterImage: "wurstmeister/kafka:2.12-2.3.0"
   readOnlyConfig: |
     auto.create.topics.enable=false
   brokers:
@@ -56,6 +56,11 @@ spec:
         name: "plaintext"
         containerPort: 29092
         usedForInnerBrokerCommunication: true
+      - type: "plaintext"
+        name: "controller"
+        containerPort: 29093
+        usedForInnerBrokerCommunication: false
+        usedForControllerCommunication: true
   cruiseControlConfig:
     config: |
       # Copyright 2017 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.

--- a/config/samples/kafkacluster_without_ssl_groups.yaml
+++ b/config/samples/kafkacluster_without_ssl_groups.yaml
@@ -9,7 +9,7 @@ spec:
   zkAddresses:
     - "example-zookeepercluster-client.zookeeper:2181"
   oneBrokerPerNode: false
-  clusterImage: "wurstmeister/kafka:2.12-2.1.0"
+  clusterImage: "wurstmeister/kafka:2.12-2.3.0"
   readOnlyConfig: |
     auto.create.topics.enable=false
   brokerConfigGroups:
@@ -42,6 +42,11 @@ spec:
         name: "plaintext"
         containerPort: 29092
         usedForInnerBrokerCommunication: true
+      - type: "plaintext"
+        name: "controller"
+        containerPort: 29093
+        usedForInnerBrokerCommunication: false
+        usedForControllerCommunication: true
   cruiseControlConfig:
     config: |
       # Copyright 2017 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.

--- a/config/samples/simplekafkacluster.yaml
+++ b/config/samples/simplekafkacluster.yaml
@@ -9,7 +9,7 @@ spec:
   zkAddresses:
     - "example-zookeepercluster-client.zookeeper:2181"
   oneBrokerPerNode: false
-  clusterImage: "wurstmeister/kafka:2.12-2.1.0"
+  clusterImage: "wurstmeister/kafka:2.12-2.3.0"
   readOnlyConfig: |
     auto.create.topics.enable=false
   brokerConfigGroups:
@@ -34,9 +34,14 @@ spec:
   listenersConfig:
     internalListeners:
       - type: "plaintext"
-        name: "plaintext"
+        name: "internal"
         containerPort: 29092
         usedForInnerBrokerCommunication: true
+      - type: "plaintext"
+        name: "controller"
+        containerPort: 29093
+        usedForInnerBrokerCommunication: false
+        usedForControllerCommunication: true
   cruiseControlConfig:
     config: |
       # Copyright 2017 LinkedIn Corp. Licensed under the BSD 2-Clause License (the "License"). See License in the project root for license information.

--- a/docs/test.md
+++ b/docs/test.md
@@ -27,7 +27,7 @@ EOF
 To create a sample topic from the CLI you can run the following:
 
 ```bash
-kubectl -n kafka run kafka-topics -it --image=wurstmeister/kafka:2.12-2.1.0 --rm=true --restart=Never -- /opt/kafka/bin/kafka-topics.sh --zookeeper example-zookeepercluster-client.zookeeper:2181 --topic my-topic --create --partitions 1 --replication-factor 1
+kubectl -n kafka run kafka-topics -it --image=wurstmeister/kafka:2.12-2.3.0 --rm=true --restart=Never -- /opt/kafka/bin/kafka-topics.sh --zookeeper example-zookeepercluster-client.zookeeper:2181 --topic my-topic --create --partitions 1 --replication-factor 1
 ```
 
 ## Send and Receive Messages
@@ -39,13 +39,13 @@ kubectl -n kafka run kafka-topics -it --image=wurstmeister/kafka:2.12-2.1.0 --rm
 ##### Produce Messages
 
 ```bash
-kubectl -n kafka run kafka-producer -it --image=wurstmeister/kafka:2.12-2.1.0 --rm=true --restart=Never -- /opt/kafka/bin/kafka-console-producer.sh --broker-list kafka-headless:29092 --topic my-topic
+kubectl -n kafka run kafka-producer -it --image=wurstmeister/kafka:2.12-2.3.0 --rm=true --restart=Never -- /opt/kafka/bin/kafka-console-producer.sh --broker-list kafka-headless:29092 --topic my-topic
 ```
 
 ##### Consume Messages
 
 ```bash
-kubectl -n kafka run kafka-consumer -it --image=wurstmeister/kafka:2.12-2.1.0 --rm=true --restart=Never -- /opt/kafka/bin/kafka-console-consumer.sh --bootstrap-server kafka-headless:29092 --topic my-topic --from-beginning
+kubectl -n kafka run kafka-consumer -it --image=wurstmeister/kafka:2.12-2.3.0 --rm=true --restart=Never -- /opt/kafka/bin/kafka-console-consumer.sh --bootstrap-server kafka-headless:29092 --topic my-topic --from-beginning
 ```
 
 #### SSL Enabled

--- a/pkg/resources/kafka/configmap_test.go
+++ b/pkg/resources/kafka/configmap_test.go
@@ -38,13 +38,13 @@ func TestGenerateBrokerConfig(t *testing.T) {
 			clusterWideConfig:       ``,
 			perBrokerConfig:         ``,
 			perBrokerReadOnlyConfig: ``,
-			expectedConfig: `advertised.listeners=PLAINTEXT://kafka-0.kafka.svc.cluster.local:9092
+			expectedConfig: `advertised.listeners=INTERNAL://kafka-0.kafka.svc.cluster.local:9092
 broker.id=0
-cruise.control.metrics.reporter.bootstrap.servers=PLAINTEXT://kafka-0.kafka.svc.cluster.local:9092
-listener.security.protocol.map=PLAINTEXT:PLAINTEXT
-listeners=PLAINTEXT://:9092
+cruise.control.metrics.reporter.bootstrap.servers=INTERNAL://kafka-0.kafka.svc.cluster.local:9092
+inter.broker.listener.name=INTERNAL
+listener.security.protocol.map=INTERNAL:PLAINTEXT
+listeners=INTERNAL://:9092
 metric.reporters=com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporter
-security.inter.broker.protocol=PLAINTEXT
 super.users=
 zookeeper.connect=example.zk:2181`,
 		},
@@ -59,14 +59,14 @@ zookeeper.connect=example.zk:2181`,
 					MountPath: "/kafka-logs",
 				},
 			},
-			expectedConfig: `advertised.listeners=PLAINTEXT://kafka-0.kafka.svc.cluster.local:9092
+			expectedConfig: `advertised.listeners=INTERNAL://kafka-0.kafka.svc.cluster.local:9092
 broker.id=0
-cruise.control.metrics.reporter.bootstrap.servers=PLAINTEXT://kafka-0.kafka.svc.cluster.local:9092
-listener.security.protocol.map=PLAINTEXT:PLAINTEXT
-listeners=PLAINTEXT://:9092
+cruise.control.metrics.reporter.bootstrap.servers=INTERNAL://kafka-0.kafka.svc.cluster.local:9092
+inter.broker.listener.name=INTERNAL
+listener.security.protocol.map=INTERNAL:PLAINTEXT
+listeners=INTERNAL://:9092
 log.dirs=/kafka-logs/kafka
 metric.reporters=com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporter
-security.inter.broker.protocol=PLAINTEXT
 super.users=
 zookeeper.connect=example.zk:2181`,
 		},
@@ -84,15 +84,15 @@ compression.type=snappy
 			perBrokerReadOnlyConfig: `
 auto.create.topics.enable=true
 `,
-			expectedConfig: `advertised.listeners=PLAINTEXT://kafka-0.kafka.svc.cluster.local:9092
+			expectedConfig: `advertised.listeners=INTERNAL://kafka-0.kafka.svc.cluster.local:9092
 auto.create.topics.enable=true
 broker.id=0
 control.plane.listener.name=thisisatest
-cruise.control.metrics.reporter.bootstrap.servers=PLAINTEXT://kafka-0.kafka.svc.cluster.local:9092
-listener.security.protocol.map=PLAINTEXT:PLAINTEXT
-listeners=PLAINTEXT://:9092
+cruise.control.metrics.reporter.bootstrap.servers=INTERNAL://kafka-0.kafka.svc.cluster.local:9092
+inter.broker.listener.name=INTERNAL
+listener.security.protocol.map=INTERNAL:PLAINTEXT
+listeners=INTERNAL://:9092
 metric.reporters=com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporter
-security.inter.broker.protocol=PLAINTEXT
 super.users=
 zookeeper.connect=example.zk:2181`,
 		},
@@ -117,7 +117,7 @@ zookeeper.connect=example.zk:2181`,
 								InternalListeners: []v1beta1.InternalListenerConfig{
 									{
 										Type:                            "plaintext",
-										Name:                            "plaintext",
+										Name:                            "internal",
 										UsedForInnerBrokerCommunication: true,
 										ContainerPort:                   9092,
 									},


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #62 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

This PR introduces the new queue separation between clients and controller and brokers by using the `control.plane.listener.name` config. This means now the operator installed Kafka 2.2+ can leverage this feature. We introduced a new field inside internal listeners called: `usedForControllerCommunication`

It also ditches `security.inter.broker.protocol` to `inter.broker.listener.name`.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)