### PR TITLE
Add support to configure operator to watch resources in a set of namespaces ADDENDUM

### DIFF
--- a/main.go
+++ b/main.go
@@ -95,12 +95,13 @@ func main() {
 	//For further information see the kubernetes documentation about
 	//Using [RBAC Authorization](https://kubernetes.io/docs/reference/access-authn-authz/rbac/).
 	managerWatchCache := (cache.NewCacheFunc)(nil)
+	var namespaceList []string
 	if namespaces != "" {
-		ns := strings.Split(namespaces, ",")
-		for i := range ns {
-			ns[i] = strings.TrimSpace(ns[i])
+		namespaceList = strings.Split(namespaces, ",")
+		for i := range namespaceList {
+			namespaceList[i] = strings.TrimSpace(namespaceList[i])
 		}
-		managerWatchCache = cache.MultiNamespacedCacheBuilder(ns)
+		managerWatchCache = cache.MultiNamespacedCacheBuilder(namespaceList)
 	}
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
@@ -130,6 +131,7 @@ func main() {
 		Client:       mgr.GetClient(),
 		DirectClient: mgr.GetAPIReader(),
 		Scheme:       mgr.GetScheme(),
+		Namespaces:   namespaceList,
 		Log:          ctrl.Log.WithName("controllers").WithName("KafkaCluster"),
 	}
 


### PR DESCRIPTION
…



| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | followup #305
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

This is a followup patch of https://github.com/banzaicloud/kafka-operator/pull/305
Make KafkaCluster finalizers aware  of watch namespaces if configured.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
