### PR TITLE
enhancement: Configurable resource pattern type of KafkaUser ACLs.

### DIFF
--- a/api/v1alpha1/common_types.go
+++ b/api/v1alpha1/common_types.go
@@ -17,6 +17,9 @@ package v1alpha1
 // KafkaAccessType hold info about Kafka ACL
 type KafkaAccessType string
 
+// KafkaPatternType hold the Resource Pattern Type of kafka ACL
+type KafkaPatternType string
+
 // TopicState defines the state of a KafkaTopic
 type TopicState string
 
@@ -35,6 +38,12 @@ const (
 	KafkaAccessTypeRead KafkaAccessType = "read"
 	// KafkaAccessTypeWrite states that a user wants produce access to a topic
 	KafkaAccessTypeWrite KafkaAccessType = "write"
+	// Resource pattern types. More info: https://kafka.apache.org/20/javadoc/org/apache/kafka/common/resource/PatternType.html
+	KafkaPatternTypeAny      KafkaPatternType = "any"
+	KafkaPatternTypeLiteral  KafkaPatternType = "literal"
+	KafkaPatternTypeMatch    KafkaPatternType = "match"
+	KafkaPatternTypePrefixed KafkaPatternType = "prefixed"
+	KafkaPatternTypeDefault  KafkaPatternType = "literal"
 	// TopicStateCreated describes the status of a KafkaTopic as created
 	TopicStateCreated TopicState = "created"
 	// UserStateCreated describes the status of a KafkaUser as created

--- a/api/v1alpha1/kafkauser_types.go
+++ b/api/v1alpha1/kafkauser_types.go
@@ -33,6 +33,8 @@ type UserTopicGrant struct {
 	TopicName string `json:"topicName"`
 	// +kubebuilder:validation:Enum={"read","write"}
 	AccessType KafkaAccessType `json:"accessType"`
+	// +kubebuilder:validation:Enum={"literal","match","prefixed","any"}
+	PatternType KafkaPatternType `json:"patternType"`
 }
 
 // KafkaUserStatus defines the observed state of KafkaUser

--- a/charts/kafka-operator/templates/operator-kafka-user-crd.yaml
+++ b/charts/kafka-operator/templates/operator-kafka-user-crd.yaml
@@ -75,6 +75,15 @@ spec:
                     type: string
                   topicName:
                     type: string
+                  patternType:
+                    description: 'patternType is the Resource Pattern Type of this ACL entry.
+                      More info: https://kafka.apache.org/20/javadoc/org/apache/kafka/common/resource/PatternType.html'
+                    enum:
+                    - prefixed
+                    - literal
+                    - match
+                    - any
+                    type: string
                 required:
                 - accessType
                 - topicName

--- a/config/base/crds/kafka.banzaicloud.io_kafkausers.yaml
+++ b/config/base/crds/kafka.banzaicloud.io_kafkausers.yaml
@@ -63,6 +63,15 @@ spec:
                     type: string
                   topicName:
                     type: string
+                  patternType:
+                    description: 'patternType is the Resource Pattern Type of this ACL entry.
+                      More info: https://kafka.apache.org/20/javadoc/org/apache/kafka/common/resource/PatternType.html'
+                    enum:
+                    - prefixed
+                    - literal
+                    - match
+                    - any
+                    type: string
                 required:
                 - accessType
                 - topicName

--- a/controllers/kafkauser_controller.go
+++ b/controllers/kafkauser_controller.go
@@ -202,7 +202,7 @@ func (r *KafkaUserReconciler) Reconcile(request reconcile.Request) (reconcile.Re
 		for _, grant := range instance.Spec.TopicGrants {
 			reqLogger.Info(fmt.Sprintf("Ensuring %s ACLs for User: %s -> Topic: %s", grant.AccessType, user.DN(), grant.TopicName))
 			// CreateUserACLs returns no error if the ACLs already exist
-			if err = broker.CreateUserACLs(grant.AccessType, user.DN(), grant.TopicName); err != nil {
+			if err = broker.CreateUserACLs(grant.AccessType, grant.PatternType, user.DN(), grant.TopicName); err != nil {
 				return requeueWithError(reqLogger, "failed to ensure ACLs for kafkauser", err)
 			}
 		}

--- a/pkg/kafkaclient/client.go
+++ b/pkg/kafkaclient/client.go
@@ -38,7 +38,7 @@ type KafkaClient interface {
 	DeleteTopic(string, bool) error
 	GetTopic(string) (*sarama.TopicDetail, error)
 	DescribeTopic(string) (*sarama.TopicMetadata, error)
-	CreateUserACLs(v1alpha1.KafkaAccessType, string, string) error
+	CreateUserACLs(v1alpha1.KafkaAccessType, v1alpha1.KafkaPatternType, string, string) error
 	DeleteUserACLs(string) error
 
 	Brokers() map[int32]string


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #269 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Kafka 2.x supports [four types of `ResourcePatternType`](https://kafka.apache.org/20/javadoc/org/apache/kafka/common/resource/PatternType.html) when configuring user ACLs.
Currently, the `topicGrants` property in `KafkaUser` CRD requires user to provide `topicName` explicitly, because it uses `LITERAL` pattern type by default.

This PR makes the User ACL pattern type configurable. User can use other pattern types.

In the following example, the `prefixed` pattern types enables user to assign permissions on any topics with a `test.` prefix.
```yaml
apiVersion: kafka.banzaicloud.io/v1alpha1
kind: KafkaUser
...
spec:
  ...
  topicGrants:
    - topicName: test.
      accessType: write
      patternType: prefixed
```
`literal` will be default if `patternType` is not provided.

The detailed behavior and pattern syntax of these pattern types depends on kafka.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

Actually, I don't understand the behavior of `MATCH` pattern type. According to [Kafka Documentation](https://kafka.apache.org/20/javadoc/org/apache/kafka/common/resource/PatternType.html#MATCH), it says:

>public static final PatternType MATCH
In a filter, will perform pattern matching. e.g. Given a filter of ResourcePatternFilter(TOPIC, "payments.received", MATCH)`, the filter match any ResourcePattern that matches topic 'payments.received'. This might include:
A Literal pattern with the same type and name, e.g. ResourcePattern(TOPIC, "payments.received", LITERAL)
A Wildcard pattern with the same type, e.g. ResourcePattern(TOPIC, "*", LITERAL)
A Prefixed pattern with the same type and where the name is a matching prefix, e.g. ResourcePattern(TOPIC, "payments.", PREFIXED)

This sounds counterintuitive. It's supposed to use regex matching when pattern type is `MATCH`, but it doesn't. Actually it matches other ACLs that will match this "payments.received".

As for `ANY`, it's also confusing. What does ["In a filter, matches any resource pattern type."](https://kafka.apache.org/20/javadoc/org/apache/kafka/common/resource/PatternType.html#ANY) mean? It means when I use `ANY` while deleting ACLs for a topic, it will delete all ACLs of the topic no matter what pattern type it has? So what about the behavior of creating ACLs with `ANY` type?

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [ ] User guide and development docs updated (if needed)

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [x] If the PR is not complete but you want to discuss the approach, list what remains to be done here
