### PR TITLE
Prepare release v0.12.2 by updaiting the helm chart

### DIFF
--- a/charts/kafka-operator/Chart.yaml
+++ b/charts/kafka-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: kafka-operator
-version: 0.2.20
+version: 0.2.21
 description: kafka-operator manages Kafka deployments on Kubernetes
 sources:
   - https://github.com/banzaicloud/kafka-operator
-appVersion: v0.12.1
+appVersion: v0.12.2

--- a/charts/kafka-operator/values.yaml
+++ b/charts/kafka-operator/values.yaml
@@ -12,7 +12,7 @@ operator:
   annotations: {}
   image:
     repository: banzaicloud/kafka-operator
-    tag: v0.12.1
+    tag: v0.12.2
     pullPolicy: IfNotPresent
   vaultAddress: ""
   # vaultSecret containing a `ca.crt` key with the Vault CA Certificate


### PR DESCRIPTION
This PR upgrades the helm chart to use the operator version 0.12.2