### PR TITLE
Remove unnecessary NodeAffinity from the broker pods

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -102,7 +102,7 @@ rules:
   - patch
   - update
 - apiGroups:
-  - certmanager.k8s.io
+  - cert-manager.io
   resources:
   - certificates
   verbs:
@@ -114,7 +114,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - certmanager.k8s.io
+  - cert-manager.io
   resources:
   - clusterissuers
   verbs:
@@ -126,7 +126,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - certmanager.k8s.io
+  - cert-manager.io
   resources:
   - issuers
   verbs:

--- a/controllers/kafkauser_controller.go
+++ b/controllers/kafkauser_controller.go
@@ -100,9 +100,9 @@ type KafkaUserReconciler struct {
 
 // +kubebuilder:rbac:groups=kafka.banzaicloud.io,resources=kafkausers,verbs=get;list;watch;create;update;patch;delete;deletecollection
 // +kubebuilder:rbac:groups=kafka.banzaicloud.io,resources=kafkausers/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=certmanager.k8s.io,resources=certificates,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=certmanager.k8s.io,resources=issuers,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=certmanager.k8s.io,resources=clusterissuers,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=cert-manager.io,resources=certificates,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=cert-manager.io,resources=issuers,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=cert-manager.io,resources=clusterissuers,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile reads that state of the cluster for a KafkaUser object and makes changes based on the state read
 // and what is in the KafkaUser.Spec

--- a/pkg/k8sutil/zoneandregion.go
+++ b/pkg/k8sutil/zoneandregion.go
@@ -22,35 +22,6 @@ import (
 	runtimeClient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const (
-	zoneLabel   = "failure-domain.beta.kubernetes.io/zone"
-	regionLabel = "failure-domain.beta.kubernetes.io/region"
-)
-
-func failureDomainSelectors(nodeName string, client runtimeClient.Client) ([]corev1.NodeSelectorTerm, error) {
-	terms := []corev1.NodeSelectorTerm{}
-
-	labels, err := getSpecificNodeLabels(nodeName, client, []string{zoneLabel, regionLabel})
-	if err != nil {
-		return nil, err
-	}
-
-	if len(labels) > 0 {
-		defaultFailureDomainSelector := corev1.NodeSelectorTerm{}
-
-		for key, val := range labels {
-			defaultFailureDomainSelector.MatchExpressions =
-				append(defaultFailureDomainSelector.MatchExpressions, corev1.NodeSelectorRequirement{
-					Key:      key,
-					Operator: corev1.NodeSelectorOpIn,
-					Values:   []string{val},
-				})
-		}
-		terms = append(terms, defaultFailureDomainSelector)
-	}
-	return terms, nil
-}
-
 func getSpecificNodeLabels(nodeName string, client runtimeClient.Client, filter []string) (map[string]string, error) {
 	node := &corev1.Node{}
 	err := client.Get(context.TODO(), types.NamespacedName{Name: nodeName, Namespace: ""}, node)

--- a/pkg/resources/kafka/kafka.go
+++ b/pkg/resources/kafka/kafka.go
@@ -577,10 +577,6 @@ func (r *Reconciler) reconcileKafkaPod(log logr.Logger, desiredPod *corev1.Pod) 
 			}
 		}
 
-		err = k8sutil.UpdateCrWithNodeAffinity(currentPod, r.KafkaCluster, r.Client)
-		if err != nil {
-			return errorfactory.New(errorfactory.StatusUpdateError{}, err, "updating cr with node affinity failed")
-		}
 		err = r.Client.Delete(context.TODO(), currentPod)
 		if err != nil {
 			return errorfactory.New(errorfactory.APIFailure{}, err, "deleting resource failed", "kind", desiredType)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |yes|
| New feature?    | no|
| API breaks?     | no|
| Deprecations?   | no|
| Related tickets | fixes #187
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

This PR removes the NodeAffinity placer function, since Kubernetes already handles this if a  new pod required for an existing PV. It also fixes the RBAC for the new Cert manager API, installing the operator through kustomize.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)

### To Do
<!-- (Please remove this section if you don't need it.) -->
Backport this to branch 0.7.x 
