### PR TITLE
Create catch-all ACLs for transactional and idempotent producer

### DIFF
--- a/pkg/kafkaclient/users.go
+++ b/pkg/kafkaclient/users.go
@@ -149,7 +149,7 @@ func (k *kafkaClient) createWriteACLs(dn string, topic string, patternType saram
 func (k *kafkaClient) createCommonWriteACLs(dn string) (err error) {
 	if err = k.admin.CreateACL(sarama.Resource{
 		ResourceType:        sarama.AclResourceCluster,
-		ResourceName:        "*",
+		ResourceName:        "kafka-cluster",
 		ResourcePatternType: sarama.AclPatternLiteral,
 	}, sarama.Acl{
 		Principal:      dn,


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #365 and #348
| License         | Apache 2.0


### What's in this PR?
During creation of write ACLs also create two more:
 - cluster level ACL enabling idempotent writes
 - TransactionId level ACL enabling write for all transaction ids 

### Additional context
I don't see any harm in enabling idempotent writes in all cases. However support for transaction Ids is quite simplistic - it just allows all of them. If this is good enough or if there should be ability to enable specific transactionIds in KafkaUser CRD is something for discussion.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
