### PR TITLE
Fix nil pointer dereference since the 0.11 cert manager does not popu…

### DIFF
--- a/pkg/pki/certmanagerpki/certmanager_user.go
+++ b/pkg/pki/certmanagerpki/certmanager_user.go
@@ -16,6 +16,7 @@ package certmanagerpki
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/banzaicloud/kafka-operator/api/v1alpha1"
@@ -72,6 +73,13 @@ func (c *certManager) ReconcileUserCertificate(ctx context.Context, user *v1alph
 	// Ensure controller reference on user secret
 	if err = c.ensureControllerReference(ctx, user, secret, scheme); err != nil {
 		return nil, err
+	}
+
+	// Ensure that the secret is populated with the required values.
+	for _, v := range secret.Data {
+		if len(v) == 0 {
+			return nil, errorfactory.New(errorfactory.APIFailure{}, errors.New("not all secret value populated"), "secret is not ready")
+		}
 	}
 
 	return &pkicommon.UserCertificate{


### PR DESCRIPTION
…late all secrets during creation

| Q               | A
| --------------- | ---
| Bug fix?        | yes|
| New feature?    | no|
| API breaks?     | no|
| Deprecations?   | no|
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

This PR fixes a nil pointer dereference in the operator since, cert manager 0.11 does not populate 
secrets immediately. It creates a secret with empty values and updates it. Operator now checks if all required values are set in the secret and proceed accordingly.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
