### PR TITLE
ISSUE-320 - Kafka broker pods are recreated in a loop

### DIFF
--- a/controllers/kafkacluster_controller.go
+++ b/controllers/kafkacluster_controller.go
@@ -121,18 +121,17 @@ func (r *KafkaClusterReconciler) Reconcile(request ctrl.Request) (ctrl.Result, e
 		if err != nil {
 			switch errors.Cause(err).(type) {
 			case errorfactory.BrokersUnreachable:
-				log.Info("Brokers unreachable, may still be starting up")
+				log.Info("Brokers unreachable, may still be starting up", "error", err.Error())
 				return ctrl.Result{
 					RequeueAfter: time.Duration(15) * time.Second,
 				}, nil
 			case errorfactory.BrokersNotReady:
-				log.Info("Brokers not ready, may still be starting up")
+				log.Info("Brokers not ready, may still be starting up", "error", err.Error())
 				return ctrl.Result{
 					RequeueAfter: time.Duration(15) * time.Second,
 				}, nil
 			case errorfactory.ResourceNotReady:
-				log.Info("A new resource was not found or may not be ready")
-				log.Info(err.Error())
+				log.Info("A new resource was not found or may not be ready", "error", err.Error())
 				return ctrl.Result{
 					RequeueAfter: time.Duration(7) * time.Second,
 				}, nil

--- a/pkg/kafkaclient/client.go
+++ b/pkg/kafkaclient/client.go
@@ -15,6 +15,7 @@
 package kafkaclient
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/Shopify/sarama"
@@ -86,7 +87,7 @@ func (k *kafkaClient) Open() error {
 	var err error
 	config := k.getSaramaConfig()
 	if k.admin, err = k.newClusterAdmin([]string{k.opts.BrokerURI}, config); err != nil {
-		err = errorfactory.New(errorfactory.BrokersUnreachable{}, err, "could not connect to kafka brokers")
+		err = errorfactory.New(errorfactory.BrokersUnreachable{}, err, fmt.Sprintf("could not connect to kafka brokers: %s", k.opts.BrokerURI))
 		return err
 	}
 

--- a/pkg/resources/kafka/pvc.go
+++ b/pkg/resources/kafka/pvc.go
@@ -25,13 +25,13 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-func (r *Reconciler) pvc(id int32, storage v1beta1.StorageConfig, log logr.Logger) runtime.Object {
+func (r *Reconciler) pvc(brokerId int32, storageIndex int, storage v1beta1.StorageConfig, log logr.Logger) runtime.Object {
 	return &corev1.PersistentVolumeClaim{
 		ObjectMeta: templates.ObjectMetaWithGeneratedNameAndAnnotations(
-			fmt.Sprintf(brokerStorageTemplate, r.KafkaCluster.Name, id),
+			fmt.Sprintf(brokerStorageTemplate, r.KafkaCluster.Name, brokerId, storageIndex),
 			util.MergeLabels(
 				LabelsForKafka(r.KafkaCluster.Name),
-				map[string]string{"brokerId": fmt.Sprintf("%d", id)},
+				map[string]string{"brokerId": fmt.Sprintf("%d", brokerId)},
 			),
 			map[string]string{"mountPath": storage.MountPath}, r.KafkaCluster),
 		Spec: *storage.PvcSpec,


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #320 
| License         | Apache 2.0


### What's in this PR?

Ensure the kafka pod PVCs are always listed in the order they were created
- add the storage index to the PVC name
- Sort kafka pod PVC list during reconcile to avoid false negatives 
in pod change detection

<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
