### PR TITLE
Use kafka cluster service account in CC and envoy as well

### DIFF
--- a/api/v1beta1/kafkacluster_types.go
+++ b/api/v1beta1/kafkacluster_types.go
@@ -364,19 +364,19 @@ func (bConfig *BrokerConfig) GetServiceAccount(KafkaClusterName string) string {
 }
 
 //GetServiceAccount returns the Kubernetes Service Account to use for EnvoyConfig
-func (eConfig *EnvoyConfig) GetServiceAccount() string {
+func (eConfig *EnvoyConfig) GetServiceAccount(KafkaClusterName string) string {
 	if eConfig.ServiceAccountName != "" {
 		return eConfig.ServiceAccountName
 	}
-	return "default"
+	return fmt.Sprintf(ServiceAccountNameFormat, KafkaClusterName)
 }
 
 //GetServiceAccount returns the Kubernetes Service Account to use for CruiseControl
-func (cConfig *CruiseControlConfig) GetServiceAccount() string {
+func (cConfig *CruiseControlConfig) GetServiceAccount(KafkaClusterName string) string {
 	if cConfig.ServiceAccountName != "" {
 		return cConfig.ServiceAccountName
 	}
-	return "default"
+	return fmt.Sprintf(ServiceAccountNameFormat, KafkaClusterName)
 }
 
 //GetTolerations returns the tolerations for the given broker

--- a/charts/kafka-operator/templates/operator-rbac.yaml
+++ b/charts/kafka-operator/templates/operator-rbac.yaml
@@ -149,6 +149,7 @@ rules:
   - get
   - update
   - create
+  - watch
   - list
   - delete
 - apiGroups:

--- a/config/base/rbac/role.yaml
+++ b/config/base/rbac/role.yaml
@@ -80,6 +80,7 @@ rules:
   - list
   - patch
   - update
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/controllers/kafkacluster_controller.go
+++ b/controllers/kafkacluster_controller.go
@@ -69,7 +69,7 @@ type KafkaClusterReconciler struct {
 // +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;delete;patch
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch

--- a/pkg/resources/cruisecontrol/deployment.go
+++ b/pkg/resources/cruisecontrol/deployment.go
@@ -64,7 +64,7 @@ func (r *Reconciler) deployment(log logr.Logger, clientPass string) runtime.Obje
 					Annotations: generatePodAnnotations(r.KafkaCluster, log),
 				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName:            r.KafkaCluster.Spec.CruiseControlConfig.GetServiceAccount(),
+					ServiceAccountName:            r.KafkaCluster.Spec.CruiseControlConfig.GetServiceAccount(r.KafkaCluster.Name),
 					ImagePullSecrets:              r.KafkaCluster.Spec.CruiseControlConfig.GetImagePullSecrets(),
 					Tolerations:                   r.KafkaCluster.Spec.CruiseControlConfig.GetTolerations(),
 					NodeSelector:                  r.KafkaCluster.Spec.CruiseControlConfig.GetNodeSelector(),

--- a/pkg/resources/envoy/deployment.go
+++ b/pkg/resources/envoy/deployment.go
@@ -63,7 +63,7 @@ func (r *Reconciler) deployment(log logr.Logger) runtime.Object {
 					Labels: labelSelector,
 				},
 				Spec: corev1.PodSpec{
-					ServiceAccountName: r.KafkaCluster.Spec.EnvoyConfig.GetServiceAccount(),
+					ServiceAccountName: r.KafkaCluster.Spec.EnvoyConfig.GetServiceAccount(r.KafkaCluster.Name),
 					ImagePullSecrets:   r.KafkaCluster.Spec.EnvoyConfig.GetImagePullSecrets(),
 					Tolerations:        r.KafkaCluster.Spec.EnvoyConfig.GetTolerations(),
 					NodeSelector:       r.KafkaCluster.Spec.EnvoyConfig.GetNodeSelector(),


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Use the kafka clusters service account instead of the default one in case of CruiseControl and Envoy as well. See #336 
Add watch to the cluster role
