### PR TITLE
fix: cluster is continuously reconciled if either serviceAnnotation or virtualServiceAnnotation field is changed

### DIFF
--- a/pkg/resources/istioingress/virtualservice.go
+++ b/pkg/resources/istioingress/virtualservice.go
@@ -45,7 +45,7 @@ func (r *Reconciler) virtualService(log logr.Logger, externalListenerConfig v1be
 		ObjectMeta: templates.ObjectMetaWithAnnotations(
 			fmt.Sprintf(virtualServiceTemplate, r.KafkaCluster.Name, externalListenerConfig.Name),
 			labelsForIstioIngress(r.KafkaCluster.Name, externalListenerConfig.Name),
-			r.KafkaCluster.Spec.IstioIngressConfig.VirtualServiceAnnotations,
+			r.KafkaCluster.Spec.IstioIngressConfig.GetVirtualServiceAnnotations(),
 			r.KafkaCluster),
 		Spec: vServiceSpec,
 	}

--- a/pkg/resources/kafka/allBrokerService.go
+++ b/pkg/resources/kafka/allBrokerService.go
@@ -50,7 +50,7 @@ func (r *Reconciler) allBrokerService() runtime.Object {
 		ObjectMeta: templates.ObjectMetaWithAnnotations(
 			fmt.Sprintf(kafkautils.AllBrokerServiceTemplate, r.KafkaCluster.Name),
 			LabelsForKafka(r.KafkaCluster.Name),
-			r.KafkaCluster.Spec.ListenersConfig.ServiceAnnotations,
+			r.KafkaCluster.Spec.ListenersConfig.GetServiceAnnotations(),
 			r.KafkaCluster),
 		Spec: corev1.ServiceSpec{
 			Type:            corev1.ServiceTypeClusterIP,

--- a/pkg/resources/kafka/headlessService.go
+++ b/pkg/resources/kafka/headlessService.go
@@ -51,7 +51,7 @@ func (r *Reconciler) headlessService() runtime.Object {
 		ObjectMeta: templates.ObjectMetaWithAnnotations(
 			fmt.Sprintf(kafkautils.HeadlessServiceTemplate, r.KafkaCluster.Name),
 			util.MergeLabels(LabelsForKafka(r.KafkaCluster.Name), r.KafkaCluster.Labels),
-			r.KafkaCluster.Spec.ListenersConfig.ServiceAnnotations,
+			r.KafkaCluster.Spec.ListenersConfig.GetServiceAnnotations(),
 			r.KafkaCluster,
 		),
 		Spec: corev1.ServiceSpec{

--- a/pkg/resources/kafka/service.go
+++ b/pkg/resources/kafka/service.go
@@ -63,7 +63,7 @@ func (r *Reconciler) service(id int32, log logr.Logger) runtime.Object {
 				LabelsForKafka(r.KafkaCluster.Name),
 				map[string]string{"brokerId": fmt.Sprintf("%d", id)},
 			),
-			r.KafkaCluster.Spec.ListenersConfig.ServiceAnnotations,
+			r.KafkaCluster.Spec.ListenersConfig.GetServiceAnnotations(),
 			r.KafkaCluster),
 		Spec: corev1.ServiceSpec{
 			Type:            corev1.ServiceTypeClusterIP,

--- a/pkg/sdk/v1beta1/kafkacluster_types.go
+++ b/pkg/sdk/v1beta1/kafkacluster_types.go
@@ -167,6 +167,17 @@ type IstioIngressConfig struct {
 	VirtualServiceAnnotations map[string]string            `json:"virtualServiceAnnotations,omitempty"`
 }
 
+// GetVirtualServiceAnnotations returns a copy of the VirtualServiceAnnotations field
+func (iIConfig *IstioIngressConfig) GetVirtualServiceAnnotations() map[string]string {
+	annotations := make(map[string]string, len(iIConfig.VirtualServiceAnnotations))
+
+	for key, value := range iIConfig.VirtualServiceAnnotations {
+		annotations[key] = value
+	}
+
+	return annotations
+}
+
 // MonitoringConfig defines the config for monitoring Kafka and Cruise Control
 type MonitoringConfig struct {
 	JmxImage               string `json:"jmxImage"`
@@ -187,6 +198,17 @@ type ListenersConfig struct {
 	InternalListeners  []InternalListenerConfig `json:"internalListeners"`
 	SSLSecrets         *SSLSecrets              `json:"sslSecrets,omitempty"`
 	ServiceAnnotations map[string]string        `json:"serviceAnnotations,omitempty"`
+}
+
+// GetServiceAnnotations returns a copy of the ServiceAnnotations field.
+func (c ListenersConfig) GetServiceAnnotations() map[string]string {
+	annotations := make(map[string]string, len(c.ServiceAnnotations))
+
+	for key, value := range c.ServiceAnnotations {
+		annotations[key] = value
+	}
+
+	return annotations
 }
 
 // SSLSecrets defines the Kafka SSL secrets


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Copy the service annotation and virtual service annotation fields  from KafkaCluster custom resource before applying to services and virtual service resources.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
If the original serviceAnnotation and virtualServiceAnnotation field is used than these are shared by both the KafkaCluster CR and the K8s resources all pointing to the same memory address. This causes the `last-applied` annotation set on services and virtual service resources to appear in the KafkaCluster CR as well which triggers a continuous reconcile.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested

