### PR TITLE
Fix helm chart to use the right RBAC for cert-manager

### DIFF
--- a/charts/kafka-operator/Chart.yaml
+++ b/charts/kafka-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kafka-operator
-version: 0.2.6
+version: 0.2.7
 description: kafka-operator manages Kafka deployments on Kubernetes
 sources:
   - https://github.com/banzaicloud/kafka-operator

--- a/charts/kafka-operator/templates/operator-rbac.yaml
+++ b/charts/kafka-operator/templates/operator-rbac.yaml
@@ -167,6 +167,7 @@ rules:
   - update
   - patch
   - delete
+{{- if contains "0.8." .Values.operator.image.tag }}
 - apiGroups:
   - cert-manager.io
   resources:
@@ -181,6 +182,22 @@ rules:
   - patch
   - update
   - watch
+{{- else }}
+- apiGroups:
+  - certmanager.k8s.io
+  resources:
+  - issuers
+  - clusterissuers
+  - certificates
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
Fix helm chart to install different RBAC for the different operator version.