### PR TITLE
Bug fixes cherry-picked from master

### DIFF
--- a/charts/kafka-operator/templates/operator-deployment.yaml
+++ b/charts/kafka-operator/templates/operator-deployment.yaml
@@ -61,6 +61,7 @@ spec:
             - /manager
           args:
             - --enable-leader-election
+            - --cert-manager-namespace={{ .Values.certManager.namespace }}
           {{- if .Values.operator.verboseLogging }}
             - --verbose
           {{- end }}

--- a/charts/kafka-operator/values.yaml
+++ b/charts/kafka-operator/values.yaml
@@ -25,6 +25,9 @@ operator:
       cpu: 100m
       memory: 128Mi
 
+certManager:
+  namespace: "cert-manager"
+
 alertManager:
   enable: true
 

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -20,6 +20,7 @@ spec:
         - /manager
         args:
         - --enable-leader-election
+        - --cert-manager-namespace=cert-manager
         image: controller:latest
         name: manager
         ports:

--- a/controllers/controller_common.go
+++ b/controllers/controller_common.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"time"
 
+	"emperror.dev/errors"
 	"github.com/banzaicloud/kafka-operator/api/v1alpha1"
 	"github.com/banzaicloud/kafka-operator/api/v1beta1"
 	"github.com/banzaicloud/kafka-operator/pkg/errorfactory"
@@ -89,7 +90,7 @@ func newBrokerConnection(log logr.Logger, client client.Client, cluster *v1beta1
 // checkBrokerConnectionError is a convenience wrapper for returning from common
 // broker connection errors
 func checkBrokerConnectionError(logger logr.Logger, err error) (ctrl.Result, error) {
-	switch err.(type) {
+	switch errors.Cause(err).(type) {
 	case errorfactory.BrokersUnreachable:
 		return ctrl.Result{
 			Requeue:      true,

--- a/controllers/kafkacluster_controller.go
+++ b/controllers/kafkacluster_controller.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 	"time"
 
+	"emperror.dev/errors"
 	"github.com/banzaicloud/k8s-objectmatcher/patch"
 	"github.com/banzaicloud/kafka-operator/api/v1alpha1"
 	"github.com/banzaicloud/kafka-operator/api/v1beta1"
@@ -113,7 +114,7 @@ func (r *KafkaClusterReconciler) Reconcile(request ctrl.Request) (ctrl.Result, e
 	for _, rec := range reconcilers {
 		err = rec.Reconcile(log)
 		if err != nil {
-			switch err.(type) {
+			switch errors.Cause(err).(type) {
 			case errorfactory.BrokersUnreachable:
 				log.Info("Brokers unreachable, may still be starting up")
 				return ctrl.Result{

--- a/controllers/kafkauser_controller.go
+++ b/controllers/kafkauser_controller.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 	"time"
 
+	"emperror.dev/errors"
 	"github.com/banzaicloud/kafka-operator/api/v1alpha1"
 	"github.com/banzaicloud/kafka-operator/api/v1beta1"
 	"github.com/banzaicloud/kafka-operator/pkg/errorfactory"
@@ -148,7 +149,7 @@ func (r *KafkaUserReconciler) Reconcile(request reconcile.Request) (reconcile.Re
 	// that will allow the error to fall through if the certificate doesn't exist.
 	user, err := pkiManager.ReconcileUserCertificate(ctx, instance, r.Scheme)
 	if err != nil {
-		switch err.(type) {
+		switch errors.Cause(err).(type) {
 		case errorfactory.ResourceNotReady:
 			reqLogger.Info("generated secret not found, may not be ready")
 			return ctrl.Result{

--- a/main.go
+++ b/main.go
@@ -36,6 +36,7 @@ import (
 	banzaicloudv1alpha1 "github.com/banzaicloud/kafka-operator/api/v1alpha1"
 	banzaicloudv1beta1 "github.com/banzaicloud/kafka-operator/api/v1beta1"
 	"github.com/banzaicloud/kafka-operator/controllers"
+	"github.com/banzaicloud/kafka-operator/pkg/pki/certmanagerpki"
 	"github.com/banzaicloud/kafka-operator/pkg/webhook"
 	certv1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -71,6 +72,7 @@ func main() {
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 	flag.StringVar(&webhookCertDir, "tls-cert-dir", "/etc/webhook/certs", "The directory with a tls.key and tls.crt for serving HTTPS requests")
 	flag.BoolVar(&verboseLogging, "verbose", false, "Enable verbose logging")
+	flag.StringVar(&certmanagerpki.NamespaceCertManager, "cert-manager-namespace", "cert-manager", "The namespace where cert-manager is running")
 	flag.Parse()
 
 	ctrl.SetLogger(zap.Logger(verboseLogging))

--- a/main.go
+++ b/main.go
@@ -36,7 +36,6 @@ import (
 	banzaicloudv1alpha1 "github.com/banzaicloud/kafka-operator/api/v1alpha1"
 	banzaicloudv1beta1 "github.com/banzaicloud/kafka-operator/api/v1beta1"
 	"github.com/banzaicloud/kafka-operator/controllers"
-	"github.com/banzaicloud/kafka-operator/pkg/pki/certmanagerpki"
 	"github.com/banzaicloud/kafka-operator/pkg/webhook"
 	certv1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -72,7 +71,6 @@ func main() {
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 	flag.StringVar(&webhookCertDir, "tls-cert-dir", "/etc/webhook/certs", "The directory with a tls.key and tls.crt for serving HTTPS requests")
 	flag.BoolVar(&verboseLogging, "verbose", false, "Enable verbose logging")
-	flag.StringVar(&certmanagerpki.NamespaceCertManager, "cert-manager-namespace", "cert-manager", "The namespace where cert-manager is running")
 	flag.Parse()
 
 	ctrl.SetLogger(zap.Logger(verboseLogging))

--- a/pkg/pki/certmanagerpki/certmanager.go
+++ b/pkg/pki/certmanagerpki/certmanager.go
@@ -15,10 +15,18 @@
 package certmanagerpki
 
 import (
+	"flag"
+
 	"github.com/banzaicloud/kafka-operator/api/v1beta1"
 	pkicommon "github.com/banzaicloud/kafka-operator/pkg/util/pki"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+var namespaceCertManager string
+
+func init() {
+	flag.StringVar(&namespaceCertManager, "cert-manager-namespace", "cert-manager", "The namespace where cert-manager is running")
+}
 
 type CertManager interface {
 	pkicommon.PKIManager

--- a/pkg/pki/certmanagerpki/certmanager_pki.go
+++ b/pkg/pki/certmanagerpki/certmanager_pki.go
@@ -35,8 +35,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-var NamespaceCertManager = "cert-manager"
-
 func (c *certManager) FinalizePKI(ctx context.Context, logger logr.Logger) error {
 	logger.Info("Removing cert-manager certificates and secrets")
 
@@ -48,7 +46,7 @@ func (c *certManager) FinalizePKI(ctx context.Context, logger logr.Logger) error
 	if c.cluster.Spec.ListenersConfig.SSLSecrets.Create {
 		// Names of our certificates and secrets
 		objNames := []types.NamespacedName{
-			{Name: fmt.Sprintf(pkicommon.BrokerCACertTemplate, c.cluster.Name), Namespace: NamespaceCertManager},
+			{Name: fmt.Sprintf(pkicommon.BrokerCACertTemplate, c.cluster.Name), Namespace: namespaceCertManager},
 			{Name: fmt.Sprintf(pkicommon.BrokerServerCertTemplate, c.cluster.Name), Namespace: c.cluster.Namespace},
 			{Name: fmt.Sprintf(pkicommon.BrokerControllerTemplate, c.cluster.Name), Namespace: c.cluster.Namespace},
 		}
@@ -157,7 +155,7 @@ func ensureCASecretOwnership(ctx context.Context, client client.Client, cluster 
 	secret := &corev1.Secret{}
 	if err := client.Get(ctx, types.NamespacedName{
 		Name:      fmt.Sprintf(pkicommon.BrokerCACertTemplate, cluster.Name),
-		Namespace: NamespaceCertManager,
+		Namespace: namespaceCertManager,
 	}, secret); err != nil {
 		if apierrors.IsNotFound(err) {
 			return errorfactory.New(errorfactory.ResourceNotReady{}, err, "pki secret not ready")
@@ -190,8 +188,10 @@ func caSecretForProvidedCert(ctx context.Context, client client.Client, cluster 
 
 	caKey := secret.Data[v1alpha1.CAPrivateKeyKey]
 	caCert := secret.Data[v1alpha1.CACertKey]
+	rootCertMeta := templates.ObjectMeta(fmt.Sprintf(pkicommon.BrokerCACertTemplate, cluster.Name), pkicommon.LabelsForKafkaPKI(cluster.Name), cluster)
+	rootCertMeta.Namespace = namespaceCertManager
 	caSecret := &corev1.Secret{
-		ObjectMeta: templates.ObjectMeta(fmt.Sprintf(pkicommon.BrokerCACertTemplate, cluster.Name), pkicommon.LabelsForKafkaPKI(cluster.Name), cluster),
+		ObjectMeta: rootCertMeta,
 		Data: map[string][]byte{
 			v1alpha1.CoreCACertKey:  caCert,
 			corev1.TLSCertKey:       caCert,
@@ -219,7 +219,7 @@ func selfSignerForCluster(cluster *v1beta1.KafkaCluster, scheme *runtime.Scheme)
 
 func caCertForCluster(cluster *v1beta1.KafkaCluster, scheme *runtime.Scheme) *certv1.Certificate {
 	rootCertMeta := templates.ObjectMeta(fmt.Sprintf(pkicommon.BrokerCACertTemplate, cluster.Name), pkicommon.LabelsForKafkaPKI(cluster.Name), cluster)
-	rootCertMeta.Namespace = NamespaceCertManager
+	rootCertMeta.Namespace = namespaceCertManager
 	ca := &certv1.Certificate{
 		ObjectMeta: rootCertMeta,
 		Spec: certv1.CertificateSpec{

--- a/pkg/pki/certmanagerpki/certmanager_pki.go
+++ b/pkg/pki/certmanagerpki/certmanager_pki.go
@@ -35,7 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-const namespaceCertManager = "cert-manager"
+var NamespaceCertManager = "cert-manager"
 
 func (c *certManager) FinalizePKI(ctx context.Context, logger logr.Logger) error {
 	logger.Info("Removing cert-manager certificates and secrets")
@@ -48,7 +48,7 @@ func (c *certManager) FinalizePKI(ctx context.Context, logger logr.Logger) error
 	if c.cluster.Spec.ListenersConfig.SSLSecrets.Create {
 		// Names of our certificates and secrets
 		objNames := []types.NamespacedName{
-			{Name: fmt.Sprintf(pkicommon.BrokerCACertTemplate, c.cluster.Name), Namespace: "cert-manager"},
+			{Name: fmt.Sprintf(pkicommon.BrokerCACertTemplate, c.cluster.Name), Namespace: NamespaceCertManager},
 			{Name: fmt.Sprintf(pkicommon.BrokerServerCertTemplate, c.cluster.Name), Namespace: c.cluster.Namespace},
 			{Name: fmt.Sprintf(pkicommon.BrokerControllerTemplate, c.cluster.Name), Namespace: c.cluster.Namespace},
 		}
@@ -157,7 +157,7 @@ func ensureCASecretOwnership(ctx context.Context, client client.Client, cluster 
 	secret := &corev1.Secret{}
 	if err := client.Get(ctx, types.NamespacedName{
 		Name:      fmt.Sprintf(pkicommon.BrokerCACertTemplate, cluster.Name),
-		Namespace: namespaceCertManager,
+		Namespace: NamespaceCertManager,
 	}, secret); err != nil {
 		if apierrors.IsNotFound(err) {
 			return errorfactory.New(errorfactory.ResourceNotReady{}, err, "pki secret not ready")
@@ -219,7 +219,7 @@ func selfSignerForCluster(cluster *v1beta1.KafkaCluster, scheme *runtime.Scheme)
 
 func caCertForCluster(cluster *v1beta1.KafkaCluster, scheme *runtime.Scheme) *certv1.Certificate {
 	rootCertMeta := templates.ObjectMeta(fmt.Sprintf(pkicommon.BrokerCACertTemplate, cluster.Name), pkicommon.LabelsForKafkaPKI(cluster.Name), cluster)
-	rootCertMeta.Namespace = namespaceCertManager
+	rootCertMeta.Namespace = NamespaceCertManager
 	ca := &certv1.Certificate{
 		ObjectMeta: rootCertMeta,
 		Spec: certv1.CertificateSpec{


### PR DESCRIPTION
This PR contains the following bug fixes for the 0.7.x release line.

- Introduce cert-manager flag to be able to use existing cert-manager on the given namespace
- Remove owner references from user/topic crds
- Fix reconcile error handling logic if a known error happens