### PR TITLE
Do not block on pending brokers during upscale

### DIFF
--- a/pkg/k8sutil/cr.go
+++ b/pkg/k8sutil/cr.go
@@ -32,10 +32,6 @@ import (
 
 // UpdateCrWithRackAwarenessConfig updates the CR with rack awareness config
 func UpdateCrWithRackAwarenessConfig(pod *corev1.Pod, cr *v1beta1.KafkaCluster, client runtimeClient.Client) (v1beta1.RackAwarenessState, error) {
-
-	if pod.Spec.NodeName == "" {
-		return "", errorfactory.New(errorfactory.ResourceNotReady{}, errors.New("pod does not scheduled to node yet"), "trying")
-	}
 	rackConfigMap, err := getSpecificNodeLabels(pod.Spec.NodeName, client, cr.Spec.RackAwareness.Labels)
 	if err != nil {
 		return "", errorfactory.New(errorfactory.StatusUpdateError{}, err, "updating cr with rack awareness info failed")

--- a/pkg/resources/kafka/kafka.go
+++ b/pkg/resources/kafka/kafka.go
@@ -525,7 +525,9 @@ func (r *Reconciler) reconcileKafkaPod(log logr.Logger, desiredPod *corev1.Pod) 
 		currentPod = podList.Items[0].DeepCopy()
 		brokerId := currentPod.Labels["brokerId"]
 		if _, ok := r.KafkaCluster.Status.BrokersState[brokerId]; ok {
-			if r.KafkaCluster.Spec.RackAwareness != nil {
+			if currentPod.Spec.NodeName == "" {
+				log.Info(fmt.Sprintf("pod for brokerId %s does not scheduled to node yet", brokerId))
+			} else if r.KafkaCluster.Spec.RackAwareness != nil {
 				rackAwarenessState, err := k8sutil.UpdateCrWithRackAwarenessConfig(currentPod, r.KafkaCluster, r.Client)
 				if err != nil {
 					return err


### PR DESCRIPTION
This fixes the following scenario:
1. Start with a 3 racks cluster (3 brokers per rack)
2. One AZ goes completely down
  - existing brokers on that AZ are lost/failed
  - new brokers/pod cannot be scheduled on that AZ

At this point, we assume topics in Kafka are still healthy (replication factor > 1 + rack-aware balanced replicas)
but under-replicated (offline partitions on lost AZ)

One of the possible actions now is to trigger an upscale in the other 2 healthy AZs with more brokers
to take the load and move offline replicas

3. This patch ensures that `Pending` broker pods are not blocking bootstrapping other pods that can be scheduled.
And not stuck serially on each pod to be scheduled.


| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->



### Checklist

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [ ] User guide and development docs updated (if needed)

