### PR TITLE
Bump chart version to release 0.7.1

### DIFF
--- a/charts/kafka-operator/Chart.yaml
+++ b/charts/kafka-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: kafka-operator
-version: 0.2.3
+version: 0.2.4
 description: kafka-operator manages Kafka deployments on Kubernetes
 sources:
   - https://github.com/banzaicloud/kafka-operator
-appVersion: 0.7.0
+appVersion: 0.7.1

--- a/charts/kafka-operator/values.yaml
+++ b/charts/kafka-operator/values.yaml
@@ -11,7 +11,7 @@ imagePullSecrets: []
 operator:
   image:
     repository: banzaicloud/kafka-operator
-    tag: 0.7.0
+    tag: 0.7.1
     pullPolicy: IfNotPresent
   vaultAddress: ""
   # vaultSecret containing a `ca.crt` key with the Vault CA Certificate


### PR DESCRIPTION
This PR bumps the chart version to 0.2.4 to use the latest release version 0.7.1