### PR TITLE
Remove finalizer when CR is in delete state without certificates

### DIFF
--- a/controllers/kafkauser_controller.go
+++ b/controllers/kafkauser_controller.go
@@ -185,6 +185,13 @@ func (r *KafkaUserReconciler) Reconcile(request reconcile.Request) (reconcile.Re
 					RequeueAfter: time.Duration(15) * time.Second,
 				}, nil
 			default:
+				if k8sutil.IsMarkedForDeletion(instance.ObjectMeta) {
+					reqLogger.Info("Kafka user marked for deletion before creating certificates")
+					if err = r.removeFinalizer(ctx, instance); err != nil {
+						return requeueWithError(reqLogger, "failed to remove finalizer from kafkauser", err)
+					}
+					return reconciled()
+				}
 				return requeueWithError(reqLogger, "failed to reconcile user secret", err)
 			}
 		}


### PR DESCRIPTION
Sometimes the KafkaUser CR can come into a weird state where the CR is
being deleted before it got the chance to create credentials. This fix
will make sure the finalizer is being removed so the CR can be deleted.

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #414
| License         | Apache 2.0


### What's in this PR?
This PR will remove the finalized when the CR is in a delete state when it fails to create credentials.

### Why?
Sometimes the KafkaUser CR can come into a weird state where the CR is being deleted before it got the chance to create credentials. If the delete state is a result of a namespace deletion the finalize step never happens because it tries to reconcile till the credentials are being created, but they can't be created because the namespace is being deleted.

### Checklist

- [X] Implementation tested
- [X] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [X] Logging code meets the guideline
- [ ] User guide and development docs updated (if needed)
