### PR TITLE
Improve CruiseControl task handling during upscale and downscale

### DIFF
--- a/api/v1beta1/common_types.go
+++ b/api/v1beta1/common_types.go
@@ -23,6 +23,9 @@ type CruiseControlState string
 // CruiseControlTopicStatus holds info about the CC topic status
 type CruiseControlTopicStatus string
 
+// CruiseControlUserTaskState holds info about the CC user task state
+type CruiseControlUserTaskState string
+
 // ClusterState holds info about the cluster state
 type ClusterState string
 
@@ -82,6 +85,16 @@ const (
 	CruiseControlTopicNotReady CruiseControlTopicStatus = "CruiseControlTopicNotReady"
 	// CruiseControlTopicReady states the CC required topic is created
 	CruiseControlTopicReady CruiseControlTopicStatus = "CruiseControlTopicReady"
+	// CruiseControlTaskActive states the CC task is scheduled but not yet running
+	CruiseControlTaskActive CruiseControlUserTaskState = "Active"
+	// CruiseControlTaskNotFound states the CC task is not found (can happen when CC is restarted during operation)
+	CruiseControlTaskNotFound CruiseControlUserTaskState = "NotFound"
+	// CruiseControlTaskInExecution states the CC task is executing
+	CruiseControlTaskInExecution CruiseControlUserTaskState = "InExecution"
+	// CruiseControlTaskCompleted states the CC task compeleted successfully
+	CruiseControlTaskCompleted CruiseControlUserTaskState = "Completed"
+	// CruiseControlTaskCompletedWithError states the CC task completed with error
+	CruiseControlTaskCompletedWithError CruiseControlUserTaskState = "CompletedWithError"
 	// KafkaClusterReconciling states that the cluster is still in reconciling stage
 	KafkaClusterReconciling ClusterState = "ClusterReconciling"
 	// KafkaClusterRollingUpgrading states that the cluster is rolling upgrading

--- a/controllers/kafkacluster_controller.go
+++ b/controllers/kafkacluster_controller.go
@@ -148,11 +148,7 @@ func (r *KafkaClusterReconciler) Reconcile(request ctrl.Request) (ctrl.Result, e
 				return ctrl.Result{
 					RequeueAfter: time.Duration(20) * time.Second,
 				}, nil
-			case errorfactory.CruiseControlTaskTimeout:
-				return ctrl.Result{
-					RequeueAfter: time.Duration(20) * time.Second,
-				}, nil
-			case errorfactory.CruiseControlTaskFailure:
+			case errorfactory.CruiseControlTaskTimeout, errorfactory.CruiseControlTaskFailure:
 				return ctrl.Result{
 					RequeueAfter: time.Duration(20) * time.Second,
 				}, nil

--- a/controllers/kafkacluster_controller.go
+++ b/controllers/kafkacluster_controller.go
@@ -148,6 +148,14 @@ func (r *KafkaClusterReconciler) Reconcile(request ctrl.Request) (ctrl.Result, e
 				return ctrl.Result{
 					RequeueAfter: time.Duration(20) * time.Second,
 				}, nil
+			case errorfactory.CruiseControlTaskTimeout:
+				return ctrl.Result{
+					RequeueAfter: time.Duration(20) * time.Second,
+				}, nil
+			case errorfactory.CruiseControlTaskFailure:
+				return ctrl.Result{
+					RequeueAfter: time.Duration(20) * time.Second,
+				}, nil
 			default:
 				return requeueWithError(log, err.Error(), err)
 			}

--- a/pkg/errorfactory/errorfactory.go
+++ b/pkg/errorfactory/errorfactory.go
@@ -64,6 +64,12 @@ type CruiseControlNotReady struct{ error }
 // CruiseControlTaskRunning states that CC task is still running
 type CruiseControlTaskRunning struct{ error }
 
+// CruiseControlTaskRunning states that CC task timed out
+type CruiseControlTaskTimeout struct{ error }
+
+// CruiseControlTaskFailure states that CC task was not found (CC restart?) or failed
+type CruiseControlTaskFailure struct{ error }
+
 // New creates a new error factory error
 func New(t interface{}, err error, msg string, wrapArgs ...interface{}) error {
 	wrapped := errors.WrapIfWithDetails(err, msg, wrapArgs...)
@@ -100,6 +106,10 @@ func New(t interface{}, err error, msg string, wrapArgs ...interface{}) error {
 		return CruiseControlNotReady{wrapped}
 	case CruiseControlTaskRunning:
 		return CruiseControlTaskRunning{wrapped}
+	case CruiseControlTaskTimeout:
+		return CruiseControlTaskTimeout{wrapped}
+	case CruiseControlTaskFailure:
+		return CruiseControlTaskFailure{wrapped}
 	}
 	return wrapped
 }

--- a/pkg/scale/scale.go
+++ b/pkg/scale/scale.go
@@ -18,12 +18,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/banzaicloud/kafka-operator/api/v1beta1"
 	"io/ioutil"
 	"net/http"
 	"strconv"
 	"strings"
 
+	banzaicloudv1beta1 "github.com/banzaicloud/kafka-operator/api/v1beta1"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
@@ -378,8 +378,8 @@ func KillCCTask(namespace, ccEndpoint, clusterName string) error {
 	return nil
 }
 
-// CheckIfCCTaskFinished checks whether the given CC Task ID finished or not
-func GetCCTaskState(uTaskId, namespace, ccEndpoint, clusterName string) (v1beta1.CruiseControlUserTaskState, error) {
+// GetCCTaskState checks whether the given CC Task ID finished or not
+func GetCCTaskState(uTaskId, namespace, ccEndpoint, clusterName string) (banzaicloudv1beta1.CruiseControlUserTaskState, error) {
 
 	gResp, err := getCruiseControl(getTaskListAction, namespace, map[string]string{
 		"json":          "true",
@@ -413,15 +413,15 @@ func GetCCTaskState(uTaskId, namespace, ccEndpoint, clusterName string) (v1beta1
 	}
 	// No cc task found with this UID
 	if len(taskLists.UserTasks) == 0 {
-		return v1beta1.CruiseControlTaskNotFound, nil
+		return banzaicloudv1beta1.CruiseControlTaskNotFound, nil
 	}
 
 	for _, task := range taskLists.UserTasks {
 		if task.UserTaskId == uTaskId {
 			log.Info("Cruise control task state", "state", task.Status, "taskID", uTaskId)
-			return v1beta1.CruiseControlUserTaskState(task.Status), nil
+			return banzaicloudv1beta1.CruiseControlUserTaskState(task.Status), nil
 		}
 	}
 	log.Info("Cruise control task not found", "taskID", uTaskId)
-	return v1beta1.CruiseControlTaskNotFound, nil
+	return banzaicloudv1beta1.CruiseControlTaskNotFound, nil
 }


### PR DESCRIPTION
- handle cases where task id fails in CC or is lost due to CC restart

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no|yes
| API breaks?     | no|yes
| Deprecations?   | no|yes
| Related tickets | fixes #272
| License         | Apache 2.0


### What's in this PR?

Better handle CC task status codes when the task fails or CC is restarted and CC task is not found anymore.
Operator now handles these cases and reschedules a new CC task.


### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [ ] User guide and development docs updated (if needed)

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [ ] If the PR is not complete but you want to discuss the approach, list what remains to be done here
