### PR TITLE
Kafka downscale reconcile should search for broker pods only

### DIFF
--- a/pkg/resources/kafka/kafka.go
+++ b/pkg/resources/kafka/kafka.go
@@ -158,9 +158,7 @@ func (r *Reconciler) Reconcile(log logr.Logger) error {
 	}
 	// Handle Pod delete
 	podList := &corev1.PodList{}
-	matchingLabels := client.MatchingLabels{
-		"kafka_cr": r.KafkaCluster.Name,
-	}
+	matchingLabels := client.MatchingLabels(labelsForKafka(r.KafkaCluster.Name))
 
 	err := r.Client.List(context.TODO(), podList, client.ListOption(client.InNamespace(r.KafkaCluster.Namespace)), client.ListOption(matchingLabels))
 	if err != nil {
@@ -617,10 +615,7 @@ func (r *Reconciler) reconcileKafkaPod(log logr.Logger, desiredPod *corev1.Pod) 
 			if r.KafkaCluster.Status.State == v1beta1.KafkaClusterRollingUpgrading {
 				// Check if any kafka pod is in terminating state
 				podList := &corev1.PodList{}
-				matchingLabels := client.MatchingLabels{
-					"kafka_cr": r.KafkaCluster.Name,
-					"app":      "kafka",
-				}
+				matchingLabels := client.MatchingLabels(labelsForKafka(r.KafkaCluster.Name))
 				err := r.Client.List(context.TODO(), podList, client.ListOption(client.InNamespace(r.KafkaCluster.Namespace)), client.ListOption(matchingLabels))
 				if err != nil {
 					return errors.WrapIf(err, "failed to reconcile resource")


### PR DESCRIPTION

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Currently when the user initiates a downscale by removing broker ids from spec
the operator will also select the cruise-control pod as a pod delete candidate.
Limiting the filter to broker pods only.



### Why?
Avoid unnecessary invalid empty `remove_broker` calls to cruise-control.  



### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [ ] User guide and development docs updated (if needed)

