### PR TITLE
Istioingress tls

### DIFF
--- a/api/v1beta1/kafkacluster_types.go
+++ b/api/v1beta1/kafkacluster_types.go
@@ -17,6 +17,7 @@ package v1beta1
 import (
 	"strings"
 
+	"github.com/banzaicloud/istio-client-go/pkg/networking/v1alpha3"
 	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -158,6 +159,7 @@ type IstioIngressConfig struct {
 	NodeSelector map[string]string            `json:"nodeSelector,omitempty"`
 	Tolerations  []corev1.Toleration          `json:"tolerations,omitempty"`
 	Annotations  map[string]string            `json:"annotations,omitempty"`
+	TLSOptions   *v1alpha3.TLSOptions         `json:"gatewayConfig,omitempty"`
 }
 
 // MonitoringConfig defines the config for monitoring Kafka and Cruise Control

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -19,6 +19,7 @@
 package v1beta1
 
 import (
+	"github.com/banzaicloud/istio-client-go/pkg/networking/v1alpha3"
 	metav1 "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
 	"k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -317,6 +318,11 @@ func (in *IstioIngressConfig) DeepCopyInto(out *IstioIngressConfig) {
 		for key, val := range *in {
 			(*out)[key] = val
 		}
+	}
+	if in.TLSOptions != nil {
+		in, out := &in.TLSOptions, &out.TLSOptions
+		*out = new(v1alpha3.TLSOptions)
+		(*in).DeepCopyInto(*out)
 	}
 }
 

--- a/charts/kafka-operator/templates/operator-kafka-crd.yaml
+++ b/charts/kafka-operator/templates/operator-kafka-crd.yaml
@@ -1178,6 +1178,90 @@ spec:
                   additionalProperties:
                     type: string
                   type: object
+                gatewayConfig:
+                  properties:
+                    caCertificates:
+                      description: REQUIRED if mode is `MUTUAL`. The path to a file
+                        containing certificate authority certificates to use in verifying
+                        a presented client side certificate.
+                      type: string
+                    cipherSuites:
+                      description: 'Optional: If specified, only support the specified
+                        cipher list. Otherwise default to the default cipher list
+                        supported by Envoy.'
+                      items:
+                        type: string
+                      type: array
+                    credentialName:
+                      description: The credentialName stands for a unique identifier
+                        that can be used to identify the serverCertificate and the
+                        privateKey. The credentialName appended with suffix "-cacert"
+                        is used to identify the CaCertificates associated with this
+                        server. Gateway workloads capable of fetching credentials
+                        from a remote credential store such as Kubernetes secrets,
+                        will be configured to retrieve the serverCertificate and the
+                        privateKey using credentialName, instead of using the file
+                        system paths specified above. If using mutual TLS, gateway
+                        workload instances will retrieve the CaCertificates using
+                        credentialName-cacert. The semantics of the name are platform
+                        dependent.  In Kubernetes, the default Istio supplied credential
+                        server expects the credentialName to match the name of the
+                        Kubernetes secret that holds the server certificate, the private
+                        key, and the CA certificate (if using mutual TLS). Set the
+                        `ISTIO_META_USER_SDS` metadata variable in the gateway's proxy
+                        to enable the dynamic credential fetching feature.
+                      type: string
+                    httpsRedirect:
+                      description: If set to true, the load balancer will send a 301
+                        redirect for all http connections, asking the clients to use
+                        HTTPS.
+                      type: boolean
+                    maxProtocolVersion:
+                      description: 'Optional: Maximum TLS protocol version.'
+                      type: string
+                    minProtocolVersion:
+                      description: 'Optional: Minimum TLS protocol version.'
+                      type: string
+                    mode:
+                      description: 'Optional: Indicates whether connections to this
+                        port should be secured using TLS. The value of this field
+                        determines how TLS is enforced.'
+                      type: string
+                    privateKey:
+                      description: REQUIRED if mode is `SIMPLE` or `MUTUAL`. The path
+                        to the file holding the server's private key.
+                      type: string
+                    serverCertificate:
+                      description: REQUIRED if mode is `SIMPLE` or `MUTUAL`. The path
+                        to the file holding the server-side TLS certificate to use.
+                      type: string
+                    subjectAltNames:
+                      description: A list of alternate names to verify the subject
+                        identity in the certificate presented by the client.
+                      items:
+                        type: string
+                      type: array
+                    verifyCertificateHash:
+                      description: 'An optional list of hex-encoded SHA-256 hashes
+                        of the authorized client certificates. Both simple and colon
+                        separated formats are acceptable. Note: When both verify_certificate_hash
+                        and verify_certificate_spki are specified, a hash matching
+                        either value will result in the certificate being accepted.'
+                      items:
+                        type: string
+                      type: array
+                    verifyCertificateSpki:
+                      description: 'An optional list of base64-encoded SHA-256 hashes
+                        of the SKPIs of authorized client certificates. Note: When
+                        both verify_certificate_hash and verify_certificate_spki are
+                        specified, a hash matching either value will result in the
+                        certificate being accepted.'
+                      items:
+                        type: string
+                      type: array
+                  required:
+                    - httpsRedirect
+                  type: object
                 nodeSelector:
                   additionalProperties:
                     type: string

--- a/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
+++ b/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
@@ -1174,6 +1174,90 @@ spec:
                   additionalProperties:
                     type: string
                   type: object
+                gatewayConfig:
+                  properties:
+                    caCertificates:
+                      description: REQUIRED if mode is `MUTUAL`. The path to a file
+                        containing certificate authority certificates to use in verifying
+                        a presented client side certificate.
+                      type: string
+                    cipherSuites:
+                      description: 'Optional: If specified, only support the specified
+                        cipher list. Otherwise default to the default cipher list
+                        supported by Envoy.'
+                      items:
+                        type: string
+                      type: array
+                    credentialName:
+                      description: The credentialName stands for a unique identifier
+                        that can be used to identify the serverCertificate and the
+                        privateKey. The credentialName appended with suffix "-cacert"
+                        is used to identify the CaCertificates associated with this
+                        server. Gateway workloads capable of fetching credentials
+                        from a remote credential store such as Kubernetes secrets,
+                        will be configured to retrieve the serverCertificate and the
+                        privateKey using credentialName, instead of using the file
+                        system paths specified above. If using mutual TLS, gateway
+                        workload instances will retrieve the CaCertificates using
+                        credentialName-cacert. The semantics of the name are platform
+                        dependent.  In Kubernetes, the default Istio supplied credential
+                        server expects the credentialName to match the name of the
+                        Kubernetes secret that holds the server certificate, the private
+                        key, and the CA certificate (if using mutual TLS). Set the
+                        `ISTIO_META_USER_SDS` metadata variable in the gateway's proxy
+                        to enable the dynamic credential fetching feature.
+                      type: string
+                    httpsRedirect:
+                      description: If set to true, the load balancer will send a 301
+                        redirect for all http connections, asking the clients to use
+                        HTTPS.
+                      type: boolean
+                    maxProtocolVersion:
+                      description: 'Optional: Maximum TLS protocol version.'
+                      type: string
+                    minProtocolVersion:
+                      description: 'Optional: Minimum TLS protocol version.'
+                      type: string
+                    mode:
+                      description: 'Optional: Indicates whether connections to this
+                        port should be secured using TLS. The value of this field
+                        determines how TLS is enforced.'
+                      type: string
+                    privateKey:
+                      description: REQUIRED if mode is `SIMPLE` or `MUTUAL`. The path
+                        to the file holding the server's private key.
+                      type: string
+                    serverCertificate:
+                      description: REQUIRED if mode is `SIMPLE` or `MUTUAL`. The path
+                        to the file holding the server-side TLS certificate to use.
+                      type: string
+                    subjectAltNames:
+                      description: A list of alternate names to verify the subject
+                        identity in the certificate presented by the client.
+                      items:
+                        type: string
+                      type: array
+                    verifyCertificateHash:
+                      description: 'An optional list of hex-encoded SHA-256 hashes
+                        of the authorized client certificates. Both simple and colon
+                        separated formats are acceptable. Note: When both verify_certificate_hash
+                        and verify_certificate_spki are specified, a hash matching
+                        either value will result in the certificate being accepted.'
+                      items:
+                        type: string
+                      type: array
+                    verifyCertificateSpki:
+                      description: 'An optional list of base64-encoded SHA-256 hashes
+                        of the SKPIs of authorized client certificates. Note: When
+                        both verify_certificate_hash and verify_certificate_spki are
+                        specified, a hash matching either value will result in the
+                        certificate being accepted.'
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - httpsRedirect
+                  type: object
                 nodeSelector:
                   additionalProperties:
                     type: string

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/Shopify/sarama v1.23.1
 	github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a // indirect
 	github.com/banzaicloud/bank-vaults/pkg/sdk v0.2.0
-	github.com/banzaicloud/istio-client-go v0.0.0-20191203163313-928801ec5028
+	github.com/banzaicloud/istio-client-go v0.0.0-20200207164547-0c6796585145
 	github.com/banzaicloud/istio-operator v0.0.0-20191212123221-6e3658721f00
 	github.com/banzaicloud/k8s-objectmatcher v1.0.0
 	github.com/envoyproxy/go-control-plane v0.8.6

--- a/go.sum
+++ b/go.sum
@@ -123,6 +123,8 @@ github.com/banzaicloud/bank-vaults/pkg/sdk v0.2.0 h1:9cNXS+jRQwK9SRYoC6PMkdF5PYY
 github.com/banzaicloud/bank-vaults/pkg/sdk v0.2.0/go.mod h1:2NYclIV7rF4QT5BE7wE2u/dy148gt8CQZ81Np81Mza0=
 github.com/banzaicloud/istio-client-go v0.0.0-20191203163313-928801ec5028 h1:5K/exwqDVN9g69f+Lco3eADTDaIREb0tdUZiphG2xlw=
 github.com/banzaicloud/istio-client-go v0.0.0-20191203163313-928801ec5028/go.mod h1:kKhUPoDXdY0EE1hTBiN+R9C2mVgSNyvkt8dZ/xb9obM=
+github.com/banzaicloud/istio-client-go v0.0.0-20200207164547-0c6796585145 h1:giNuJZcO63LVBr3zWdsQXC/QpxiRerKjwRkwAmLmfc4=
+github.com/banzaicloud/istio-client-go v0.0.0-20200207164547-0c6796585145/go.mod h1:kKhUPoDXdY0EE1hTBiN+R9C2mVgSNyvkt8dZ/xb9obM=
 github.com/banzaicloud/istio-operator v0.0.0-20190821151858-a47cd7d9bc7a/go.mod h1:ZsHnkYOQmq/OhsTX/apqgSoT2Jt5qkr15zuoVcj48Xk=
 github.com/banzaicloud/istio-operator v0.0.0-20191212123221-6e3658721f00 h1:RpxUAyBPcN+pgNDy9KlpQlUNtGmQsesbDteXuwHMpU8=
 github.com/banzaicloud/istio-operator v0.0.0-20191212123221-6e3658721f00/go.mod h1:ZsHnkYOQmq/OhsTX/apqgSoT2Jt5qkr15zuoVcj48Xk=

--- a/pkg/resources/istioingress/gateway.go
+++ b/pkg/resources/istioingress/gateway.go
@@ -37,13 +37,20 @@ func (r *Reconciler) gateway(log logr.Logger, externalListenerConfig v1beta1.Ext
 
 func generateServers(kc *v1beta1.KafkaCluster, externalListenerConfig v1beta1.ExternalListenerConfig, log logr.Logger) []v1alpha3.Server {
 	servers := make([]v1alpha3.Server, 0)
+	protocol := v1alpha3.ProtocolTCP
+	var tlsConfig *v1alpha3.TLSOptions
+	if kc.Spec.IstioIngressConfig.TLSOptions != nil {
+		tlsConfig = kc.Spec.IstioIngressConfig.TLSOptions
+		protocol = v1alpha3.ProtocolTLS
+	}
 	for _, broker := range kc.Spec.Brokers {
 		servers = append(servers, v1alpha3.Server{
 			Port: &v1alpha3.Port{
 				Number:   int(broker.Id + externalListenerConfig.ExternalStartingPort),
-				Protocol: v1alpha3.ProtocolTCP,
+				Protocol: protocol,
 				Name:     fmt.Sprintf("broker-%d", broker.Id),
 			},
+			TLS:   tlsConfig,
 			Hosts: []string{"*"},
 		})
 	}

--- a/pkg/resources/istioingress/gateway.go
+++ b/pkg/resources/istioingress/gateway.go
@@ -54,6 +54,17 @@ func generateServers(kc *v1beta1.KafkaCluster, externalListenerConfig v1beta1.Ex
 			Hosts: []string{"*"},
 		})
 	}
+	if !kc.Spec.HeadlessServiceEnabled && len(kc.Spec.ListenersConfig.ExternalListeners) > 0 {
+		servers = append(servers, v1alpha3.Server{
+			Port: &v1alpha3.Port{
+				Number:   int(kc.Spec.ListenersConfig.InternalListeners[0].ContainerPort),
+				Protocol: protocol,
+				Name:     allBrokers,
+			},
+			Hosts: []string{"*"},
+			TLS:   tlsConfig,
+		})
+	}
 
 	return servers
 }

--- a/pkg/resources/istioingress/istioingress.go
+++ b/pkg/resources/istioingress/istioingress.go
@@ -28,6 +28,7 @@ const (
 	componentName          = "istioingress"
 	gatewayNameTemplate    = "%s-%s-gateway"
 	virtualServiceTemplate = "%s-%s-virtualservice"
+	allBrokers             = "all-brokers"
 )
 
 // labelsForIstioIngress returns the labels for selecting the resources

--- a/pkg/resources/kafka/allBrokerService.go
+++ b/pkg/resources/kafka/allBrokerService.go
@@ -37,6 +37,14 @@ func (r *Reconciler) allBrokerService() runtime.Object {
 			Protocol:   corev1.ProtocolTCP,
 		})
 	}
+	//Append external listener ports as well to allow using this service for metadata fetch
+	for _, eListeners := range r.KafkaCluster.Spec.ListenersConfig.ExternalListeners {
+		usedPorts = append(usedPorts, corev1.ServicePort{
+			Name:     strings.ReplaceAll(eListeners.Name, "_", ""),
+			Port:     eListeners.ContainerPort,
+			Protocol: corev1.ProtocolTCP,
+		})
+	}
 
 	return &corev1.Service{
 		ObjectMeta: templates.ObjectMeta(fmt.Sprintf(kafkautils.AllBrokerServiceTemplate, r.KafkaCluster.Name), labelsForKafka(r.KafkaCluster.Name), r.KafkaCluster),


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no|
| New feature?    |yes|
| API breaks?     | no|
| Deprecations?   | no|
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
This PR introduces couple of new things:
- Adds support to modify TLSOptions when the ingress controller is Istio
- Updates dependency istio-client-go
- Create an external endpoint which can be used for metadata fetching

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
