### PR TITLE
Helm chart: Make operator ServiceAccount configurable

### DIFF
--- a/charts/kafka-operator/README.md
+++ b/charts/kafka-operator/README.md
@@ -39,11 +39,15 @@ Parameter | Description | Default
 `operator.image.repository` | Operator container image repository | `banzaicloud/kafka-operator`
 `operator.image.tag` | Operator container image tag | `v0.11.0`
 `operator.image.pullPolicy` | Operator container image pull policy | `IfNotPresent`
+`operator.serviceAccount.name` | ServiceAccount used by the operator pod | `kafka-operator`
+`operator.serviceAccount.create` | If true, create the `operator.serviceAccount.name` service account | `true`
 `operator.resources` | CPU/Memory resource requests/limits (YAML) | Memory: `128Mi/256Mi`, CPU: `100m/200m`
 `operator.namespaces` | List of namespaces where Operator watches for custom resources.<br><br>**Note** that the operator still requires to read the cluster-scoped `Node` labels to configure `rack awareness`. Make sure the operator ServiceAccount is granted `get` permissions on this `Node` resource when using limited RBACs.| `""` i.e. all namespaces
 `operator.annotations` | Operator pod annotations can be set | `{}`
 `prometheusMetrics.enabled` | If true, use direct access for Prometheus metrics | `false`
 `prometheusMetrics.authProxy.enabled` | If true, use auth proxy for Prometheus metrics | `true`
+`prometheusMetrics.authProxy.serviceAccount.create` | If true, create the service account (see `prometheusMetrics.authProxy.serviceAccount.name`) used by prometheus auth proxy | `true`
+`prometheusMetrics.authProxy.serviceAccount.name` | ServiceAccount used by prometheus auth proxy | `kafka-operator-authproxy`
 `prometheusMetrics.authProxy.image.repository` | Auth proxy container image repository | `gcr.io/kubebuilder/kube-rbac-proxy`
 `prometheusMetrics.authProxy.image.tag` | Auth proxy container image tag | `v0.4.0`
 `prometheusMetrics.authProxy.image.pullPolicy` | Auth proxy container image pull policy | `IfNotPresent`

--- a/charts/kafka-operator/templates/_helpers.tpl
+++ b/charts/kafka-operator/templates/_helpers.tpl
@@ -30,3 +30,25 @@ Create chart name and version as used by the chart label.
 {{- define "kafka-operator.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Compute operator deployment serviceAccountName key
+*/}}
+{{- define "operator.serviceAccountName" -}}
+{{- if .Values.operator.serviceAccount.create -}}
+{{ default "default" .Values.operator.serviceAccount.name }}
+{{- else -}}
+{{- printf "%s" "default" }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Compute operator prometheus metrics auth proxy service account
+*/}}
+{{- define "operator.metricsAuthProxy.serviceAccountName" -}}
+{{- if .Values.prometheusMetrics.authProxy.serviceAccount.create -}}
+{{ default "default" .Values.prometheusMetrics.authProxy.serviceAccount.name }}
+{{- else -}}
+{{- printf "%s" "default" }}
+{{- end -}}
+{{- end -}}

--- a/charts/kafka-operator/templates/authproxy-rbac.yaml
+++ b/charts/kafka-operator/templates/authproxy-rbac.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.rbac.enabled .Values.prometheusMetrics.enabled .Values.prometheusMetrics.authProxy.enabled }}
+{{- if and .Values.prometheusMetrics.authProxy.serviceAccount.create .Values.prometheusMetrics.enabled .Values.prometheusMetrics.authProxy.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 {{- if .Values.imagePullSecrets }}
@@ -8,7 +8,7 @@ imagePullSecrets:
 {{- end }}
 {{- end }}
 metadata:
-  name: {{ include "kafka-operator.fullname" . }}-authproxy
+  name: {{ include "operator.metricsAuthProxy.serviceAccountName" .}}
   namespace: {{ .Release.Namespace | quote }}
   labels:
     app.kubernetes.io/name: {{ include "kafka-operator.name" . }}
@@ -17,6 +17,8 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
     app.kubernetes.io/component: authproxy
+{{- end }}
+{{- if and .Values.rbac.enabled .Values.prometheusMetrics.enabled .Values.prometheusMetrics.authProxy.enabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -56,6 +58,6 @@ roleRef:
   name: "{{ include "kafka-operator.fullname" . }}-authproxy"
 subjects:
 - kind: ServiceAccount
-  name: {{ include "kafka-operator.fullname" . }}-authproxy
+  name: {{ include "operator.metricsAuthProxy.serviceAccountName" .}}
   namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/charts/kafka-operator/templates/operator-deployment.yaml
+++ b/charts/kafka-operator/templates/operator-deployment.yaml
@@ -37,9 +37,7 @@ spec:
         app: prometheus
         component: alertmanager
     spec:
-      {{- if .Values.rbac.enabled }}
-      serviceAccountName: {{ include "kafka-operator.fullname" . }}-operator
-      {{- end }}
+      serviceAccountName: {{ include "operator.serviceAccountName" .}}
       volumes:
       {{- if .Values.webhook.enabled }}
         - name: serving-cert

--- a/charts/kafka-operator/templates/operator-rbac.yaml
+++ b/charts/kafka-operator/templates/operator-rbac.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.enabled }}
+{{- if .Values.operator.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 {{- if .Values.imagePullSecrets }}
@@ -8,7 +8,7 @@ imagePullSecrets:
 {{- end }}
 {{- end }}
 metadata:
-  name: {{ include "kafka-operator.fullname" . }}-operator
+  name: {{ include "operator.serviceAccountName" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels:
     app.kubernetes.io/name: {{ include "kafka-operator.name" . }}
@@ -17,6 +17,8 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
     app.kubernetes.io/component: operator
+{{- end }}
+{{- if .Values.rbac.enabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -248,6 +250,6 @@ roleRef:
   name: {{ include "kafka-operator.fullname" . }}-operator
 subjects:
 - kind: ServiceAccount
-  name: {{ include "kafka-operator.fullname" . }}-operator
+  name: {{ include "operator.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/charts/kafka-operator/values.yaml
+++ b/charts/kafka-operator/values.yaml
@@ -27,6 +27,9 @@ operator:
     requests:
       cpu: 100m
       memory: 128Mi
+  serviceAccount:
+    create: true
+    name: kafka-operator
 
 webhook:
   enabled: true
@@ -49,6 +52,10 @@ prometheusMetrics:
       repository: gcr.io/kubebuilder/kube-rbac-proxy
       tag: v0.4.0
       pullPolicy: IfNotPresent
+    serviceAccount:
+      create: true
+      name: kafka-operator-authproxy
+
 
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no|yes
| Deprecations?   | no|yes
| Related tickets | fixes #X, partially #Y, mentioned in #Z
| License         | Apache 2.0


### What's in this PR?

Extend the helm-chart to allow the user to configure whether the ServiceAccount(s) used by operator pod and wehbook should be created during the chart installation. In situations where the SAs are created externally `serviceAccount.create` can be set to `false`
Keep it true as default for backward compatibility
 
### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] User guide and development docs updated (if needed)
