### PR TITLE
Fix: Add CC config and clusterConfig hash annotations to cc deployment

### DIFF
--- a/pkg/resources/cruisecontrol/deployment.go
+++ b/pkg/resources/cruisecontrol/deployment.go
@@ -176,10 +176,14 @@ fi`},
 
 func generatePodAnnotations(kafkaCluster *v1beta1.KafkaCluster, log logr.Logger) map[string]string {
 	hashedCruiseControlCapacityJson := sha256.Sum256([]byte(GenerateCapacityConfig(kafkaCluster, log)))
+	hashedCruiseControlConfigJson := sha256.Sum256([]byte(kafkaCluster.Spec.CruiseControlConfig.Config))
+	hashedCruiseControlClusterConfigJson := sha256.Sum256([]byte(kafkaCluster.Spec.CruiseControlConfig.ClusterConfig))
 
 	annotations := []map[string]string{
 		{
-			"cruiseControlCapacity.json": hex.EncodeToString(hashedCruiseControlCapacityJson[:]),
+			"cruiseControlCapacity.json":      hex.EncodeToString(hashedCruiseControlCapacityJson[:]),
+			"cruiseControlConfig.json":        hex.EncodeToString(hashedCruiseControlConfigJson[:]),
+			"cruiseControlClusterConfig.json": hex.EncodeToString(hashedCruiseControlClusterConfigJson[:]),
 		},
 		util.MonitoringAnnotations(metricsPort),
 	}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |yes|
| New feature?    | no|
| API breaks?     | no|
| Deprecations?   | no|
| Related tickets | fixes #371 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
This PR adds CC config and clusterConfig hash annotations to the cc deployment, to trigger pod restart when config change occurs.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
