### PR TITLE
Fix panic if the user wants to create a Kafka user when cluster is in…

### DIFF
--- a/controllers/kafkauser_controller.go
+++ b/controllers/kafkauser_controller.go
@@ -133,6 +133,11 @@ func (r *KafkaUserReconciler) Reconcile(request reconcile.Request) (reconcile.Re
 		}
 		return requeueWithError(reqLogger, "failed to lookup referenced cluster", err)
 	}
+	// Avoid panic if the user wants to create a kafka user but the cluster is in plaintext mode
+	// TODO: refactor this and use webhook to validate if the cluster is eligible to create a kafka user
+	if cluster.Spec.ListenersConfig.SSLSecrets == nil {
+		return requeueWithError(reqLogger, "could not create kafka user since cluster does not use ssl", errors.New("failed to create kafka user"))
+	}
 
 	pkiManager := pki.GetPKIManager(r.Client, cluster)
 


### PR DESCRIPTION
… plaintext mode

| Q               | A
| --------------- | ---
| Bug fix?        | yes|
| New feature?    | no|
| API breaks?     | no|
| Deprecations?   | no|
| Related tickets | fixes #193 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

This PR fixes a panic if the user want to create a Kafka user when the cluster is in plaintext mode.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
