### PR TITLE
Add pending pod health check during rolling upgrade

### DIFF
--- a/pkg/k8sutil/resource.go
+++ b/pkg/k8sutil/resource.go
@@ -158,3 +158,21 @@ func CheckIfObjectUpdated(log logr.Logger, desiredType reflect.Type, current, de
 		return true
 	}
 }
+
+func IsPodContainsTerminatedContainer(pod *corev1.Pod) bool {
+	for _, containerState := range pod.Status.ContainerStatuses {
+		if containerState.State.Terminated != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func IsPodContainsPendingContainer(pod *corev1.Pod) bool {
+	for _, containerState := range pod.Status.ContainerStatuses {
+		if containerState.State.Waiting != nil {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no|
| New feature?    | yes|
| API breaks?     | no|
| Deprecations?   | no|
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
This PR adds an extra check to pod deletion during rolling upgrade. 
Now if there is any pending pod in the kafka cluster, the rolling upgrade won't proceed.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
