### PR TITLE
Remove tailing '/' character from `zkAddresses` that cause cruise-control unbootable.

### DIFF
--- a/pkg/resources/cruisecontrol/configmap.go
+++ b/pkg/resources/cruisecontrol/configmap.go
@@ -93,5 +93,5 @@ func prepareZookeeperAddress(zkAddresses []string) string {
 	for _, addr := range zkAddresses {
 		preparedAddress = append(preparedAddress, strings.TrimSuffix(addr, "/"))
 	}
-	return strings.Join(preparedAddress, ",")
+	return strings.Join(preparedAddress, ",") + "/"
 }

--- a/pkg/resources/cruisecontrol/configmap.go
+++ b/pkg/resources/cruisecontrol/configmap.go
@@ -91,11 +91,7 @@ func generateBootstrapServer(headlessEnabled bool, clusterName string) string {
 func prepareZookeeperAddress(zkAddresses []string) string {
 	preparedAddress := []string{}
 	for _, addr := range zkAddresses {
-		if strings.Contains(addr, "/") {
-			preparedAddress = append(preparedAddress, addr)
-		} else {
-			preparedAddress = append(preparedAddress, addr+"/")
-		}
+		preparedAddress = append(preparedAddress, addr)
 	}
 	return strings.Join(preparedAddress, ",")
 }

--- a/pkg/resources/cruisecontrol/configmap.go
+++ b/pkg/resources/cruisecontrol/configmap.go
@@ -91,7 +91,7 @@ func generateBootstrapServer(headlessEnabled bool, clusterName string) string {
 func prepareZookeeperAddress(zkAddresses []string) string {
 	preparedAddress := []string{}
 	for _, addr := range zkAddresses {
-		preparedAddress = append(preparedAddress, addr)
+		preparedAddress = append(preparedAddress, strings.TrimSuffix(addr, "/"))
 	}
 	return strings.Join(preparedAddress, ",")
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #235
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Remove tailing '/' character from `zkAddresses`

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

If `zkAddresses` has tailing `/` character, the generated `zookeeper.connect` string will be incorrect and cause `cruise-control` fail to start. 

See #235 for details.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
