### PR TITLE
HOTFIX: fix sequence order in the envs field

### DIFF
--- a/pkg/resources/kafka/pod.go
+++ b/pkg/resources/kafka/pod.go
@@ -16,6 +16,7 @@ package kafka
 
 import (
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -355,10 +356,17 @@ func generateEnvConfig(brokerConfig *v1beta1.BrokerConfig, defaultEnvVars, clust
 			Value: brokerConfig.GetKafkaPerfJmvOpts(),
 		}
 	}
+	//Sort map values by key to avoid diff in sequence
+	keys := make([]string, 0, len(envs))
+
+	for k := range envs {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
 
 	mergedEnv := make([]corev1.EnvVar, 0)
-	for _, v := range envs {
-		mergedEnv = append(mergedEnv, corev1.EnvVar{Name: v.Name, Value: v.Value})
+	for _, k := range keys {
+		mergedEnv = append(mergedEnv, corev1.EnvVar{Name: envs[k].Name, Value: envs[k].Value})
 	}
 
 	return mergedEnv


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |yes|
| New feature?    | no|
| API breaks?     | no|
| Deprecations?   | no|
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Fixes the sequence order in the envs field which causes constant diffs in the pod spec. It triggers constant rolling upgrades.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
