### PR TITLE
feat: Add support for Vault Path in authentication

### DIFF
--- a/charts/kafka-operator/templates/operator-deployment.yaml
+++ b/charts/kafka-operator/templates/operator-deployment.yaml
@@ -92,6 +92,10 @@ spec:
             - name: VAULT_CACERT
               value: /etc/vault/certs/ca.crt
           {{- end }}
+          {{- if .Values.operator.vaultPath }}
+            - name: VAULT_PATH
+              value: {{ .Values.operator.vaultPath }}
+          {{- end }}
           ports:
           {{- if .Values.webhook.enabled }}
             - containerPort: 443

--- a/pkg/pki/vaultpki/vault_common.go
+++ b/pkg/pki/vaultpki/vault_common.go
@@ -18,6 +18,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"os"
 	"path"
 	"strconv"
 	"strings"
@@ -101,7 +102,17 @@ func getKubernetesClient(clusterUID types.UID, role string) (client *vaultapi.Cl
 	if vaultClient, ok := vaultClients[clusterUID]; ok {
 		return vaultClient.RawClient(), nil
 	}
-	vaultClient, err := vault.NewClient(role)
+
+	vaultPath := "kubernetes"
+	if path := os.Getenv("VAULT_PATH"); path != "" {
+		vaultPath = path
+	}
+
+	vaultClient, err := vault.NewClientWithOptions(
+		vault.ClientAuthPath(vaultPath),
+		vault.ClientRole(role),
+	)
+
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no|

| License         | Apache 2.0


### What's in this PR?
Add support for specifying the vault path for vault kubernetes auth.


### Why?
If you have multiple clusters in kubernetes but fewer Vault's this allows you to have a shared vault.

### Additional context

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [ ] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [ ] Logging code meets the guideline
- [ ] User guide and development docs updated (if needed)

### To Do
N/A