### PR TITLE
Create service account for kafka cluster instead of using default

### DIFF
--- a/api/v1beta1/kafkacluster_types.go
+++ b/api/v1beta1/kafkacluster_types.go
@@ -19,7 +19,6 @@ import (
 	"strings"
 
 	"github.com/banzaicloud/istio-client-go/pkg/networking/v1alpha3"
-	"github.com/banzaicloud/kafka-operator/pkg/resources/kafka"
 	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -30,6 +29,10 @@ import (
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
+
+const (
+	ServiceAccountNameFormat = "%s-cluster"
+)
 
 // KafkaClusterSpec defines the desired state of KafkaCluster
 type KafkaClusterSpec struct {
@@ -346,7 +349,7 @@ func (bConfig *BrokerConfig) GetServiceAccount(KafkaClusterName string) string {
 	if bConfig.ServiceAccountName != "" {
 		return bConfig.ServiceAccountName
 	}
-	return fmt.Sprintf(kafka.ServiceAccountNameFormat, KafkaClusterName)
+	return fmt.Sprintf(ServiceAccountNameFormat, KafkaClusterName)
 }
 
 //GetServiceAccount returns the Kubernetes Service Account to use for EnvoyConfig

--- a/api/v1beta1/kafkacluster_types.go
+++ b/api/v1beta1/kafkacluster_types.go
@@ -15,9 +15,11 @@
 package v1beta1
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/banzaicloud/istio-client-go/pkg/networking/v1alpha3"
+	"github.com/banzaicloud/kafka-operator/pkg/resources/kafka"
 	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -340,11 +342,11 @@ func (eConfig *EnvoyConfig) GetReplicas() int32 {
 }
 
 //GetServiceAccount returns the Kubernetes Service Account to use for Kafka Cluster
-func (bConfig *BrokerConfig) GetServiceAccount() string {
+func (bConfig *BrokerConfig) GetServiceAccount(KafkaClusterName string) string {
 	if bConfig.ServiceAccountName != "" {
 		return bConfig.ServiceAccountName
 	}
-	return "default"
+	return fmt.Sprintf(kafka.ServiceAccountNameFormat, KafkaClusterName)
 }
 
 //GetServiceAccount returns the Kubernetes Service Account to use for EnvoyConfig

--- a/charts/kafka-operator/templates/operator-rbac.yaml
+++ b/charts/kafka-operator/templates/operator-rbac.yaml
@@ -149,7 +149,6 @@ rules:
   - get
   - update
   - create
-  - watch
   - list
   - delete
 - apiGroups:

--- a/charts/kafka-operator/templates/operator-rbac.yaml
+++ b/charts/kafka-operator/templates/operator-rbac.yaml
@@ -144,6 +144,17 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - serviceaccounts
+  verbs:
+  - get
+  - update
+  - create
+  - watch
+  - list
+  - delete
+- apiGroups:
+  - ""
+  resources:
   - nodes
   verbs:
   - get

--- a/config/base/rbac/role.yaml
+++ b/config/base/rbac/role.yaml
@@ -72,6 +72,17 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - serviceaccounts
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
   - services
   verbs:
   - create

--- a/controllers/kafkacluster_controller.go
+++ b/controllers/kafkacluster_controller.go
@@ -69,6 +69,7 @@ type KafkaClusterReconciler struct {
 // +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;delete;patch
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch

--- a/pkg/resources/kafka/kafka.go
+++ b/pkg/resources/kafka/kafka.go
@@ -163,6 +163,15 @@ func (r *Reconciler) Reconcile(log logr.Logger) error {
 		return errorfactory.New(errorfactory.StatusUpdateError{}, statusErr, "updating deprecated status failed")
 	}
 
+	o, err := r.serviceAccount()
+	if err != nil {
+		return errors.WrapIfWithDetails(err, "failed to create service account for kafka cluster", "resource", o.GetObjectKind().GroupVersionKind())
+	}
+	err = k8sutil.Reconcile(log, r.Client, o, r.KafkaCluster)
+	if err != nil {
+		return errors.WrapIfWithDetails(err, "failed to reconcile resource", "resource", o.GetObjectKind().GroupVersionKind())
+	}
+
 	if r.KafkaCluster.Spec.HeadlessServiceEnabled {
 		o := r.headlessService()
 		err := k8sutil.Reconcile(log, r.Client, o, r.KafkaCluster)

--- a/pkg/resources/kafka/kafka.go
+++ b/pkg/resources/kafka/kafka.go
@@ -186,7 +186,7 @@ func (r *Reconciler) Reconcile(log logr.Logger) error {
 		}
 	}
 	// Handle Pod delete
-	err := r.reconcileKafkaPodDelete(log)
+	err = r.reconcileKafkaPodDelete(log)
 	if err != nil {
 		return errors.WrapIf(err, "failed to reconcile resource")
 	}

--- a/pkg/resources/kafka/kafka.go
+++ b/pkg/resources/kafka/kafka.go
@@ -163,11 +163,8 @@ func (r *Reconciler) Reconcile(log logr.Logger) error {
 		return errorfactory.New(errorfactory.StatusUpdateError{}, statusErr, "updating deprecated status failed")
 	}
 
-	o, err := r.serviceAccount()
-	if err != nil {
-		return errors.WrapIfWithDetails(err, "failed to create service account for kafka cluster", "resource", o.GetObjectKind().GroupVersionKind())
-	}
-	err = k8sutil.Reconcile(log, r.Client, o, r.KafkaCluster)
+	o := r.serviceAccount()
+	err := k8sutil.Reconcile(log, r.Client, o, r.KafkaCluster)
 	if err != nil {
 		return errors.WrapIfWithDetails(err, "failed to reconcile resource", "resource", o.GetObjectKind().GroupVersionKind())
 	}

--- a/pkg/resources/kafka/pod.go
+++ b/pkg/resources/kafka/pod.go
@@ -221,7 +221,7 @@ fi
 			RestartPolicy:                 corev1.RestartPolicyNever,
 			TerminationGracePeriodSeconds: util.Int64Pointer(120),
 			ImagePullSecrets:              brokerConfig.GetImagePullSecrets(),
-			ServiceAccountName:            brokerConfig.GetServiceAccount(),
+			ServiceAccountName:            brokerConfig.GetServiceAccount(r.KafkaCluster.Name),
 			Tolerations:                   brokerConfig.GetTolerations(),
 			NodeSelector:                  brokerConfig.GetNodeSelector(),
 		},

--- a/pkg/resources/kafka/serviceAccount.go
+++ b/pkg/resources/kafka/serviceAccount.go
@@ -18,28 +18,16 @@ import (
 	"fmt"
 
 	"github.com/banzaicloud/kafka-operator/api/v1beta1"
-	"github.com/banzaicloud/kafka-operator/pkg/util"
+	"github.com/banzaicloud/kafka-operator/pkg/resources/templates"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
 func (r *Reconciler) serviceAccount() runtime.Object {
 	return &corev1.ServiceAccount{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: r.KafkaCluster.Namespace,
-			Name:      fmt.Sprintf(v1beta1.ServiceAccountNameFormat, r.KafkaCluster.Name),
-			Labels:    LabelsForKafka(r.KafkaCluster.Name),
-			OwnerReferences: []metav1.OwnerReference{
-				{
-					APIVersion:         r.KafkaCluster.APIVersion,
-					Kind:               r.KafkaCluster.Kind,
-					Name:               r.KafkaCluster.Name,
-					UID:                r.KafkaCluster.UID,
-					Controller:         util.BoolPointer(true),
-					BlockOwnerDeletion: util.BoolPointer(true),
-				},
-			},
-		},
+		ObjectMeta: templates.ObjectMeta(
+			fmt.Sprintf(v1beta1.ServiceAccountNameFormat, r.KafkaCluster.Name),
+			LabelsForKafka(r.KafkaCluster.Name),
+			r.KafkaCluster),
 	}
 }

--- a/pkg/resources/kafka/serviceAccount.go
+++ b/pkg/resources/kafka/serviceAccount.go
@@ -15,65 +15,31 @@
 package kafka
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/banzaicloud/kafka-operator/api/v1beta1"
 	"github.com/banzaicloud/kafka-operator/pkg/util"
 	corev1 "k8s.io/api/core/v1"
-	apiErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 )
 
-func (r *Reconciler) serviceAccount() (runtime.Object, error) {
-
-	exists, err := r.serviceAccountForKafkaClusterExists()
-	if err != nil {
-		return nil, err
-	}
-
-	if !exists {
-		serviceAccount := &corev1.ServiceAccount{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace:   r.KafkaCluster.Namespace,
-				Name:        fmt.Sprintf(v1beta1.ServiceAccountNameFormat, r.KafkaCluster.Name),
-				Labels:      LabelsForKafka(r.KafkaCluster.Name),
-				Annotations: nil,
-				OwnerReferences: []metav1.OwnerReference{
-					{
-						APIVersion:         r.KafkaCluster.APIVersion,
-						Kind:               r.KafkaCluster.Kind,
-						Name:               r.KafkaCluster.Name,
-						UID:                r.KafkaCluster.UID,
-						Controller:         util.BoolPointer(true),
-						BlockOwnerDeletion: util.BoolPointer(true),
-					},
+func (r *Reconciler) serviceAccount() runtime.Object {
+	return &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: r.KafkaCluster.Namespace,
+			Name:      fmt.Sprintf(v1beta1.ServiceAccountNameFormat, r.KafkaCluster.Name),
+			Labels:    LabelsForKafka(r.KafkaCluster.Name),
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion:         r.KafkaCluster.APIVersion,
+					Kind:               r.KafkaCluster.Kind,
+					Name:               r.KafkaCluster.Name,
+					UID:                r.KafkaCluster.UID,
+					Controller:         util.BoolPointer(true),
+					BlockOwnerDeletion: util.BoolPointer(true),
 				},
 			},
-		}
-
-		return serviceAccount, nil
+		},
 	}
-
-	return nil, nil
-}
-
-func (r *Reconciler) serviceAccountForKafkaClusterExists() (bool, error) {
-	serviceAccount := corev1.ServiceAccount{}
-	namespacedName := types.NamespacedName{
-		Namespace: r.KafkaCluster.Namespace,
-		Name:      fmt.Sprintf(v1beta1.ServiceAccountNameFormat, r.KafkaCluster.Name),
-	}
-
-	err := r.Get(context.Background(), namespacedName, &serviceAccount)
-	if err != nil {
-		if apiErrors.IsNotFound(err) {
-			return false, nil
-		}
-		return false, err
-	}
-
-	return true, nil
 }

--- a/pkg/resources/kafka/serviceAccount.go
+++ b/pkg/resources/kafka/serviceAccount.go
@@ -1,0 +1,82 @@
+// Copyright © 2020 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kafka
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/banzaicloud/kafka-operator/pkg/util"
+	corev1 "k8s.io/api/core/v1"
+	apiErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+const (
+	ServiceAccountNameFormat            = "%s-cluster"
+)
+
+func (r *Reconciler) serviceAccount() (runtime.Object, error) {
+
+	exists, err := r.serviceAccountForKafkaClusterExists()
+	if err != nil {
+		return nil, err
+	}
+
+	if !exists {
+		serviceAccount := &corev1.ServiceAccount{
+			ObjectMeta:                   metav1.ObjectMeta{
+				Namespace: r.KafkaCluster.Namespace,
+				Name:      fmt.Sprintf(ServiceAccountNameFormat, r.KafkaCluster.Name),
+				Labels:                     LabelsForKafka(r.KafkaCluster.Name),
+				Annotations:                nil,
+				OwnerReferences:            []metav1.OwnerReference{
+					{
+						APIVersion:         r.KafkaCluster.APIVersion,
+						Kind:               r.KafkaCluster.Kind,
+						Name:               r.KafkaCluster.Name,
+						UID:                r.KafkaCluster.UID,
+						Controller:         util.BoolPointer(true),
+						BlockOwnerDeletion: util.BoolPointer(true),
+					},
+				},
+			},
+		}
+
+		return serviceAccount, nil
+	}
+
+	return nil, nil
+}
+
+func (r *Reconciler) serviceAccountForKafkaClusterExists() (bool, error){
+	serviceAccount := corev1.ServiceAccount{}
+	namespacedName := types.NamespacedName{
+		Namespace: r.KafkaCluster.Namespace,
+		Name:      fmt.Sprintf(ServiceAccountNameFormat, r.KafkaCluster.Name),
+	}
+
+	err := r.Get(context.Background(), namespacedName, &serviceAccount)
+	if err != nil {
+		if apiErrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	return true, nil
+}

--- a/pkg/resources/kafka/serviceAccount.go
+++ b/pkg/resources/kafka/serviceAccount.go
@@ -18,16 +18,13 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/banzaicloud/kafka-operator/api/v1beta1"
 	"github.com/banzaicloud/kafka-operator/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	apiErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-)
-
-const (
-	ServiceAccountNameFormat            = "%s-cluster"
 )
 
 func (r *Reconciler) serviceAccount() (runtime.Object, error) {
@@ -39,12 +36,12 @@ func (r *Reconciler) serviceAccount() (runtime.Object, error) {
 
 	if !exists {
 		serviceAccount := &corev1.ServiceAccount{
-			ObjectMeta:                   metav1.ObjectMeta{
-				Namespace: r.KafkaCluster.Namespace,
-				Name:      fmt.Sprintf(ServiceAccountNameFormat, r.KafkaCluster.Name),
-				Labels:                     LabelsForKafka(r.KafkaCluster.Name),
-				Annotations:                nil,
-				OwnerReferences:            []metav1.OwnerReference{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:   r.KafkaCluster.Namespace,
+				Name:        fmt.Sprintf(v1beta1.ServiceAccountNameFormat, r.KafkaCluster.Name),
+				Labels:      LabelsForKafka(r.KafkaCluster.Name),
+				Annotations: nil,
+				OwnerReferences: []metav1.OwnerReference{
 					{
 						APIVersion:         r.KafkaCluster.APIVersion,
 						Kind:               r.KafkaCluster.Kind,
@@ -63,11 +60,11 @@ func (r *Reconciler) serviceAccount() (runtime.Object, error) {
 	return nil, nil
 }
 
-func (r *Reconciler) serviceAccountForKafkaClusterExists() (bool, error){
+func (r *Reconciler) serviceAccountForKafkaClusterExists() (bool, error) {
 	serviceAccount := corev1.ServiceAccount{}
 	namespacedName := types.NamespacedName{
 		Namespace: r.KafkaCluster.Namespace,
-		Name:      fmt.Sprintf(ServiceAccountNameFormat, r.KafkaCluster.Name),
+		Name:      fmt.Sprintf(v1beta1.ServiceAccountNameFormat, r.KafkaCluster.Name),
 	}
 
 	err := r.Get(context.Background(), namespacedName, &serviceAccount)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Creating a new service account for each Kafka cluster to use, instead of the existing default service account.


### Why?
Better separation of concerns between Kafka clusters, roles and permissions can now be provided on a cluster-by-cluster basis.

