### PR TITLE
Fix storageconfig merge issues

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -180,7 +180,7 @@ func GetBrokerConfig(broker v1beta1.Broker, clusterSpec v1beta1.KafkaClusterSpec
 		bConfig = broker.BrokerConfig.DeepCopy()
 	}
 
-	err := mergo.Merge(bConfig, clusterSpec.BrokerConfigGroups[broker.BrokerConfigGroup])
+	err := mergo.Merge(bConfig, clusterSpec.BrokerConfigGroups[broker.BrokerConfigGroup], mergo.WithAppendSlice)
 	if err != nil {
 		return nil, errors.WrapIf(err, "could not merge brokerConfig with ConfigGroup")
 	}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -18,8 +18,79 @@ import (
 	"reflect"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
 	"github.com/banzaicloud/kafka-operator/api/v1beta1"
 )
+
+func TestGetBrokerConfig(t *testing.T) {
+	expected := &v1beta1.BrokerConfig{
+		StorageConfigs: []v1beta1.StorageConfig{
+			{
+				MountPath: "kafka-test/log",
+				PvcSpec: &corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("10Gi")},
+					},
+				},
+			},
+			{
+				MountPath: "kafka-test1/log",
+				PvcSpec: &corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("10Gi")},
+					},
+				},
+			},
+		},
+	}
+	broker := v1beta1.Broker{
+		Id:                0,
+		BrokerConfigGroup: "default",
+		BrokerConfig: &v1beta1.BrokerConfig{
+			StorageConfigs: []v1beta1.StorageConfig{
+				{
+					MountPath: "kafka-test/log",
+					PvcSpec: &corev1.PersistentVolumeClaimSpec{
+						AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("10Gi")},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	cluster := v1beta1.KafkaClusterSpec{
+		BrokerConfigGroups: map[string]v1beta1.BrokerConfig{
+			"default": {
+				StorageConfigs: []v1beta1.StorageConfig{
+					{
+						MountPath: "kafka-test1/log",
+						PvcSpec: &corev1.PersistentVolumeClaimSpec{
+							AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("10Gi")},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	result, err := GetBrokerConfig(broker, cluster)
+	if err != nil {
+		t.Error("Error GetBrokerConfig throw an unexpected error")
+	}
+	if !reflect.DeepEqual(result, expected) {
+		t.Error("Expected:", expected, "Got:", result)
+	}
+}
 
 func TestParsePropertiesFormat(t *testing.T) {
 	testProp := `


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes|
| New feature?    | no|
| API breaks?     | no|
| Deprecations?   | no|
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
This PR fixes the broker config merge issues which happens with storageconfigs when brokerConfigGroups and brokerConfig is defined as well.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)