### PR TITLE
Handle toleration causing unnecessary updates because of objectmatcher

### DIFF
--- a/pkg/resources/kafka/kafka.go
+++ b/pkg/resources/kafka/kafka.go
@@ -503,6 +503,19 @@ func (r *Reconciler) reconcileKafkaPod(log logr.Logger, desiredPod *corev1.Pod) 
 	}
 	// TODO check if this err == nil check necessary (baluchicken)
 	if err == nil {
+		//Since toleration does not support patchStrategy:"merge,retainKeys", we need to add all toleration from the current pod if the toleration is set in the CR
+		if len(desiredPod.Spec.Tolerations) > 0 {
+			desiredPod.Spec.Tolerations = append(desiredPod.Spec.Tolerations, currentPod.Spec.Tolerations...)
+			uniqueTolerations := []corev1.Toleration{}
+			keys := make(map[corev1.Toleration]bool)
+			for _, t := range desiredPod.Spec.Tolerations {
+				if _, value := keys[t]; !value {
+					keys[t] = true
+					uniqueTolerations = append(uniqueTolerations, t)
+				}
+			}
+			desiredPod.Spec.Tolerations = uniqueTolerations
+		}
 		// Check if the resource actually updated
 		patchResult, err := patch.DefaultPatchMaker.Calculate(currentPod, desiredPod)
 		if err != nil {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes|
| New feature?    | no|
| API breaks?     | no|
| Deprecations?   | no|
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
This PR fixes the unnecessary update which occurs because the tolerations does not have 
patchStrategy:"merge,retainKeys" so the objectmatcher thinks the object is updated but it is not.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
