### PR TITLE
chart: allow users to specify custom annotations for operator deployment

### DIFF
--- a/charts/kafka-operator/README.md
+++ b/charts/kafka-operator/README.md
@@ -41,6 +41,7 @@ Parameter | Description | Default
 `operator.image.pullPolicy` | Operator container image pull policy | `IfNotPresent`
 `operator.resources` | CPU/Memory resource requests/limits (YAML) | Memory: `128Mi/256Mi`, CPU: `100m/200m`
 `operator.namespaces` | List of namespaces where Operator watches for custom resources.<br><br>**Note** that the operator still requires to read the cluster-scoped `Node` labels to configure `rack awareness`. Make sure the operator ServiceAccount is granted `get` permissions on this `Node` resource when using limited RBACs.| `""` i.e. all namespaces
+`operator.annotations` | Operator pod annotations can be set | `{}`
 `prometheusMetrics.enabled` | If true, use direct access for Prometheus metrics | `false`
 `prometheusMetrics.authProxy.enabled` | If true, use auth proxy for Prometheus metrics | `true`
 `prometheusMetrics.authProxy.image.repository` | Auth proxy container image repository | `gcr.io/kubebuilder/kube-rbac-proxy`

--- a/charts/kafka-operator/templates/operator-deployment.yaml
+++ b/charts/kafka-operator/templates/operator-deployment.yaml
@@ -25,6 +25,9 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/operator-validating-webhook.yaml") . | sha256sum }}
+        {{- with .Values.operator.annotations -}}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
       labels:
         control-plane: controller-manager
         controller-tools.k8s.io: "1.0"

--- a/charts/kafka-operator/values.yaml
+++ b/charts/kafka-operator/values.yaml
@@ -9,6 +9,7 @@ imagePullSecrets: []
   # - private-registry-key
 
 operator:
+  annotations: {}
   image:
     repository: banzaicloud/kafka-operator
     tag: v0.11.2


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0

### What's in this PR?

This PR allows users of the helm chart to provide custom annotations for operator deployment.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

Via annotations, user can configure metadata processed by other parties like logs collectors, kube-janitor TTL etc...

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
