### PR TITLE
Fix finalizer when the listener type is plaintext

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ If you are willing to kickstart your managed Apache Kafka experience on 5 cloud 
 
 The operator installs the 2.3.0 version of Apache Kafka, and can run on Minikube v0.33.1+ and Kubernetes 1.12.0+.
 
+> The operator supports Kafka 2.0+
+
 As a pre-requisite it needs a Kubernetes cluster (you can create one using [Pipeline](https://github.com/banzaicloud/pipeline)). Also, Kafka requires Zookeeper so you need to first have a Zookeeper cluster if you don't already have one.
 
 The operator also uses `cert-manager` for issuing certificates to users and brokers, so you'll need to have it setup in case you haven't already.

--- a/controllers/kafkacluster_controller.go
+++ b/controllers/kafkacluster_controller.go
@@ -288,7 +288,11 @@ func topicListToStrSlice(list v1alpha1.KafkaTopicList) []string {
 }
 
 func (r *KafkaClusterReconciler) ensureFinalizers(ctx context.Context, cluster *v1beta1.KafkaCluster) (updated *v1beta1.KafkaCluster, err error) {
-	for _, finalizer := range []string{clusterFinalizer, clusterTopicsFinalizer, clusterUsersFinalizer} {
+	finalizers := []string{clusterFinalizer, clusterTopicsFinalizer}
+	if cluster.Spec.ListenersConfig.SSLSecrets != nil {
+		finalizers = append(finalizers, clusterUsersFinalizer)
+	}
+	for _, finalizer := range finalizers {
 		if util.StringSliceContains(cluster.GetFinalizers(), finalizer) {
 			continue
 		}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |yes|
| New feature?    | no|
| API breaks?     | no|
| Deprecations?   | no|
| Related tickets | fixes #173
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
This PR fixes the behaviour when the listener type is plaintext the cluster does not get deleted because the user finaliser placed incorrectly.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
