### PR TITLE
Bump helm chart version to prepare v0.11.0 release

### DIFF
--- a/charts/kafka-operator/Chart.yaml
+++ b/charts/kafka-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: kafka-operator
-version: 0.2.14
+version: 0.2.15
 description: kafka-operator manages Kafka deployments on Kubernetes
 sources:
   - https://github.com/banzaicloud/kafka-operator
-appVersion: 0.10.0
+appVersion: v0.11.0

--- a/charts/kafka-operator/values.yaml
+++ b/charts/kafka-operator/values.yaml
@@ -11,7 +11,7 @@ imagePullSecrets: []
 operator:
   image:
     repository: banzaicloud/kafka-operator
-    tag: 0.10.0
+    tag: v0.11.0
     pullPolicy: IfNotPresent
   vaultAddress: ""
   # vaultSecret containing a `ca.crt` key with the Vault CA Certificate


### PR DESCRIPTION
This PR updates the helm chart version to prepare for the new v0.11.0 release