### PR TITLE
Refine logging for cruise-control interactions

### DIFF
--- a/controllers/cruisecontroltask_controller.go
+++ b/controllers/cruisecontroltask_controller.go
@@ -196,7 +196,7 @@ func (r *CruiseControlTaskReconciler) handlePodAddCCTask(kafkaCluster *v1beta1.K
 	cc := scale.NewCruiseControlScaler(kafkaCluster.Namespace, kafkaCluster.Spec.GetKubernetesClusterDomain(), kafkaCluster.Spec.CruiseControlConfig.CruiseControlEndpoint, kafkaCluster.Name)
 	uTaskId, taskStartTime, scaleErr := cc.UpScaleCluster(brokerIds)
 	if scaleErr != nil {
-		log.Info("cruise control communication error during upscaling broker(s)", "brokerId(s)", brokerIds)
+		log.Info("Cannot upscale broker(s)", "brokerId(s)", brokerIds, "error", scaleErr.Error())
 		return errorfactory.New(errorfactory.CruiseControlNotReady{}, scaleErr, fmt.Sprintf("broker id(s): %s", brokerIds))
 	}
 	statusErr := k8sutil.UpdateBrokerStatus(r.Client, brokerIds, kafkaCluster,


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Refactored the logging for calls to cruise-control to:
-  reduce code duplication
- always report the cruise-control error message in logs where there is a non-200 return code

### Why?
This was done while investigating https://github.com/banzaicloud/kafka-operator/issues/400




### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [ ] User guide and development docs updated (if needed)
