### PR TITLE
Helm chart: Make CRDs installation helm2 and helm3 compatible

### DIFF
--- a/charts/kafka-operator/crds/operator-kafka-crd.yaml
+++ b/charts/kafka-operator/crds/operator-kafka-crd.yaml
@@ -5,6 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.2.5
+    helm.sh/hook: crd-install
   creationTimestamp: null
   name: kafkaclusters.kafka.banzaicloud.io
 spec:

--- a/charts/kafka-operator/crds/operator-kafka-topic-crd.yaml
+++ b/charts/kafka-operator/crds/operator-kafka-topic-crd.yaml
@@ -5,6 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.2.5
+    helm.sh/hook: crd-install
   creationTimestamp: null
   name: kafkatopics.kafka.banzaicloud.io
 spec:

--- a/charts/kafka-operator/crds/operator-kafka-user-crd.yaml
+++ b/charts/kafka-operator/crds/operator-kafka-user-crd.yaml
@@ -5,6 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.2.5
+    helm.sh/hook: crd-install
   creationTimestamp: null
   name: kafkausers.kafka.banzaicloud.io
 spec:

--- a/charts/kafka-operator/templates/crds.yaml
+++ b/charts/kafka-operator/templates/crds.yaml
@@ -1,0 +1,6 @@
+{{- if .Values.crd.enabled }}
+{{- range $path, $bytes := .Files.Glob "crds/*.yaml" }}
+{{ $.Files.Get $path }}
+---
+{{- end }}
+{{- end }}

--- a/charts/kafka-operator/values.yaml
+++ b/charts/kafka-operator/values.yaml
@@ -56,6 +56,9 @@ fullnameOverride: ""
 rbac:
   enabled: true
 
+crd:
+  enabled: true
+
 nodeSelector: {}
 
 tolerations: []


### PR DESCRIPTION

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Helm3 changed the way CRDs are installed as part of helm install/upgrade.
To keep the helm chart compatible with both helm2 and helm3 this PR employ the pattern proposed in other helm charts and described at https://geeksocket.in/posts/helm-2-3-migration/

tldr:
- move the CRDs definition in helm3 `crds` folder (this is used by helm3 to install crds if they don't exist)
- import them in templates/crds.yaml - this is used by helm2
- add `helm.sh/hook: crd-install` annotation required by helm2 when dealing with CRDs (ignored by helm3)
- add `crd.enabled` flag to be used in `helm template` static helmfile rendering

### Why?

Make kafka-operator helm chart installable using both helm2 and helm3



### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [ ] User guide and development docs updated (if needed)

### To Do
- [ ] User guide and development docs updated
