### PR TITLE
Allow disabling the "preserveUnknownFields" option in CRD 

### DIFF
--- a/charts/kafka-operator/README.md
+++ b/charts/kafka-operator/README.md
@@ -61,3 +61,4 @@ Parameter | Description | Default
 `webhook.enabled` | Operator will activate the admission webhooks for custom resources | `true`
 `webhook.certs.generate` | Helm chart will generate cert for the webhook | `true`
 `webhook.certs.secret` | Helm chart will use the secret name applied here for the cert | `kafka-operator-serving-cert`
+`crds.preserveUnknownFieldsSupported` | Don't set the `preserveUnknownFields` option on CRDs (k8s 1.14) | `true`

--- a/charts/kafka-operator/templates/operator-kafka-crd.yaml
+++ b/charts/kafka-operator/templates/operator-kafka-crd.yaml
@@ -14,7 +14,9 @@ spec:
     listKind: KafkaClusterList
     plural: kafkaclusters
     singular: kafkacluster
+  {{ if .Values.crds.preserveUnknownFieldsSupported }}
   preserveUnknownFields: false
+  {{ end }}
   scope: Namespaced
   subresources:
     status: {}

--- a/charts/kafka-operator/templates/operator-kafka-topic-crd.yaml
+++ b/charts/kafka-operator/templates/operator-kafka-topic-crd.yaml
@@ -14,7 +14,9 @@ spec:
     listKind: KafkaTopicList
     plural: kafkatopics
     singular: kafkatopic
+  {{ if .Values.crds.preserveUnknownFieldsSupported }}
   preserveUnknownFields: false
+  {{ end }}
   scope: Namespaced
   subresources:
     status: {}

--- a/charts/kafka-operator/templates/operator-kafka-user-crd.yaml
+++ b/charts/kafka-operator/templates/operator-kafka-user-crd.yaml
@@ -14,7 +14,9 @@ spec:
     listKind: KafkaUserList
     plural: kafkausers
     singular: kafkauser
+  {{ if .Values.crds.preserveUnknownFieldsSupported }}
   preserveUnknownFields: false
+  {{ end }}
   scope: Namespaced
   subresources:
     status: {}

--- a/charts/kafka-operator/values.yaml
+++ b/charts/kafka-operator/values.yaml
@@ -56,6 +56,9 @@ fullnameOverride: ""
 rbac:
   enabled: true
 
+crds:
+  preserveUnknownFieldsSupported: true
+
 nodeSelector: {}
 
 tolerations: []


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | n/a
| License         | Apache 2.0


### What's in this PR?
This allows installing the operator on Kubernetes 1.14 by optionally disabling the `preserveUnknownFields` flag in the CRD manifests.


### Why?
Because I am still running 1.14 and want to use the operator 😆


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] User guide and development docs updated (if needed)