### PR TITLE
Fix panic when pvc size is updated externally

### DIFF
--- a/pkg/resources/kafka/kafka.go
+++ b/pkg/resources/kafka/kafka.go
@@ -804,7 +804,8 @@ func (r *Reconciler) reconcileKafkaPvc(log logr.Logger, brokersDesiredPvcs map[s
 					}
 
 					if isDesiredStorageValueInvalid(desiredPvc, currentPvc) {
-						return errorfactory.New(errorfactory.InternalError{}, nil, "one can not reduce the size of a PVC", "kind", desiredType)
+						return errorfactory.New(errorfactory.InternalError{}, errors.New("could not modify pvc size"),
+							"one can not reduce the size of a PVC", "kind", desiredType)
 					}
 
 					resReq := desiredPvc.Spec.Resources.Requests


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |yes|
| New feature?    | no|
| API breaks?     | no|
| Deprecations?   | no|
| Related tickets | fixes #393 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
This PR fixes the panic which occur when the pvc size is updated externally 


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
