### PR TITLE
Don't put cluster owner ref on cert-manager CA resources

### DIFF
--- a/pkg/pki/certmanagerpki/certmanager_pki.go
+++ b/pkg/pki/certmanagerpki/certmanager_pki.go
@@ -158,10 +158,13 @@ func caSecretForProvidedCert(ctx context.Context, client client.Client, cluster 
 
 	caKey := secret.Data[v1alpha1.CAPrivateKeyKey]
 	caCert := secret.Data[v1alpha1.CACertKey]
-	rootCertMeta := templates.ObjectMeta(fmt.Sprintf(pkicommon.BrokerCACertTemplate, cluster.Name), pkicommon.LabelsForKafkaPKI(cluster.Name), cluster)
-	rootCertMeta.Namespace = namespaceCertManager
+
 	caSecret := &corev1.Secret{
-		ObjectMeta: rootCertMeta,
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf(pkicommon.BrokerCACertTemplate, cluster.Name),
+			Namespace: namespaceCertManager,
+			Labels:    pkicommon.LabelsForKafkaPKI(cluster.Name),
+		},
 		Data: map[string][]byte{
 			v1alpha1.CoreCACertKey:  caCert,
 			corev1.TLSCertKey:       caCert,
@@ -187,10 +190,12 @@ func selfSignerForCluster(cluster *v1beta1.KafkaCluster, scheme *runtime.Scheme)
 }
 
 func caCertForCluster(cluster *v1beta1.KafkaCluster, scheme *runtime.Scheme) *certv1.Certificate {
-	rootCertMeta := templates.ObjectMeta(fmt.Sprintf(pkicommon.BrokerCACertTemplate, cluster.Name), pkicommon.LabelsForKafkaPKI(cluster.Name), cluster)
-	rootCertMeta.Namespace = namespaceCertManager
-	ca := &certv1.Certificate{
-		ObjectMeta: rootCertMeta,
+	return &certv1.Certificate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf(pkicommon.BrokerCACertTemplate, cluster.Name),
+			Namespace: namespaceCertManager,
+			Labels:    pkicommon.LabelsForKafkaPKI(cluster.Name),
+		},
 		Spec: certv1.CertificateSpec{
 			SecretName: fmt.Sprintf(pkicommon.BrokerCACertTemplate, cluster.Name),
 			CommonName: fmt.Sprintf(pkicommon.CAFQDNTemplate, cluster.Name, cluster.Namespace),
@@ -201,7 +206,6 @@ func caCertForCluster(cluster *v1beta1.KafkaCluster, scheme *runtime.Scheme) *ce
 			},
 		},
 	}
-	return ca
 }
 
 func mainIssuerForCluster(cluster *v1beta1.KafkaCluster, scheme *runtime.Scheme) *certv1.ClusterIssuer {

--- a/pkg/pki/certmanagerpki/certmanager_pki_test.go
+++ b/pkg/pki/certmanagerpki/certmanager_pki_test.go
@@ -95,24 +95,18 @@ func TestReconcilePKI(t *testing.T) {
 	manager := newMock(cluster)
 	ctx := context.Background()
 
-	if err := manager.ReconcilePKI(ctx, log, scheme.Scheme, []string{}); err == nil {
-		t.Error("Expected error got nil")
-	} else if reflect.TypeOf(err) != reflect.TypeOf(errorfactory.ResourceNotReady{}) {
-		t.Error("Expected not ready error, got:", reflect.TypeOf(err))
-	}
-
 	manager.client.Create(ctx, newServerSecret())
-	if err := manager.ReconcilePKI(ctx, log, scheme.Scheme, []string{}); err == nil {
-		t.Error("Expected error got nil")
-	} else if reflect.TypeOf(err) != reflect.TypeOf(errorfactory.ResourceNotReady{}) {
-		t.Error("Expected not ready error, got:", reflect.TypeOf(err))
+	if err := manager.ReconcilePKI(ctx, log, scheme.Scheme, []string{}); err != nil {
+		if reflect.TypeOf(err) != reflect.TypeOf(errorfactory.ResourceNotReady{}) {
+			t.Error("Expected not ready error, got:", reflect.TypeOf(err))
+		}
 	}
 
 	manager.client.Create(ctx, newControllerSecret())
-	if err := manager.ReconcilePKI(ctx, log, scheme.Scheme, []string{}); err == nil {
-		t.Error("Expected error got nil")
-	} else if reflect.TypeOf(err) != reflect.TypeOf(errorfactory.ResourceNotReady{}) {
-		t.Error("Expected not ready error, got:", reflect.TypeOf(err))
+	if err := manager.ReconcilePKI(ctx, log, scheme.Scheme, []string{}); err != nil {
+		if reflect.TypeOf(err) != reflect.TypeOf(errorfactory.ResourceNotReady{}) {
+			t.Error("Expected not ready error, got:", reflect.TypeOf(err))
+		}
 	}
 
 	manager.client.Create(ctx, newCASecret())


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no|
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #229 
| License         | Apache 2.0


### What's in this PR?

The operator was still placing an owner reference on the `cert-manager` CA certificate and secret. This is not needed since `FinalizePKI` attempts to grab them anyway. 

NOTE: This still leaves an owner-ref on the `ClusterIssuer` which is a cluster-scoped resource. I haven't seen this cause any issues for anyone, but may be worth taking that off and adding cleanup logic to the `FinalizePKI` method instead. 

### Checklist

- [X] Implementation tested
