### PR TITLE
Add DESCRIBE_CONFIG to the common ACLs

### DIFF
--- a/pkg/kafkaclient/users.go
+++ b/pkg/kafkaclient/users.go
@@ -143,9 +143,9 @@ func (k *kafkaClient) createWriteACLs(dn string, topic string, patternType saram
 	return
 }
 
-func (k *kafkaClient) createCommonACLs(dn string, topic string, patternType sarama.AclResourcePatternType) error {
+func (k *kafkaClient) createCommonACLs(dn string, topic string, patternType sarama.AclResourcePatternType) (err error) {
 	// DESCRIBE on topic
-	return k.admin.CreateACL(sarama.Resource{
+	if err =  k.admin.CreateACL(sarama.Resource{
 		ResourceType:        sarama.AclResourceTopic,
 		ResourceName:        topic,
 		ResourcePatternType: patternType,
@@ -154,5 +154,22 @@ func (k *kafkaClient) createCommonACLs(dn string, topic string, patternType sara
 		Host:           "*",
 		Operation:      sarama.AclOperationDescribe,
 		PermissionType: sarama.AclPermissionAllow,
-	})
+	}); err != nil {
+		return
+	}
+
+	// DESCRIBE_CONFIGS on topic
+	if err =  k.admin.CreateACL(sarama.Resource{
+		ResourceType:        sarama.AclResourceTopic,
+		ResourceName:        topic,
+		ResourcePatternType: patternType,
+	}, sarama.Acl{
+		Principal:      dn,
+		Host:           "*",
+		Operation:      sarama.AclOperationDescribeConfigs,
+		PermissionType: sarama.AclPermissionAllow,
+	}); err != nil {
+		return
+	}
+	return
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #409
| License         | Apache 2.0


### What's in this PR?
People that want to use the confluent schema registry will not get it to work with the operator. This is because the service will verify that the correct retention policy is set. This is only possible when the AclOperationDescribeConfigs is set on the topic. It also seems like a reasonable default for a community operator.

### Why?
Reasonable default ACL for consumers and producers to verify the topic configuration

### Checklist
- [X] Implementation tested
- [X] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [ ] Logging code meets the guideline
- [ ] User guide and development docs updated (if needed)
