### PR TITLE
Feature: Use user-provided Issuer/ClusterIssuer to generate TLS certs

### DIFF
--- a/api/v1beta1/kafkacluster_types.go
+++ b/api/v1beta1/kafkacluster_types.go
@@ -17,6 +17,7 @@ package v1beta1
 import (
 	"strings"
 
+	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -182,10 +183,10 @@ type ListenersConfig struct {
 
 // SSLSecrets defines the Kafka SSL secrets
 type SSLSecrets struct {
-	TLSSecretName   string `json:"tlsSecretName"`
-	JKSPasswordName string `json:"jksPasswordName"`
-	Create          bool   `json:"create,omitempty"`
-
+	TLSSecretName   string                  `json:"tlsSecretName"`
+	JKSPasswordName string                  `json:"jksPasswordName"`
+	Create          bool                    `json:"create,omitempty"`
+	IssuerRef       *cmmeta.ObjectReference `json:"issuerRef,omitempty"`
 	// +kubebuilder:validation:Enum={"cert-manager","vault"}
 	PKIBackend PKIBackend `json:"pkiBackend,omitempty"`
 }

--- a/charts/kafka-operator/templates/operator-kafka-crd.yaml
+++ b/charts/kafka-operator/templates/operator-kafka-crd.yaml
@@ -1310,6 +1310,20 @@ spec:
                       type: string
                     tlsSecretName:
                       type: string
+                    issuerRef:
+                      type: object
+                      description: IssuerRef represents a reference to an Issuer object
+                      required:
+                      - name
+                      - kind
+                      properties:
+                        name:
+                          type: string
+                        kind:
+                          type: string
+                          enum:
+                          - Issuer
+                          - ClusterIssuer
                   required:
                     - jksPasswordName
                     - tlsSecretName

--- a/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
+++ b/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
@@ -1306,6 +1306,20 @@ spec:
                       type: string
                     tlsSecretName:
                       type: string
+                    issuerRef:
+                      type: object
+                      description: IssuerRef represents a reference to an Issuer object
+                      required:
+                      - name
+                      - kind
+                      properties:
+                        name:
+                          type: string
+                        kind:
+                          type: string
+                          enum:
+                          - Issuer
+                          - ClusterIssuer
                   required:
                   - jksPasswordName
                   - tlsSecretName

--- a/pkg/pki/certmanagerpki/certmanager_pki.go
+++ b/pkg/pki/certmanagerpki/certmanager_pki.go
@@ -111,9 +111,8 @@ func (c *certManager) kafkapki(ctx context.Context, scheme *runtime.Scheme, exte
 	if sslConfig.Create {
 		if sslConfig.IssuerRef == nil {
 			return fullPKI(c.cluster, scheme, externalHostnames), nil
-		} else {
-			return userProvidedIssuerPKI(c.cluster, externalHostnames), nil
 		}
+		return userProvidedIssuerPKI(c.cluster, externalHostnames), nil
 	}
 	return userProvidedPKI(ctx, c.client, c.cluster, scheme, externalHostnames)
 }

--- a/pkg/pki/certmanagerpki/certmanager_pki.go
+++ b/pkg/pki/certmanagerpki/certmanager_pki.go
@@ -46,9 +46,14 @@ func (c *certManager) FinalizePKI(ctx context.Context, logger logr.Logger) error
 	if c.cluster.Spec.ListenersConfig.SSLSecrets.Create {
 		// Names of our certificates and secrets
 		objNames := []types.NamespacedName{
-			{Name: fmt.Sprintf(pkicommon.BrokerCACertTemplate, c.cluster.Name), Namespace: namespaceCertManager},
 			{Name: fmt.Sprintf(pkicommon.BrokerServerCertTemplate, c.cluster.Name), Namespace: c.cluster.Namespace},
 			{Name: fmt.Sprintf(pkicommon.BrokerControllerTemplate, c.cluster.Name), Namespace: c.cluster.Namespace},
+		}
+		if c.cluster.Spec.ListenersConfig.SSLSecrets.IssuerRef == nil {
+			objNames = append(
+				objNames,
+				types.NamespacedName{Name: fmt.Sprintf(pkicommon.BrokerCACertTemplate, c.cluster.Name), Namespace: namespaceCertManager})
+
 		}
 		for _, obj := range objNames {
 			// Delete the certificates first so we don't accidentally recreate the

--- a/pkg/pki/certmanagerpki/certmanager_user.go
+++ b/pkg/pki/certmanagerpki/certmanager_user.go
@@ -163,7 +163,14 @@ func (c *certManager) clusterCertificateForUser(user *v1alpha1.KafkaUser, scheme
 
 // getCA returns the CA name/kind for the KafkaCluster
 func (c *certManager) getCA() (caName, caKind string) {
-	caKind = certv1.ClusterIssuerKind
-	caName = fmt.Sprintf(pkicommon.BrokerIssuerTemplate, c.cluster.Name)
+	issuerRef := c.cluster.Spec.ListenersConfig.SSLSecrets.IssuerRef
+	if issuerRef != nil {
+		caName = issuerRef.Name
+		caKind = issuerRef.Kind
+	} else {
+		caKind = certv1.ClusterIssuerKind
+		caName = fmt.Sprintf(pkicommon.BrokerIssuerTemplate, c.cluster.Name)
+	}
+	// TODO: Do we need to ensure this Issuer is exist?
 	return
 }

--- a/pkg/pki/certmanagerpki/certmanager_user.go
+++ b/pkg/pki/certmanagerpki/certmanager_user.go
@@ -148,6 +148,7 @@ func (c *certManager) clusterCertificateForUser(user *v1alpha1.KafkaUser, scheme
 			SecretName:  user.Spec.SecretName,
 			KeyEncoding: certv1.PKCS8,
 			CommonName:  user.Name,
+			Usages:      []certv1.KeyUsage{certv1.UsageClientAuth, certv1.UsageServerAuth},
 			IssuerRef: certmeta.ObjectReference{
 				Name: caName,
 				Kind: caKind,


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #270
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

1. The current behavior of `kafka-operator` is to generate a new self-signed CA and encapsulate it as a `ClusterIssuer` for each `KafkaCluster` if no CA provided by user. User has to trust each CA for each cluster, which brings inconvenience and security concerns.

   This PR enables user to reuse a pre-defined cert-manager `Issuer/ClusterIssuer` to issue all TLS certs used by `kafka-operator` and `KafkaUser` when SSL is enabled.

   For example, I have a `ClusterIssuer` named `my-issuer-that-already-exists` and I want to reuse it. The configuration of `KafkaCluster` resource looks like this.

   ```yaml
   listenersConfig:
     sslSecrets:
       tlsSecretName: "example-kafka-operator"
       jksPasswordName: "example-kafka-operator-pass"
       create: true
       issuerRef:      # <--- New property
         name: my-issuer-that-already-exists
         kind: ClusterIssuer
   ```

2. Add "client auth" key usage to `KafkaUser` certs.

   The default value for `CertificateSpec.Usages` is `UsageServerAuth`, which is not enough for Kafka TLS client authentication. Lacking "client auth" will lead to continuously SSL handshake failure.
   I've seen this error multiple times, and it prevents brokers to boot.

### Additional context

In enterprise environment, the CA private key will not be exposed to a user (I mean the maintainer of a kafka cluster). So the kafka admin cannot provide a k8s secret that contains `caCert` and `caKey` for a `KafkaCluster` resource. The appropriate  way to obtain a trusted certificate is through a pre-defined issuer (Usually a cluster-wide CA). Clients are only needed to trust the single CA of the issuer. 


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [ ] User guide and development docs updated (if needed)

