### PR TITLE
Export java.{lang,nio} broker JMX metrics

### DIFF
--- a/pkg/sdk/v1beta1/kafkacluster_types.go
+++ b/pkg/sdk/v1beta1/kafkacluster_types.go
@@ -681,7 +681,10 @@ rules:
   name: kafka_$1_$2_$3
   type: GAUGE
   labels:
-    quantile: "0.$4"`
+    quantile: "0.$4"
+# Export all other java.{lang,nio}* beans using default format
+- pattern: java.lang.+
+- pattern: java.nio.+`
 }
 
 // GetCCJMXExporterConfig returns the config for CC Prometheus JMX exporter


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0

### What's in this PR?
Previously only kafka.* jmx metrics were exported
Added JVM java.{java,nio} as well.

### Why?
Expose the underlying JVM metrics



### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested

