### PR TITLE
Bump chart to use 0.10.0 release

### DIFF
--- a/charts/kafka-operator/Chart.yaml
+++ b/charts/kafka-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: kafka-operator
-version: 0.2.13
+version: 0.2.14
 description: kafka-operator manages Kafka deployments on Kubernetes
 sources:
   - https://github.com/banzaicloud/kafka-operator
-appVersion: 0.9.2
+appVersion: 0.10.0

--- a/charts/kafka-operator/templates/operator-kafka-crd.yaml
+++ b/charts/kafka-operator/templates/operator-kafka-crd.yaml
@@ -1552,7 +1552,6 @@ spec:
                     required:
                       - cruiseControlState
                       - errorMessage
-                      - volumeStates
                     type: object
                   rackAwarenessState:
                     description: RackAwarenessState holds info about rack awareness

--- a/charts/kafka-operator/values.yaml
+++ b/charts/kafka-operator/values.yaml
@@ -11,7 +11,7 @@ imagePullSecrets: []
 operator:
   image:
     repository: banzaicloud/kafka-operator
-    tag: 0.9.2
+    tag: 0.10.0
     pullPolicy: IfNotPresent
   vaultAddress: ""
   # vaultSecret containing a `ca.crt` key with the Vault CA Certificate


### PR DESCRIPTION
This PR bumps the chart version and bumps the operator version value to 0.10.0