### PR TITLE
custom printcolumn listing to improve get listings

### DIFF
--- a/charts/kafka-operator/crds/operator-kafka-crd.yaml
+++ b/charts/kafka-operator/crds/operator-kafka-crd.yaml
@@ -9,6 +9,22 @@ metadata:
   creationTimestamp: null
   name: kafkaclusters.kafka.banzaicloud.io
 spec:
+  additionalPrinterColumns:
+    - JSONPath: .status.state
+      name: Cluster state
+      type: string
+    - JSONPath: .status.alertCount
+      name: Cluster alert count
+      type: integer
+    - JSONPath: .status.rollingUpgradeStatus.lastSuccess
+      name: Last successful upgrade
+      type: string
+    - JSONPath: .status.rollingUpgradeStatus.errorCount
+      name: Upgrade error count
+      type: string
+    - JSONPath: .metadata.creationTimestamp
+      name: Age
+      type: date
   group: kafka.banzaicloud.io
   names:
     kind: KafkaCluster

--- a/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
+++ b/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
@@ -8,6 +8,22 @@ metadata:
   creationTimestamp: null
   name: kafkaclusters.kafka.banzaicloud.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.state
+    name: Cluster state
+    type: string
+  - JSONPath: .status.alertCount
+    name: Cluster alert count
+    type: integer
+  - JSONPath: .status.rollingUpgradeStatus.lastSuccess
+    name: Last successful upgrade
+    type: string
+  - JSONPath: .status.rollingUpgradeStatus.errorCount
+    name: Upgrade error count
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
   group: kafka.banzaicloud.io
   names:
     kind: KafkaCluster

--- a/pkg/sdk/v1beta1/kafkacluster_types.go
+++ b/pkg/sdk/v1beta1/kafkacluster_types.go
@@ -289,6 +289,11 @@ type CommonListenerSpec struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:JSONPath=".status.state",name="Cluster state",type="string"
+// +kubebuilder:printcolumn:JSONPath=".status.alertCount",name="Cluster alert count",type="integer"
+// +kubebuilder:printcolumn:JSONPath=".status.rollingUpgradeStatus.lastSuccess",name="Last successful upgrade",type="string"
+// +kubebuilder:printcolumn:JSONPath=".status.rollingUpgradeStatus.errorCount",name="Upgrade error count",type="string"
+// +kubebuilder:printcolumn:JSONPath=".metadata.creationTimestamp",name="Age",type="date"
 
 // KafkaCluster is the Schema for the kafkaclusters API
 type KafkaCluster struct {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
improve the standard listing view's field with `Cluster state`, `Cluster alter count`, `Last successful upgrade`, `Upgrade error count` 


### Why?
Gives much faster an overview of your clusters' state without the need of output formatting or `describe`
