### PR TITLE
Decommission only registered brokers in CC during downscale

### DIFF
--- a/pkg/k8sutil/cr.go
+++ b/pkg/k8sutil/cr.go
@@ -32,10 +32,6 @@ import (
 
 // UpdateCrWithRackAwarenessConfig updates the CR with rack awareness config
 func UpdateCrWithRackAwarenessConfig(pod *corev1.Pod, cr *v1beta1.KafkaCluster, client runtimeClient.Client) (v1beta1.RackAwarenessState, error) {
-
-	if pod.Spec.NodeName == "" {
-		return "", errorfactory.New(errorfactory.ResourceNotReady{}, errors.New("pod does not scheduled to node yet"), "trying")
-	}
 	rackConfigMap, err := getSpecificNodeLabels(pod.Spec.NodeName, client, cr.Spec.RackAwareness.Labels)
 	if err != nil {
 		return "", errorfactory.New(errorfactory.StatusUpdateError{}, err, "updating cr with rack awareness info failed")

--- a/pkg/resources/kafka/kafka.go
+++ b/pkg/resources/kafka/kafka.go
@@ -525,7 +525,9 @@ func (r *Reconciler) reconcileKafkaPod(log logr.Logger, desiredPod *corev1.Pod) 
 		currentPod = podList.Items[0].DeepCopy()
 		brokerId := currentPod.Labels["brokerId"]
 		if _, ok := r.KafkaCluster.Status.BrokersState[brokerId]; ok {
-			if r.KafkaCluster.Spec.RackAwareness != nil {
+			if currentPod.Spec.NodeName == "" {
+				log.Info(fmt.Sprintf("pod for brokerId %s does not scheduled to node yet", brokerId))
+			} else if r.KafkaCluster.Spec.RackAwareness != nil {
 				rackAwarenessState, err := k8sutil.UpdateCrWithRackAwarenessConfig(currentPod, r.KafkaCluster, r.Client)
 				if err != nil {
 					return err


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?

Depends on https://github.com/banzaicloud/kafka-operator/pull/293

When downscale is initiated for brokers that are not yet part of Kafka cluster
we avoid now decommissioning the broker in CC (i.e. `remove_broker`) to avoid deadlock (CC returns 5XX when unknown brokers are removed)

Also - downscaling brokers not fully registered may miss ConfigMap
so we skip missing ConfigMaps in that case.


### Why?

When downscaling not-yet fully registered brokers in Cruise Control (this can happen when pod cannot be scheduled for example due to faulty az, etc) operator issues a invalid `remove_broker` request.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [ ] User guide and development docs updated (if needed)

