### PR TITLE
Support more than one instance of envoy proxy instance when enabling …

### DIFF
--- a/api/v1beta1/kafkacluster_types.go
+++ b/api/v1beta1/kafkacluster_types.go
@@ -116,8 +116,10 @@ type TopicConfig struct {
 
 // EnvoyConfig defines the config for Envoy
 type EnvoyConfig struct {
-	Image                    string                        `json:"image"`
-	Resources                *corev1.ResourceRequirements  `json:"resourceRequirements,omitempty"`
+	Image     string                       `json:"image,omitempty"`
+	Resources *corev1.ResourceRequirements `json:"resourceRequirements,omitempty"`
+	// +kubebuilder:validation:Minimum=1
+	Replicas                 int32                         `json:"replicas,omitempty"`
 	ServiceAccountName       string                        `json:"serviceAccountName,omitempty"`
 	ImagePullSecrets         []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
 	NodeSelector             map[string]string             `json:"nodeSelector,omitempty"`
@@ -229,6 +231,14 @@ func (eConfig *EnvoyConfig) GetLoadBalancerSourceRanges() []string {
 //GetAnnotations returns Annotations to use for Envoy generated LoadBalancer
 func (eConfig *EnvoyConfig) GetAnnotations() map[string]string {
 	return eConfig.Annotations
+}
+
+// GetReplicas returns replicas used by the Envoy deployment
+func (eConfig *EnvoyConfig) GetReplicas() int32 {
+	if eConfig.Replicas == 0 {
+		return 1
+	}
+	return eConfig.Replicas
 }
 
 //GetServiceAccount returns the Kubernetes Service Account to use for Kafka Cluster

--- a/charts/kafka-operator/templates/operator-kafka-crd.yaml
+++ b/charts/kafka-operator/templates/operator-kafka-crd.yaml
@@ -1069,6 +1069,10 @@ spec:
                   additionalProperties:
                     type: string
                   type: object
+                replicas:
+                  format: int32
+                  minimum: 1
+                  type: integer
                 resourceRequirements:
                   description: ResourceRequirements describes the compute resource
                     requirements.
@@ -1129,8 +1133,6 @@ spec:
                         type: string
                     type: object
                   type: array
-              required:
-                - image
               type: object
             headlessServiceEnabled:
               type: boolean

--- a/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
+++ b/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
@@ -1065,6 +1065,10 @@ spec:
                   additionalProperties:
                     type: string
                   type: object
+                replicas:
+                  format: int32
+                  minimum: 1
+                  type: integer
                 resourceRequirements:
                   description: ResourceRequirements describes the compute resource
                     requirements.
@@ -1125,8 +1129,6 @@ spec:
                         type: string
                     type: object
                   type: array
-              required:
-              - image
               type: object
             headlessServiceEnabled:
               type: boolean

--- a/config/samples/banzaicloud_v1beta1_kafkacluster.yaml
+++ b/config/samples/banzaicloud_v1beta1_kafkacluster.yaml
@@ -172,6 +172,8 @@ spec:
       create: true
   # envoyConfig defines the envoy specific config used for externalListeners
   #envoyConfig:
+  # replicas describes how many pods will be used for the created envoy proxy
+  #  replicas: 1
   # image describes the Envoy docker image
   #  image: "banzaicloud/envoy:0.1.0"
   # resourceRequirements works exactly like Container resources, the user can specify the limit and the requests

--- a/pkg/resources/envoy/deployment.go
+++ b/pkg/resources/envoy/deployment.go
@@ -57,6 +57,7 @@ func (r *Reconciler) deployment(log logr.Logger) runtime.Object {
 			Selector: &metav1.LabelSelector{
 				MatchLabels: labelSelector,
 			},
+			Replicas: util.Int32Pointer(r.KafkaCluster.Spec.EnvoyConfig.GetReplicas()),
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: labelSelector,


### PR DESCRIPTION
…external listeners

| Q               | A
| --------------- | ---
| Bug fix?        | no|
| New feature?    | yes|
| API breaks?     | no|
| Deprecations?   | no|
| Related tickets | fixes #226
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
This PR adds support to enable more than one envoy proxy instance when enabling external access.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
