### PR TITLE
Fix: recreate evicted pod as well

### DIFF
--- a/pkg/k8sutil/resource.go
+++ b/pkg/k8sutil/resource.go
@@ -168,6 +168,14 @@ func IsPodContainsTerminatedContainer(pod *corev1.Pod) bool {
 	return false
 }
 
+// IsPodContainsEvictedContainer returns true if pod status has an evicted reason false otherwise
+func IsPodContainsEvictedContainer(pod *corev1.Pod) bool {
+	if pod.Status.Phase == corev1.PodFailed && pod.Status.Reason == "Evicted" {
+		return true
+	}
+	return false
+}
+
 func IsPodContainsPendingContainer(pod *corev1.Pod) bool {
 	for _, containerState := range pod.Status.ContainerStatuses {
 		if containerState.State.Waiting != nil {

--- a/pkg/k8sutil/resource.go
+++ b/pkg/k8sutil/resource.go
@@ -17,6 +17,7 @@ package k8sutil
 import (
 	"context"
 	"reflect"
+	"strings"
 
 	"emperror.dev/errors"
 	"github.com/banzaicloud/k8s-objectmatcher/patch"
@@ -170,7 +171,7 @@ func IsPodContainsTerminatedContainer(pod *corev1.Pod) bool {
 
 // IsPodContainsEvictedContainer returns true if pod status has an evicted reason false otherwise
 func IsPodContainsEvictedContainer(pod *corev1.Pod) bool {
-	if pod.Status.Phase == corev1.PodFailed && pod.Status.Reason == "Evicted" {
+	if pod.Status.Phase == corev1.PodFailed && strings.Contains(pod.Status.Reason, "Evicted") {
 		return true
 	}
 	return false

--- a/pkg/resources/kafka/kafka.go
+++ b/pkg/resources/kafka/kafka.go
@@ -654,7 +654,9 @@ func (r *Reconciler) reconcileKafkaPod(log logr.Logger, desiredPod *corev1.Pod) 
 		if err != nil {
 			log.Error(err, "could not match objects", "kind", desiredType)
 		} else if patchResult.IsEmpty() {
-			if !k8sutil.IsPodContainsTerminatedContainer(currentPod) && r.KafkaCluster.Status.BrokersState[currentPod.Labels["brokerId"]].ConfigurationState == v1beta1.ConfigInSync {
+			if !k8sutil.IsPodContainsTerminatedContainer(currentPod) &&
+				r.KafkaCluster.Status.BrokersState[currentPod.Labels["brokerId"]].ConfigurationState == v1beta1.ConfigInSync &&
+				!k8sutil.IsPodContainsEvictedContainer(currentPod) {
 				log.V(1).Info("resource is in sync")
 				return nil
 			}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |yes|
| New feature?    | no|
| API breaks?     | no|
| Deprecations?   | no|
| Related tickets | fixes #326
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Without this fix the operator wont recognise an evicted pod. It leads to states where all broker pods are evicted and the operator does not restarts any of it.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
