### PR TITLE
Fix ZK path issues in case of Cruise Control

### DIFF
--- a/api/v1beta1/kafkacluster_types.go
+++ b/api/v1beta1/kafkacluster_types.go
@@ -15,6 +15,8 @@
 package v1beta1
 
 import (
+	"strings"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,6 +32,7 @@ type KafkaClusterSpec struct {
 	HeadlessServiceEnabled bool                    `json:"headlessServiceEnabled"`
 	ListenersConfig        ListenersConfig         `json:"listenersConfig"`
 	ZKAddresses            []string                `json:"zkAddresses"`
+	ZKPath                 string                  `json:"zkPath,omitempty"`
 	RackAwareness          *RackAwareness          `json:"rackAwareness,omitempty"`
 	ClusterImage           string                  `json:"clusterImage,omitempty"`
 	ReadOnlyConfig         string                  `json:"readOnlyConfig,omitempty"`
@@ -268,11 +271,24 @@ func (iIConfig *IstioIngressConfig) GetReplicas() int32 {
 	return iIConfig.Replicas
 }
 
+// GetIngressController returns the default Envoy ingress controller if not specified otherwise
 func (kSpec *KafkaClusterSpec) GetIngressController() string {
 	if kSpec.IngressController == "" {
 		return envoyutils.IngressControllerName
 	}
 	return kSpec.IngressController
+}
+
+// GetZkPath returns the default "/" ZkPath if not specified otherwise
+func (kSpec *KafkaClusterSpec) GetZkPath() string {
+	const prefix = "/"
+	if kSpec.ZKPath == "" {
+		return prefix
+	} else if !strings.HasPrefix(kSpec.ZKPath, prefix) {
+		return prefix + kSpec.ZKPath
+	} else {
+		return kSpec.ZKPath
+	}
 }
 
 //GetInitContainerImage returns the Init container image to use for CruiseControl

--- a/api/v1beta1/kafkacluster_types.go
+++ b/api/v1beta1/kafkacluster_types.go
@@ -29,17 +29,21 @@ import (
 
 // KafkaClusterSpec defines the desired state of KafkaCluster
 type KafkaClusterSpec struct {
-	HeadlessServiceEnabled bool                    `json:"headlessServiceEnabled"`
-	ListenersConfig        ListenersConfig         `json:"listenersConfig"`
-	ZKAddresses            []string                `json:"zkAddresses"`
-	ZKPath                 string                  `json:"zkPath,omitempty"`
-	RackAwareness          *RackAwareness          `json:"rackAwareness,omitempty"`
-	ClusterImage           string                  `json:"clusterImage,omitempty"`
-	ReadOnlyConfig         string                  `json:"readOnlyConfig,omitempty"`
-	ClusterWideConfig      string                  `json:"clusterWideConfig,omitempty"`
-	BrokerConfigGroups     map[string]BrokerConfig `json:"brokerConfigGroups,omitempty"`
-	Brokers                []Broker                `json:"brokers"`
-	RollingUpgradeConfig   RollingUpgradeConfig    `json:"rollingUpgradeConfig"`
+	HeadlessServiceEnabled bool            `json:"headlessServiceEnabled"`
+	ListenersConfig        ListenersConfig `json:"listenersConfig"`
+	// ZKAddresses specifies the ZooKeeper connection string
+	// in the form hostname:port where host and port are the host and port of a ZooKeeper server.
+	ZKAddresses []string `json:"zkAddresses"`
+	// ZKPath specifies the ZooKeeper chroot path as part
+	// of its ZooKeeper connection string which puts its data under some path in the global ZooKeeper namespace.
+	ZKPath               string                  `json:"zkPath,omitempty"`
+	RackAwareness        *RackAwareness          `json:"rackAwareness,omitempty"`
+	ClusterImage         string                  `json:"clusterImage,omitempty"`
+	ReadOnlyConfig       string                  `json:"readOnlyConfig,omitempty"`
+	ClusterWideConfig    string                  `json:"clusterWideConfig,omitempty"`
+	BrokerConfigGroups   map[string]BrokerConfig `json:"brokerConfigGroups,omitempty"`
+	Brokers              []Broker                `json:"brokers"`
+	RollingUpgradeConfig RollingUpgradeConfig    `json:"rollingUpgradeConfig"`
 	// +kubebuilder:default=envoy
 	// +kubebuilder:validation:Enum=envoy;istioingress
 	IngressController   string              `json:"ingressController,omitempty"`
@@ -139,6 +143,7 @@ type EnvoyConfig struct {
 	LoadBalancerSourceRanges []string                      `json:"loadBalancerSourceRanges,omitempty"`
 }
 
+// IstioIngressConfig defines the config for the Istio Ingress Controller
 type IstioIngressConfig struct {
 	Resources    *corev1.ResourceRequirements `json:"resourceRequirements,omitempty"`
 	Replicas     int32                        `json:"replicas,omitempty"`

--- a/charts/kafka-operator/templates/operator-kafka-crd.yaml
+++ b/charts/kafka-operator/templates/operator-kafka-crd.yaml
@@ -1367,6 +1367,8 @@ spec:
               items:
                 type: string
               type: array
+            zkPath:
+              type: string
           required:
             - brokers
             - cruiseControlConfig

--- a/charts/kafka-operator/templates/operator-kafka-crd.yaml
+++ b/charts/kafka-operator/templates/operator-kafka-crd.yaml
@@ -1160,6 +1160,8 @@ spec:
                 - istioingress
               type: string
             istioIngressConfig:
+              description: IstioIngressConfig defines the config for the Istio Ingress
+                Controller
               properties:
                 annotations:
                   additionalProperties:
@@ -1364,10 +1366,16 @@ spec:
               - userStore
               type: object
             zkAddresses:
+              description: ZKAddresses specifies the ZooKeeper connection string in
+                the form hostname:port where host and port are the host and port of
+                a ZooKeeper server.
               items:
                 type: string
               type: array
             zkPath:
+              description: ZKPath specifies the ZooKeeper chroot path as part of its
+                ZooKeeper connection string which puts its data under some path in
+                the global ZooKeeper namespace.
               type: string
           required:
             - brokers

--- a/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
+++ b/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
@@ -1363,6 +1363,8 @@ spec:
               items:
                 type: string
               type: array
+            zkPath:
+              type: string
           required:
           - brokers
           - cruiseControlConfig

--- a/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
+++ b/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
@@ -1156,6 +1156,8 @@ spec:
               - istioingress
               type: string
             istioIngressConfig:
+              description: IstioIngressConfig defines the config for the Istio Ingress
+                Controller
               properties:
                 annotations:
                   additionalProperties:
@@ -1360,10 +1362,16 @@ spec:
               - userStore
               type: object
             zkAddresses:
+              description: ZKAddresses specifies the ZooKeeper connection string in
+                the form hostname:port where host and port are the host and port of
+                a ZooKeeper server.
               items:
                 type: string
               type: array
             zkPath:
+              description: ZKPath specifies the ZooKeeper chroot path as part of its
+                ZooKeeper connection string which puts its data under some path in
+                the global ZooKeeper namespace.
               type: string
           required:
           - brokers

--- a/config/samples/banzaicloud_v1beta1_kafkacluster.yaml
+++ b/config/samples/banzaicloud_v1beta1_kafkacluster.yaml
@@ -8,9 +8,14 @@ spec:
   # Specify if the cluster should use headlessService for Kafka or individual services
   # using service/broker may come in handy in case of service mesh
   headlessServiceEnabled: true
+  # Specify the usable ingress controller, only envoy and istioingress supported can be left blank
+  ingressController: "envoy"
   # Specify the zookeeper addresses where the Kafka should store it's metadata
   zkAddresses:
     - "example-zookeepercluster-client.zookeeper:2181"
+  # Specify the zookeeper path where the Kafka related metadatas should be placed
+  # By default it is bound to "/" and can be left blank
+  zkPath: "/kafka"
   # rackAwareness add support for Kafka rack aware feature
   rackAwareness:
     # operator will use these labels from the nodes to create the rack for Kafka

--- a/pkg/resources/cruisecontrol/configmap.go
+++ b/pkg/resources/cruisecontrol/configmap.go
@@ -41,7 +41,7 @@ func (r *Reconciler) configMap(log logr.Logger, clientPass string) runtime.Objec
     bootstrap.servers=%s:%d
     # The zookeeper connect of the Kafka cluster
     zookeeper.connect=%s
-`, generateBootstrapServer(r.KafkaCluster.Spec.HeadlessServiceEnabled, r.KafkaCluster.Name), r.KafkaCluster.Spec.ListenersConfig.InternalListeners[0].ContainerPort, prepareZookeeperAddress(r.KafkaCluster.Spec.ZKAddresses)) +
+`, generateBootstrapServer(r.KafkaCluster.Spec.HeadlessServiceEnabled, r.KafkaCluster.Name), r.KafkaCluster.Spec.ListenersConfig.InternalListeners[0].ContainerPort, prepareZookeeperAddress(r.KafkaCluster.Spec.ZKAddresses, r.KafkaCluster.Spec.GetZkPath())) +
 				generateSSLConfig(&r.KafkaCluster.Spec.ListenersConfig, clientPass),
 			"capacity.json":       r.KafkaCluster.Spec.CruiseControlConfig.CapacityConfig,
 			"clusterConfigs.json": r.KafkaCluster.Spec.CruiseControlConfig.ClusterConfig,
@@ -92,14 +92,7 @@ func generateBootstrapServer(headlessEnabled bool, clusterName string) string {
 	return fmt.Sprintf(kafkautils.AllBrokerServiceTemplate, clusterName)
 }
 
-func prepareZookeeperAddress(zkAddresses []string) string {
-	preparedAddress := []string{}
-	for _, addr := range zkAddresses {
-		if strings.Contains(addr, "/") {
-			preparedAddress = append(preparedAddress, addr)
-		} else {
-			preparedAddress = append(preparedAddress, addr+"/")
-		}
-	}
-	return strings.Join(preparedAddress, ",")
+// The required ZK path for CC looks 'example-1:2181,example-2:2181/kafka'
+func prepareZookeeperAddress(zkAddresses []string, zkPath string) string {
+	return strings.Join(zkAddresses, ",") + zkPath
 }

--- a/pkg/resources/kafka/configmap.go
+++ b/pkg/resources/kafka/configmap.go
@@ -98,7 +98,7 @@ func (r *Reconciler) getConfigString(bConfig *v1beta1.BrokerConfig, id int32, lo
 
 // The required path for Kafka looks 'example-1:2181/kafka,example-2:2181/kafka'
 func prepareZookeeperAddress(zkAddresses []string, zkPath string) string {
-	preparedAddress := make([]string, len(zkAddresses))
+	preparedAddress := make([]string, 0)
 	for _, address := range zkAddresses {
 		preparedAddress = append(preparedAddress, address+zkPath)
 	}

--- a/pkg/resources/kafka/configmap_test.go
+++ b/pkg/resources/kafka/configmap_test.go
@@ -105,7 +105,7 @@ listener.security.protocol.map=INTERNAL:PLAINTEXT
 listeners=INTERNAL://:9092
 metric.reporters=com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporter
 super.users=
-zookeeper.connect=example.zk:2181/kafka,example.zk-1:2181/kafka`,
+zookeeper.connect=example.zk:2181,example.zk-1:2181/kafka`,
 		},
 		{
 			testName:                "basicConfigWithCustomStorage",

--- a/pkg/util/zookeeper/common.go
+++ b/pkg/util/zookeeper/common.go
@@ -1,0 +1,23 @@
+// Copyright © 2020 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package zookeeper
+
+import "strings"
+
+// PrepareConnectionAddress prepares the proper address for Kafka and CC
+// The required path for Kafka and CC looks 'example-1:2181,example-2:2181/kafka'
+func PrepareConnectionAddress(zkAddresses []string, zkPath string) string {
+	return strings.Join(zkAddresses, ",") + zkPath
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes|
| New feature?    | no|
| API breaks?     | no|
| Deprecations?   | no|
| Related tickets | fixes #235 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Fixes the Path issue since Kafka requires a different format than CC.
The right connection string for Kafka: 
`example-zk:2181/kafka,example-zk-1:2181/kafka`
According to Cruise Controls code the right connection string format is:
`example-zk:2181,example-zk-1:2181/kafka`.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
