### PR TITLE
Add support to configure operator to watch resources in a set of namespaces

### DIFF
--- a/charts/kafka-operator/README.md
+++ b/charts/kafka-operator/README.md
@@ -40,7 +40,7 @@ Parameter | Description | Default
 `operator.image.tag` | Operator container image tag | `0.6.0`
 `operator.image.pullPolicy` | Operator container image pull policy | `IfNotPresent`
 `operator.resources` | CPU/Memory resource requests/limits (YAML) | Memory: `128Mi/256Mi`, CPU: `100m/200m`
-`operator.namespaces` | List of namespaces where Operator watches for custom resources. **Note** that is not compatible with `rackAwareness` setting in the `KafkaCluster` resource as that requires read access for _cluster-scoped_ `Node` labels. | `""` i.e. all namespaces
+`operator.namespaces` | List of namespaces where Operator watches for custom resources.<br><br>**Note** that the operator still requires to read the cluster-scoped `Node` labels to configure `rack awareness`. Make sure the operator ServiceAccount is granted `get` permissions on this `Node` resource when using limited RBACs.| `""` i.e. all namespaces
 `prometheusMetrics.enabled` | If true, use direct access for Prometheus metrics | `false`
 `prometheusMetrics.authProxy.enabled` | If true, use auth proxy for Prometheus metrics | `true`
 `prometheusMetrics.authProxy.image.repository` | Auth proxy container image repository | `gcr.io/kubebuilder/kube-rbac-proxy`

--- a/charts/kafka-operator/README.md
+++ b/charts/kafka-operator/README.md
@@ -40,6 +40,7 @@ Parameter | Description | Default
 `operator.image.tag` | Operator container image tag | `0.6.0`
 `operator.image.pullPolicy` | Operator container image pull policy | `IfNotPresent`
 `operator.resources` | CPU/Memory resource requests/limits (YAML) | Memory: `128Mi/256Mi`, CPU: `100m/200m`
+`operator.namespaces` | List of namespaces where Operator watches for custom resources. **Note** that is not compatible with `rackAwareness` setting in the `KafkaCluster` resource as that requires read access for _cluster-scoped_ `Node` labels. | `""` i.e. all namespaces
 `prometheusMetrics.enabled` | If true, use direct access for Prometheus metrics | `false`
 `prometheusMetrics.authProxy.enabled` | If true, use auth proxy for Prometheus metrics | `true`
 `prometheusMetrics.authProxy.image.repository` | Auth proxy container image repository | `gcr.io/kubebuilder/kube-rbac-proxy`

--- a/charts/kafka-operator/templates/operator-deployment.yaml
+++ b/charts/kafka-operator/templates/operator-deployment.yaml
@@ -68,6 +68,9 @@ spec:
           {{- if not .Values.webhook.enabled }}
             - --disable-webhooks
           {{- end }}
+          {{- if .Values.operator.namespaces }}
+            - --namespaces={{ .Values.operator.namespaces }}
+          {{- end }}
           {{- if .Values.operator.verboseLogging }}
             - --verbose
           {{- end }}

--- a/charts/kafka-operator/values.yaml
+++ b/charts/kafka-operator/values.yaml
@@ -16,6 +16,8 @@ operator:
   vaultAddress: ""
   # vaultSecret containing a `ca.crt` key with the Vault CA Certificate
   vaultSecret: ""
+  # set of namespaces where the operator watches resources
+  namespaces: ""
   verboseLogging: false
   resources:
     limits:

--- a/controllers/kafkacluster_controller.go
+++ b/controllers/kafkacluster_controller.go
@@ -55,8 +55,9 @@ var clusterUsersFinalizer = "users.kafkaclusters.kafka.banzaicloud.io"
 // KafkaClusterReconciler reconciles a KafkaCluster object
 type KafkaClusterReconciler struct {
 	client.Client
-	Log    logr.Logger
-	Scheme *runtime.Scheme
+	DirectClient client.Reader
+	Log          logr.Logger
+	Scheme       *runtime.Scheme
 }
 
 // Reconcile reads that state of the cluster for a KafkaCluster object and makes changes based on the state read
@@ -111,7 +112,7 @@ func (r *KafkaClusterReconciler) Reconcile(request ctrl.Request) (ctrl.Result, e
 		istioingress.New(r.Client, instance),
 		kafkamonitoring.New(r.Client, instance),
 		cruisecontrolmonitoring.New(r.Client, instance),
-		kafka.New(r.Client, r.Scheme, instance),
+		kafka.New(r.Client, r.DirectClient, r.Scheme, instance),
 		cruisecontrol.New(r.Client, instance),
 	}
 

--- a/main.go
+++ b/main.go
@@ -127,9 +127,10 @@ func main() {
 	}
 
 	kafkaClusterReconciler := &controllers.KafkaClusterReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
-		Log:    ctrl.Log.WithName("controllers").WithName("KafkaCluster"),
+		Client:       mgr.GetClient(),
+		DirectClient: mgr.GetAPIReader(),
+		Scheme:       mgr.GetScheme(),
+		Log:          ctrl.Log.WithName("controllers").WithName("KafkaCluster"),
 	}
 
 	if err = controllers.SetupKafkaClusterWithManager(mgr, kafkaClusterReconciler.Log).Complete(kafkaClusterReconciler); err != nil {

--- a/pkg/k8sutil/cr.go
+++ b/pkg/k8sutil/cr.go
@@ -31,8 +31,8 @@ import (
 )
 
 // UpdateCrWithRackAwarenessConfig updates the CR with rack awareness config
-func UpdateCrWithRackAwarenessConfig(pod *corev1.Pod, cr *v1beta1.KafkaCluster, client runtimeClient.Client) (v1beta1.RackAwarenessState, error) {
-	rackConfigMap, err := getSpecificNodeLabels(pod.Spec.NodeName, client, cr.Spec.RackAwareness.Labels)
+func UpdateCrWithRackAwarenessConfig(pod *corev1.Pod, cr *v1beta1.KafkaCluster, client runtimeClient.Client, directClient runtimeClient.Reader) (v1beta1.RackAwarenessState, error) {
+	rackConfigMap, err := getSpecificNodeLabels(pod.Spec.NodeName, directClient, cr.Spec.RackAwareness.Labels)
 	if err != nil {
 		return "", errorfactory.New(errorfactory.StatusUpdateError{}, err, "updating cr with rack awareness info failed")
 	}

--- a/pkg/k8sutil/zoneandregion.go
+++ b/pkg/k8sutil/zoneandregion.go
@@ -22,7 +22,7 @@ import (
 	runtimeClient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func getSpecificNodeLabels(nodeName string, client runtimeClient.Client, filter []string) (map[string]string, error) {
+func getSpecificNodeLabels(nodeName string, client runtimeClient.Reader, filter []string) (map[string]string, error) {
 	node := &corev1.Node{}
 	err := client.Get(context.TODO(), types.NamespacedName{Name: nodeName, Namespace: ""}, node)
 	if err != nil {

--- a/pkg/resources/kafka/kafka.go
+++ b/pkg/resources/kafka/kafka.go
@@ -79,11 +79,12 @@ func LabelsForKafka(name string) map[string]string {
 }
 
 // New creates a new reconciler for Kafka
-func New(client client.Client, scheme *runtime.Scheme, cluster *v1beta1.KafkaCluster) *Reconciler {
+func New(client client.Client, directClient client.Reader, scheme *runtime.Scheme, cluster *v1beta1.KafkaCluster) *Reconciler {
 	return &Reconciler{
 		Scheme: scheme,
 		Reconciler: resources.Reconciler{
 			Client:       client,
+			DirectClient: directClient,
 			KafkaCluster: cluster,
 		},
 	}
@@ -607,7 +608,7 @@ func (r *Reconciler) reconcileKafkaPod(log logr.Logger, desiredPod *corev1.Pod) 
 			if currentPod.Spec.NodeName == "" {
 				log.Info(fmt.Sprintf("pod for brokerId %s does not scheduled to node yet", brokerId))
 			} else if r.KafkaCluster.Spec.RackAwareness != nil {
-				rackAwarenessState, err := k8sutil.UpdateCrWithRackAwarenessConfig(currentPod, r.KafkaCluster, r.Client)
+				rackAwarenessState, err := k8sutil.UpdateCrWithRackAwarenessConfig(currentPod, r.KafkaCluster, r.Client, r.DirectClient)
 				if err != nil {
 					return err
 				}

--- a/pkg/resources/reconciler.go
+++ b/pkg/resources/reconciler.go
@@ -23,9 +23,13 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-// Reconciler holds client and CR for Kafka
+// Reconciler holds:
+// - cached client : split client reading cached/watched resources from informers and writing to api-server
+// - direct client : to read non-watched resources
+// - KafkaCluster CR
 type Reconciler struct {
 	client.Client
+	DirectClient client.Reader
 	KafkaCluster *v1beta1.KafkaCluster
 }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #300
| License         | Apache 2.0


### What's in this PR?
In constrained environments where operator cannot
be granted cluster level roles, users can configure
the operator to watch CRs only in specific set of
configurable k8s namespaces.
In this scenario, users can replace the default
ClusterRole and ClusterRoleBinding to Role and RoleBinding respectively
For further information see the kubernetes documentation about
Using [RBAC Authorization](https://kubernetes.io/docs/reference/access-authn-authz/rbac/).

Admission webhooks can also be disabled in these environments as
they require more rights than the user can grant to operator


### Why?
Enable kafka-operator in sandboxed/rbac restricted environments  


### Checklist

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)


