### PR TITLE
Add external hostname to SSL certificate DNS names - allow for optional override of hostname with alias

### DIFF
--- a/api/v1beta1/kafkacluster_types.go
+++ b/api/v1beta1/kafkacluster_types.go
@@ -176,6 +176,7 @@ type ExternalListenerConfig struct {
 	Name                 string `json:"name"`
 	ExternalStartingPort int32  `json:"externalStartingPort"`
 	ContainerPort        int32  `json:"containerPort"`
+	HostnameOverride     string `json:"hostnameOverride,omitempty"`
 }
 
 // InternalListenerConfig defines the internal listener config for Kafka

--- a/charts/kafka-operator/templates/operator-kafka-crd.yaml
+++ b/charts/kafka-operator/templates/operator-kafka-crd.yaml
@@ -1152,6 +1152,8 @@ spec:
                         type: string
                       type:
                         type: string
+                      hostnameOverride:
+                        type: string
                     required:
                       - containerPort
                       - externalStartingPort

--- a/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
+++ b/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
@@ -1144,6 +1144,8 @@ spec:
                       externalStartingPort:
                         format: int32
                         type: integer
+                      hostnameOverride:
+                        type: string
                       name:
                         type: string
                       type:

--- a/pkg/pki/certmanagerpki/certmanager.go
+++ b/pkg/pki/certmanagerpki/certmanager.go
@@ -18,7 +18,7 @@ import (
 	"flag"
 
 	"github.com/banzaicloud/kafka-operator/api/v1beta1"
-	pkicommon "github.com/banzaicloud/kafka-operator/pkg/util/pki"
+	"github.com/banzaicloud/kafka-operator/pkg/util/pki"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -29,7 +29,7 @@ func init() {
 }
 
 type CertManager interface {
-	pkicommon.PKIManager
+	pki.Manager
 }
 
 // certManager implements a PKIManager using cert-manager as the backend

--- a/pkg/pki/certmanagerpki/certmanager_pki_test.go
+++ b/pkg/pki/certmanagerpki/certmanager_pki_test.go
@@ -95,40 +95,40 @@ func TestReconcilePKI(t *testing.T) {
 	manager := newMock(cluster)
 	ctx := context.Background()
 
-	if err := manager.ReconcilePKI(ctx, log, scheme.Scheme); err == nil {
+	if err := manager.ReconcilePKI(ctx, log, scheme.Scheme, []string{}); err == nil {
 		t.Error("Expected error got nil")
 	} else if reflect.TypeOf(err) != reflect.TypeOf(errorfactory.ResourceNotReady{}) {
 		t.Error("Expected not ready error, got:", reflect.TypeOf(err))
 	}
 
 	manager.client.Create(ctx, newServerSecret())
-	if err := manager.ReconcilePKI(ctx, log, scheme.Scheme); err == nil {
+	if err := manager.ReconcilePKI(ctx, log, scheme.Scheme, []string{}); err == nil {
 		t.Error("Expected error got nil")
 	} else if reflect.TypeOf(err) != reflect.TypeOf(errorfactory.ResourceNotReady{}) {
 		t.Error("Expected not ready error, got:", reflect.TypeOf(err))
 	}
 
 	manager.client.Create(ctx, newControllerSecret())
-	if err := manager.ReconcilePKI(ctx, log, scheme.Scheme); err == nil {
+	if err := manager.ReconcilePKI(ctx, log, scheme.Scheme, []string{}); err == nil {
 		t.Error("Expected error got nil")
 	} else if reflect.TypeOf(err) != reflect.TypeOf(errorfactory.ResourceNotReady{}) {
 		t.Error("Expected not ready error, got:", reflect.TypeOf(err))
 	}
 
 	manager.client.Create(ctx, newCASecret())
-	if err := manager.ReconcilePKI(ctx, log, scheme.Scheme); err != nil {
+	if err := manager.ReconcilePKI(ctx, log, scheme.Scheme, []string{}); err != nil {
 		t.Error("Expected successful reconcile, got:", err)
 	}
 
 	cluster.Spec.ListenersConfig.SSLSecrets.Create = false
 	manager = newMock(cluster)
-	if err := manager.ReconcilePKI(ctx, log, scheme.Scheme); err == nil {
+	if err := manager.ReconcilePKI(ctx, log, scheme.Scheme, []string{}); err == nil {
 		t.Error("Expected error got nil")
 	} else if reflect.TypeOf(err) != reflect.TypeOf(errorfactory.ResourceNotReady{}) {
 		t.Error("Expected not ready error, got:", reflect.TypeOf(err))
 	}
 	manager.client.Create(ctx, newPreCreatedSecret())
-	if err := manager.ReconcilePKI(ctx, log, scheme.Scheme); err != nil {
+	if err := manager.ReconcilePKI(ctx, log, scheme.Scheme, []string{}); err != nil {
 		t.Error("Expected successful reconcile, got:", err)
 	}
 }

--- a/pkg/pki/pki_manager.go
+++ b/pkg/pki/pki_manager.go
@@ -22,6 +22,7 @@ import (
 	"github.com/banzaicloud/kafka-operator/api/v1beta1"
 	"github.com/banzaicloud/kafka-operator/pkg/pki/certmanagerpki"
 	"github.com/banzaicloud/kafka-operator/pkg/pki/vaultpki"
+	"github.com/banzaicloud/kafka-operator/pkg/util/pki"
 	pkicommon "github.com/banzaicloud/kafka-operator/pkg/util/pki"
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -32,7 +33,7 @@ import (
 var MockBackend = v1beta1.PKIBackend("mock")
 
 // GetPKIManager returns a PKI/User manager interface for a given cluster
-func GetPKIManager(client client.Client, cluster *v1beta1.KafkaCluster) pkicommon.PKIManager {
+func GetPKIManager(client client.Client, cluster *v1beta1.KafkaCluster) pki.Manager {
 	switch cluster.Spec.ListenersConfig.SSLSecrets.PKIBackend {
 
 	// Use cert-manager for pki backend
@@ -57,12 +58,12 @@ func GetPKIManager(client client.Client, cluster *v1beta1.KafkaCluster) pkicommo
 // Mock types and functions
 
 type mockPKIManager struct {
-	pkicommon.PKIManager
+	pki.Manager
 	client  client.Client
 	cluster *v1beta1.KafkaCluster
 }
 
-func newMockPKIManager(client client.Client, cluster *v1beta1.KafkaCluster) pkicommon.PKIManager {
+func newMockPKIManager(client client.Client, cluster *v1beta1.KafkaCluster) pki.Manager {
 	return &mockPKIManager{client: client, cluster: cluster}
 }
 

--- a/pkg/pki/pki_manager.go
+++ b/pkg/pki/pki_manager.go
@@ -23,7 +23,6 @@ import (
 	"github.com/banzaicloud/kafka-operator/pkg/pki/certmanagerpki"
 	"github.com/banzaicloud/kafka-operator/pkg/pki/vaultpki"
 	"github.com/banzaicloud/kafka-operator/pkg/util/pki"
-	pkicommon "github.com/banzaicloud/kafka-operator/pkg/util/pki"
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -75,8 +74,8 @@ func (m *mockPKIManager) FinalizePKI(ctx context.Context, logger logr.Logger) er
 	return nil
 }
 
-func (m *mockPKIManager) ReconcileUserCertificate(ctx context.Context, user *v1alpha1.KafkaUser, scheme *runtime.Scheme) (*pkicommon.UserCertificate, error) {
-	return &pkicommon.UserCertificate{}, nil
+func (m *mockPKIManager) ReconcileUserCertificate(ctx context.Context, user *v1alpha1.KafkaUser, scheme *runtime.Scheme) (*pki.UserCertificate, error) {
+	return &pki.UserCertificate{}, nil
 }
 
 func (m *mockPKIManager) FinalizeUserCertificate(ctx context.Context, user *v1alpha1.KafkaUser) error {

--- a/pkg/pki/pki_manager.go
+++ b/pkg/pki/pki_manager.go
@@ -66,7 +66,7 @@ func newMockPKIManager(client client.Client, cluster *v1beta1.KafkaCluster) pkic
 	return &mockPKIManager{client: client, cluster: cluster}
 }
 
-func (m *mockPKIManager) ReconcilePKI(ctx context.Context, logger logr.Logger, scheme *runtime.Scheme) error {
+func (m *mockPKIManager) ReconcilePKI(ctx context.Context, logger logr.Logger, scheme *runtime.Scheme, externalHostnames []string) error {
 	return nil
 }
 

--- a/pkg/pki/pki_manager_test.go
+++ b/pkg/pki/pki_manager_test.go
@@ -57,7 +57,7 @@ func TestGetPKIManager(t *testing.T) {
 
 	// Test mock functions
 	var err error
-	if err = mock.ReconcilePKI(ctx, log, scheme.Scheme); err != nil {
+	if err = mock.ReconcilePKI(ctx, log, scheme.Scheme, []string{}); err != nil {
 		t.Error("Expected nil error got:", err)
 	}
 

--- a/pkg/pki/vaultpki/vault.go
+++ b/pkg/pki/vaultpki/vault.go
@@ -16,14 +16,14 @@ package vaultpki
 
 import (
 	"github.com/banzaicloud/kafka-operator/api/v1beta1"
-	pkicommon "github.com/banzaicloud/kafka-operator/pkg/util/pki"
+	"github.com/banzaicloud/kafka-operator/pkg/util/pki"
 	vaultapi "github.com/hashicorp/vault/api"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // VaultPKI implements a PKIManager using vault as the backend
 type VaultPKI interface {
-	pkicommon.PKIManager
+	pki.Manager
 }
 
 type vaultPKI struct {

--- a/pkg/pki/vaultpki/vault_pki.go
+++ b/pkg/pki/vaultpki/vault_pki.go
@@ -55,7 +55,7 @@ func (v *vaultPKI) FinalizePKI(ctx context.Context, logger logr.Logger) error {
 }
 
 // ReconcilePKI will use the user-provided paths to ensure broker/operator users for a new KafkaCluster
-func (v *vaultPKI) ReconcilePKI(ctx context.Context, logger logr.Logger, scheme *runtime.Scheme) (err error) {
+func (v *vaultPKI) ReconcilePKI(ctx context.Context, logger logr.Logger, scheme *runtime.Scheme, externalHostnames []string) (err error) {
 	log := logger.WithName("vault_pki")
 
 	log.Info("Retrieving vault client")
@@ -65,7 +65,7 @@ func (v *vaultPKI) ReconcilePKI(ctx context.Context, logger logr.Logger, scheme 
 	}
 
 	log.Info("Reconciling broker user in vault")
-	brokerCert, err := v.reconcileBrokerCert(ctx, vault)
+	brokerCert, err := v.reconcileBrokerCert(ctx, vault, externalHostnames)
 	if err != nil {
 		return
 	}
@@ -149,8 +149,8 @@ func (v *vaultPKI) reconcileBootstrapSecrets(ctx context.Context, scheme *runtim
 	return
 }
 
-func (v *vaultPKI) reconcileBrokerCert(ctx context.Context, vault *vaultapi.Client) (*pkicommon.UserCertificate, error) {
-	return v.reconcileStartupUser(ctx, vault, pkicommon.BrokerUserForCluster(v.cluster))
+func (v *vaultPKI) reconcileBrokerCert(ctx context.Context, vault *vaultapi.Client, externalHostnames []string) (*pkicommon.UserCertificate, error) {
+	return v.reconcileStartupUser(ctx, vault, pkicommon.BrokerUserForCluster(v.cluster, externalHostnames))
 }
 
 func (v *vaultPKI) reconcileControllerCert(ctx context.Context, vault *vaultapi.Client) (*pkicommon.UserCertificate, error) {

--- a/pkg/pki/vaultpki/vault_test.go
+++ b/pkg/pki/vaultpki/vault_test.go
@@ -161,7 +161,7 @@ func TestAll(t *testing.T) {
 		t.Fatal("Failed to convert test cert to JKS")
 	}
 
-	if err := mock.ReconcilePKI(ctx, log, scheme.Scheme); err == nil {
+	if err := mock.ReconcilePKI(ctx, log, scheme.Scheme, []string{}); err == nil {
 		t.Error("Expected resource not ready, got nil")
 	} else if reflect.TypeOf(err) != reflect.TypeOf(errorfactory.ResourceNotReady{}) {
 		t.Error("Expected resource not ready, got:", err)
@@ -185,7 +185,7 @@ func TestAll(t *testing.T) {
 	}))
 
 	// Should be safe to do multiple times
-	if err := mock.ReconcilePKI(ctx, log, scheme.Scheme); err != nil {
+	if err := mock.ReconcilePKI(ctx, log, scheme.Scheme, []string{}); err != nil {
 		t.Error("Expected no error, got:", err)
 	}
 
@@ -194,7 +194,7 @@ func TestAll(t *testing.T) {
 		t.Error("Expected no error, got:", err)
 	}
 
-	if err := mock.ReconcilePKI(ctx, log, scheme.Scheme); err != nil {
+	if err := mock.ReconcilePKI(ctx, log, scheme.Scheme, []string{}); err != nil {
 		t.Error("Expected no error, got:", err)
 	}
 

--- a/pkg/resources/kafka/configmap_test.go
+++ b/pkg/resources/kafka/configmap_test.go
@@ -140,7 +140,7 @@ zookeeper.connect=example.zk:2181`,
 					},
 				},
 			}
-			generatedConfig := r.generateBrokerConfig(0, r.KafkaCluster.Spec.Brokers[0].BrokerConfig, "", "", "", []string{}, nil)
+			generatedConfig := r.generateBrokerConfig(0, r.KafkaCluster.Spec.Brokers[0].BrokerConfig, []string{}, "", "", []string{}, nil)
 
 			if generatedConfig != test.expectedConfig {
 				t.Errorf("the expected config is %s, received: %s", test.expectedConfig, generatedConfig)

--- a/pkg/util/pki/common.go
+++ b/pkg/util/pki/common.go
@@ -39,6 +39,9 @@ const (
 	BrokerIssuerTemplate = "%s-issuer"
 	// BrokerControllerTemplate is the template used for operator certificate resources
 	BrokerControllerTemplate = "%s-controller"
+	// BrokerControllerFQDNTemplate is combined with the above and cluster namespace
+	// to create a 'fake' full-name for the controller user
+	BrokerControllerFQDNTemplate = "%s.%s.mgt.cluster.local"
 	// CAIntermediateTemplate is the template used for intermediate CA resources
 	CAIntermediateTemplate = "%s-intermediate.%s.cluster.local"
 	// CAFQDNTemplate is the template used for the FQDN of a CA
@@ -174,7 +177,7 @@ func BrokerUserForCluster(cluster *v1beta1.KafkaCluster, additionalHostnames []s
 func ControllerUserForCluster(cluster *v1beta1.KafkaCluster) *v1alpha1.KafkaUser {
 	return &v1alpha1.KafkaUser{
 		ObjectMeta: templates.ObjectMeta(
-			fmt.Sprintf("%s.%s.svc.cluster.local", fmt.Sprintf(BrokerControllerTemplate, cluster.Name), cluster.Namespace),
+			fmt.Sprintf(BrokerControllerFQDNTemplate, fmt.Sprintf(BrokerControllerTemplate, cluster.Name), cluster.Namespace),
 			LabelsForKafkaPKI(cluster.Name), cluster,
 		),
 		Spec: v1alpha1.KafkaUserSpec{

--- a/pkg/util/pki/pki_common_test.go
+++ b/pkg/util/pki/pki_common_test.go
@@ -141,7 +141,7 @@ func TestControllerUserForCluster(t *testing.T) {
 
 	expected := &v1alpha1.KafkaUser{
 		ObjectMeta: templates.ObjectMeta(
-			fmt.Sprintf("%s.%s.svc.cluster.local", fmt.Sprintf(BrokerControllerTemplate, cluster.Name), cluster.Namespace),
+			fmt.Sprintf(BrokerControllerFQDNTemplate, fmt.Sprintf(BrokerControllerTemplate, cluster.Name), cluster.Namespace),
 			LabelsForKafkaPKI(cluster.Name), cluster,
 		),
 		Spec: v1alpha1.KafkaUserSpec{


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | kinda
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?

This PR addresses an issue where the load-balancer IP on clusters with an external SSL listener was not included in the DNS names for the server certificate. In addition to that fix, you can also override this value (e.g. with a CNAME or other alias) using `spec.listenersConfig.externalListeners.*.hostnameOverride`. 

There is also some general tidying up and a couple new unit tests.


### Why?

SSL verification would fail when connecting to the external listener. Also, for some users, the load balancer IP/address may not be static, and they would like to be able to alias to it and still use SSL verification. 


### Checklist

- [X] Implementation tested
- [X] Error handling code meets the [guideline]
