### PR TITLE
remove per-broker dns names and append wildcards to cluster dns names

### DIFF
--- a/pkg/util/pki/common.go
+++ b/pkg/util/pki/common.go
@@ -122,7 +122,6 @@ func clusterDNSNames(cluster *v1beta1.KafkaCluster) (names []string) {
 		)
 
 		// service name only
-		// TODO (tinyzimmer): I'm not sure if this one is required
 		names = append(names,
 			fmt.Sprintf(kafka.HeadlessServiceTemplate, cluster.Name))
 	} else {
@@ -142,7 +141,7 @@ func clusterDNSNames(cluster *v1beta1.KafkaCluster) (names []string) {
 			fmt.Sprintf("%s.%s", fmt.Sprintf(kafka.AllBrokerServiceTemplate, cluster.Name), cluster.Namespace),
 		)
 
-		// service name only - same TODO as above
+		// service name only
 		names = append(names,
 			fmt.Sprintf(kafka.AllBrokerServiceTemplate, cluster.Name))
 	}

--- a/pkg/util/pki/pki_common_test.go
+++ b/pkg/util/pki/pki_common_test.go
@@ -81,11 +81,11 @@ func TestGetDNSNames(t *testing.T) {
 	cluster.Spec.HeadlessServiceEnabled = true
 	headlessNames := GetDNSNames(cluster)
 	expected := []string{
-		"test-cluster-0.test-cluster-headless.test-namespace.svc.cluster.local",
-		"test-cluster-0.test-cluster-headless.test-namespace.svc",
-		"test-cluster-0.test-cluster-headless.test-namespace",
+		"*.test-cluster-headless.test-namespace.svc.cluster.local",
 		"test-cluster-headless.test-namespace.svc.cluster.local",
+		"*.test-cluster-headless.test-namespace.svc",
 		"test-cluster-headless.test-namespace.svc",
+		"*.test-cluster-headless.test-namespace",
 		"test-cluster-headless.test-namespace",
 		"test-cluster-headless",
 	}
@@ -96,11 +96,11 @@ func TestGetDNSNames(t *testing.T) {
 	cluster.Spec.HeadlessServiceEnabled = false
 	allBrokerNames := GetDNSNames(cluster)
 	expected = []string{
-		"test-cluster-0.test-namespace.svc.cluster.local",
-		"test-cluster-0.test-namespace.svc",
-		"test-cluster-0.test-namespace",
+		"*.test-cluster-all-broker.test-namespace.svc.cluster.local",
 		"test-cluster-all-broker.test-namespace.svc.cluster.local",
+		"*.test-cluster-all-broker.test-namespace.svc",
 		"test-cluster-all-broker.test-namespace.svc",
+		"*.test-cluster-all-broker.test-namespace",
 		"test-cluster-all-broker.test-namespace",
 		"test-cluster-all-broker",
 	}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | n/a
| License         | Apache 2.0


### What's in this PR?

I didn't see a ticket for it, but @baluchicken brought it up on slack. There was an issue with cluster scaling and the DNS names for the broker certificates not including the new kafka nodes.

This PR gets rid of `brokerDNSNames` and instead adds a wildcard for each of the `clusterDNSName` formats. A quick test locally worked along with being able to scale the cluster and have a new pod join cleanly. On an existing cluster, it might trigger a rolling upgrade with new certificates, but we should probably verify that. 


### Checklist

- [X] Implementation tested
