### PR TITLE
Fix downscale error, do not update cc capacity config when downscale …

### DIFF
--- a/pkg/resources/cruisecontrol/configmap_test.go
+++ b/pkg/resources/cruisecontrol/configmap_test.go
@@ -352,7 +352,7 @@ func TestGenerateCapacityConfig(t *testing.T) {
 
 		t.Run(test.testName, func(t *testing.T) {
 			var actual CruiseControlCapacityConfig
-			err := json.Unmarshal([]byte(GenerateCapacityConfig(&test.kafkaCluster, log.NullLogger{})), &actual)
+			err := json.Unmarshal([]byte(GenerateCapacityConfig(&test.kafkaCluster, log.NullLogger{}, nil)), &actual)
 			if err != nil {
 				t.Error(err, "could not actual unmarshal json")
 			}

--- a/pkg/resources/cruisecontrol/deployment.go
+++ b/pkg/resources/cruisecontrol/deployment.go
@@ -31,7 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-func (r *Reconciler) deployment(log logr.Logger, config *corev1.ConfigMap) runtime.Object {
+func (r *Reconciler) deployment(log logr.Logger, podAnnotations map[string]string) runtime.Object {
 
 	volume := []corev1.Volume{}
 	volumeMount := []corev1.VolumeMount{}
@@ -61,7 +61,7 @@ func (r *Reconciler) deployment(log logr.Logger, config *corev1.ConfigMap) runti
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels:      templates.ObjectMetaLabels(r.KafkaCluster, ccLabelSelector(r.KafkaCluster.Name)),
-					Annotations: generatePodAnnotations(r.KafkaCluster, log, config),
+					Annotations: podAnnotations,
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName:            r.KafkaCluster.Spec.CruiseControlConfig.GetServiceAccount(r.KafkaCluster.Name),
@@ -174,8 +174,8 @@ fi`},
 	}
 }
 
-func generatePodAnnotations(kafkaCluster *v1beta1.KafkaCluster, log logr.Logger, config *corev1.ConfigMap) map[string]string {
-	hashedCruiseControlCapacityJson := sha256.Sum256([]byte(GenerateCapacityConfig(kafkaCluster, log, config)))
+func GeneratePodAnnotations(kafkaCluster *v1beta1.KafkaCluster, log logr.Logger, capacityConfig string) map[string]string {
+	hashedCruiseControlCapacityJson := sha256.Sum256([]byte(capacityConfig))
 	hashedCruiseControlConfigJson := sha256.Sum256([]byte(kafkaCluster.Spec.CruiseControlConfig.Config))
 	hashedCruiseControlClusterConfigJson := sha256.Sum256([]byte(kafkaCluster.Spec.CruiseControlConfig.ClusterConfig))
 

--- a/pkg/resources/cruisecontrol/deployment.go
+++ b/pkg/resources/cruisecontrol/deployment.go
@@ -31,7 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-func (r *Reconciler) deployment(log logr.Logger, clientPass string) runtime.Object {
+func (r *Reconciler) deployment(log logr.Logger, config *corev1.ConfigMap) runtime.Object {
 
 	volume := []corev1.Volume{}
 	volumeMount := []corev1.VolumeMount{}
@@ -61,7 +61,7 @@ func (r *Reconciler) deployment(log logr.Logger, clientPass string) runtime.Obje
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels:      templates.ObjectMetaLabels(r.KafkaCluster, ccLabelSelector(r.KafkaCluster.Name)),
-					Annotations: generatePodAnnotations(r.KafkaCluster, log),
+					Annotations: generatePodAnnotations(r.KafkaCluster, log, config),
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName:            r.KafkaCluster.Spec.CruiseControlConfig.GetServiceAccount(r.KafkaCluster.Name),
@@ -174,8 +174,8 @@ fi`},
 	}
 }
 
-func generatePodAnnotations(kafkaCluster *v1beta1.KafkaCluster, log logr.Logger) map[string]string {
-	hashedCruiseControlCapacityJson := sha256.Sum256([]byte(GenerateCapacityConfig(kafkaCluster, log)))
+func generatePodAnnotations(kafkaCluster *v1beta1.KafkaCluster, log logr.Logger, config *corev1.ConfigMap) map[string]string {
+	hashedCruiseControlCapacityJson := sha256.Sum256([]byte(GenerateCapacityConfig(kafkaCluster, log, config)))
 	hashedCruiseControlConfigJson := sha256.Sum256([]byte(kafkaCluster.Spec.CruiseControlConfig.Config))
 	hashedCruiseControlClusterConfigJson := sha256.Sum256([]byte(kafkaCluster.Spec.CruiseControlConfig.ClusterConfig))
 

--- a/pkg/resources/cruisecontrol/service.go
+++ b/pkg/resources/cruisecontrol/service.go
@@ -17,15 +17,15 @@ package cruisecontrol
 import (
 	"fmt"
 
-	"github.com/banzaicloud/kafka-operator/pkg/resources/templates"
-	"github.com/banzaicloud/kafka-operator/pkg/util"
-	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/banzaicloud/kafka-operator/pkg/resources/templates"
+	"github.com/banzaicloud/kafka-operator/pkg/util"
 )
 
-func (r *Reconciler) service(log logr.Logger, clientPass string) runtime.Object {
+func (r *Reconciler) service() runtime.Object {
 	return &corev1.Service{
 		ObjectMeta: templates.ObjectMeta(
 			fmt.Sprintf(serviceNameTemplate, r.KafkaCluster.Name),

--- a/pkg/resources/reconciler.go
+++ b/pkg/resources/reconciler.go
@@ -44,9 +44,6 @@ type Resource func() runtime.Object
 // ResourceWithLogs function with log parameter
 type ResourceWithLogs func(log logr.Logger) runtime.Object
 
-// ResourceWithLogsAndClientPassword function with log and password parameter
-type ResourceWithLogsAndClientPassword func(log logr.Logger, clientPass string) runtime.Object
-
 // ResourceWithLogAndExternalListenerConfig function with log and externalListenerConfig parameter
 type ResourceWithLogAndExternalListenerConfig func(log logr.Logger, externalListenerConfig v1beta1.ExternalListenerConfig) runtime.Object
 


### PR DESCRIPTION
…in progress

| Q               | A
| --------------- | ---
| Bug fix?        |yes|
| New feature?    | no|
| API breaks?     | no|
| Deprecations?   | no|
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

This PR fixes the bug which leads to infinite reconcile loop when downscaling cluster with Cruise Control Capacity config generated by the operator.

Operator removes the downscaled broker to early from the CC config which leads to nullpointer exception. To fix this, we are going to reuse the old config during downscale.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
