### PR TITLE
Do not block on pending brokers during upscale

### DIFF
--- a/charts/kafka-operator/README.md
+++ b/charts/kafka-operator/README.md
@@ -55,5 +55,6 @@ Parameter | Description | Default
 `nameOverride` | Release name can be overwritten | `""`
 `fullnameOverride` | Release full name can be overwritten | `""`
 `certManager.namespace` | Operator will look for the cert manager in this namespace | `cert-manager`
+`webhook.enabled` | Operator will activate the admission webhooks for custom resources | `true`
 `webhook.certs.generate` | Helm chart will generate cert for the webhook | `true`
 `webhook.certs.secret` | Helm chart will use the secret name applied here for the cert | `kafka-operator-serving-cert`

--- a/charts/kafka-operator/templates/operator-deployment.yaml
+++ b/charts/kafka-operator/templates/operator-deployment.yaml
@@ -65,6 +65,9 @@ spec:
           args:
             - --enable-leader-election
             - --cert-manager-namespace={{ .Values.certManager.namespace }}
+          {{- if not .Values.webhook.enabled }}
+            - --disable-webhooks
+          {{- end }}
           {{- if .Values.operator.verboseLogging }}
             - --verbose
           {{- end }}

--- a/charts/kafka-operator/templates/operator-validating-webhook.yaml
+++ b/charts/kafka-operator/templates/operator-validating-webhook.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.webhook.certs.generate -}}
+{{- if and (.Values.webhook.enabled) (.Values.webhook.certs.generate) -}}
 
 {{- $commonName := printf "%s-operator.%s.svc" (include "kafka-operator.fullname" .) .Release.Namespace -}}
 {{- $altNames := list ( $commonName ) ( printf "%s.cluster.local" $commonName ) -}}

--- a/charts/kafka-operator/values.yaml
+++ b/charts/kafka-operator/values.yaml
@@ -26,6 +26,7 @@ operator:
       memory: 128Mi
 
 webhook:
+  enabled: true
   certs:
     generate: true
     secret: "kafka-operator-serving-cert"

--- a/main.go
+++ b/main.go
@@ -71,11 +71,13 @@ func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
 	var webhookCertDir string
+	var webhookDisabled bool
 	var verboseLogging bool
 
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
+	flag.BoolVar(&webhookDisabled, "disable-webhooks", false, "Disable webhooks used to validate custom resources")
 	flag.StringVar(&webhookCertDir, "tls-cert-dir", "/etc/webhook/certs", "The directory with a tls.key and tls.crt for serving HTTPS requests")
 	flag.BoolVar(&verboseLogging, "verbose", false, "Enable verbose logging")
 	flag.Parse()
@@ -136,7 +138,9 @@ func main() {
 		os.Exit(1)
 	}
 
-	webhook.SetupServerHandlers(mgr, webhookCertDir)
+	if !webhookDisabled {
+		webhook.SetupServerHandlers(mgr, webhookCertDir)
+	}
 
 	// +kubebuilder:scaffold:builder
 


### PR DESCRIPTION
This fixes the following scenario:
1. Start with a 3 racks cluster (3 brokers per rack)
2. One AZ goes completely down
  - existing brokers on that AZ are lost/failed
  - new brokers/pod cannot be scheduled on that AZ

At this point, we assume topics in Kafka are still healthy (replication factor > 1 + rack-aware balanced replicas)
but under-replicated (offline partitions on lost AZ)

One of the possible actions now is to trigger an upscale in the other 2 healthy AZs with more brokers
to take the load and move offline replicas

3. This patch ensures that `Pending` broker pods are not blocking bootstrapping other pods that can be scheduled.
And not stuck serially on each pod to be scheduled.


| Q               | A
| --------------- | ---
| Bug fix?        | no|yes
| New feature?    | no|yes
| API breaks?     | no|yes
| Deprecations?   | no|yes
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->


### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Implementation tested
- [ ] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [ ] Logging code meets the guideline
- [ ] User guide and development docs updated (if needed)

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [ ] If the PR is not complete but you want to discuss the approach, list what remains to be done here