### PR TITLE
Make webhooks optional

### DIFF
--- a/charts/kafka-operator/README.md
+++ b/charts/kafka-operator/README.md
@@ -55,5 +55,6 @@ Parameter | Description | Default
 `nameOverride` | Release name can be overwritten | `""`
 `fullnameOverride` | Release full name can be overwritten | `""`
 `certManager.namespace` | Operator will look for the cert manager in this namespace | `cert-manager`
+`webhook.enabled` | Operator will activate the admission webhooks for custom resources | `true`
 `webhook.certs.generate` | Helm chart will generate cert for the webhook | `true`
 `webhook.certs.secret` | Helm chart will use the secret name applied here for the cert | `kafka-operator-serving-cert`

--- a/charts/kafka-operator/templates/operator-deployment.yaml
+++ b/charts/kafka-operator/templates/operator-deployment.yaml
@@ -65,6 +65,9 @@ spec:
           args:
             - --enable-leader-election
             - --cert-manager-namespace={{ .Values.certManager.namespace }}
+          {{- if not .Values.webhook.enabled }}
+            - --disable-webhooks
+          {{- end }}
           {{- if .Values.operator.verboseLogging }}
             - --verbose
           {{- end }}

--- a/charts/kafka-operator/templates/operator-validating-webhook.yaml
+++ b/charts/kafka-operator/templates/operator-validating-webhook.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.webhook.certs.generate -}}
+{{- if and (.Values.webhook.enabled) (.Values.webhook.certs.generate) -}}
 
 {{- $commonName := printf "%s-operator.%s.svc" (include "kafka-operator.fullname" .) .Release.Namespace -}}
 {{- $altNames := list ( $commonName ) ( printf "%s.cluster.local" $commonName ) -}}

--- a/charts/kafka-operator/values.yaml
+++ b/charts/kafka-operator/values.yaml
@@ -26,6 +26,7 @@ operator:
       memory: 128Mi
 
 webhook:
+  enabled: true
   certs:
     generate: true
     secret: "kafka-operator-serving-cert"

--- a/main.go
+++ b/main.go
@@ -71,11 +71,13 @@ func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
 	var webhookCertDir string
+	var webhookDisabled bool
 	var verboseLogging bool
 
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
+	flag.BoolVar(&webhookDisabled, "disable-webhooks", false, "Disable webhooks used to validate custom resources")
 	flag.StringVar(&webhookCertDir, "tls-cert-dir", "/etc/webhook/certs", "The directory with a tls.key and tls.crt for serving HTTPS requests")
 	flag.BoolVar(&verboseLogging, "verbose", false, "Enable verbose logging")
 	flag.Parse()
@@ -136,7 +138,9 @@ func main() {
 		os.Exit(1)
 	}
 
-	webhook.SetupServerHandlers(mgr, webhookCertDir)
+	if !webhookDisabled {
+		webhook.SetupServerHandlers(mgr, webhookCertDir)
+	}
 
 	// +kubebuilder:scaffold:builder
 


### PR DESCRIPTION

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->


### Why?

In constrained environments when Operator is running with least privileges creating the
ValidatingWebhookConfiguration CR may be an option from a RBAC perspective.

Allowing these webhooks to be disabled allows using the operator in these environments.

Default: true (enabled)


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
