### PR TITLE
Add resizePvc command into alert manager

### DIFF
--- a/internal/alertmanager/currentalert/process.go
+++ b/internal/alertmanager/currentalert/process.go
@@ -282,7 +282,7 @@ func resizePvc(log logr.Logger, labels model.LabelSet, annotiations model.LabelS
 		}
 	}
 
-	err = k8sutil.UpdateCrWithRollingUpgrade(0, cr, client)
+	err = k8sutil.UpdateCr(cr, client)
 	if err != nil {
 		return err
 	}

--- a/internal/alertmanager/currentalert/process_test.go
+++ b/internal/alertmanager/currentalert/process_test.go
@@ -16,6 +16,7 @@ package currentalert
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/banzaicloud/kafka-operator/api/v1beta1"
@@ -54,9 +55,8 @@ func Test_resizePvc(t *testing.T) {
 						"node":                  "test-node",
 					},
 					Annotations: model.LabelSet{
-						"command":         "resizePvc",
-						"mountPathPrefix": "/kafka-logs",
-						"diskSize":        "2G",
+						"command":     "resizePvc",
+						"incrementBy": "2G",
 					},
 				},
 			},
@@ -125,9 +125,8 @@ func Test_resizePvc(t *testing.T) {
 						"node":                  "test-node",
 					},
 					Annotations: model.LabelSet{
-						"command":         "resizePvc",
-						"mountPathPrefix": "/kafka-logs",
-						"diskSize":        "2G",
+						"command":     "resizePvc",
+						"incrementBy": "2G",
 					},
 				},
 			},
@@ -229,6 +228,7 @@ func Test_resizePvc(t *testing.T) {
 				t.Errorf("kafka cr was not found, error = %v", err)
 			}
 
+			fmt.Println(kafkaCluster.Spec.Brokers)
 			brokerStorageConfig := &kafkaCluster.Spec.Brokers[0].BrokerConfig.StorageConfigs[0]
 
 			if brokerStorageConfig.PvcSpec.Resources.Requests.Storage().Value() != 6294967296 {

--- a/internal/alertmanager/currentalert/resizepvc_validator.go
+++ b/internal/alertmanager/currentalert/resizepvc_validator.go
@@ -16,6 +16,7 @@ package currentalert
 
 import (
 	emperror "emperror.dev/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 type resizePvcValidator struct {
@@ -34,6 +35,12 @@ func (a resizePvcValidator) validateAlert() error {
 	}
 	if a.Alert.Annotations["command"] != ResizePvcCommand {
 		return emperror.NewWithDetails("unsupported command", "command", a.Alert.Annotations["command"])
+	}
+	if !a.Alert.Annotations["incrementBy"].IsValid() {
+		return emperror.New("incrementBy annotation doesn't exist")
+	}
+	if _, err := resource.ParseQuantity(string(a.Alert.Annotations["incrementBy"])); err != nil {
+		return emperror.NewWithDetails("incrementBy not valid quantity", "incrementBy", a.Alert.Annotations["incrementBy"], "error", err)
 	}
 
 	return nil

--- a/internal/alertmanager/currentalert/resizepvc_validator_test.go
+++ b/internal/alertmanager/currentalert/resizepvc_validator_test.go
@@ -37,10 +37,40 @@ func TestResizePvcValidator_validateAlert(t *testing.T) {
 						"persistentvolumeclaim": "test-pvc",
 					},
 					Annotations: model.LabelSet{
+						"command":     ResizePvcCommand,
+						"incrementBy": "10Gi",
+					},
+				},
+			},
+		},
+		{
+			name: "resizePvc validate failed due to invalid incrementBy annotation",
+			fields: fields{
+				Alert: &currentAlertStruct{
+					Labels: model.LabelSet{
+						"persistentvolumeclaim": "test-pvc",
+					},
+					Annotations: model.LabelSet{
+						"command":     ResizePvcCommand,
+						"incrementBy": "10Gb",
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "resizePvc validate failed due to missing incrementBy annotation",
+			fields: fields{
+				Alert: &currentAlertStruct{
+					Labels: model.LabelSet{
+						"persistentvolumeclaim": "test-pvc",
+					},
+					Annotations: model.LabelSet{
 						"command": ResizePvcCommand,
 					},
 				},
 			},
+			wantErr: true,
 		},
 		{
 			name: "resizePvc validate failed due to missing label",

--- a/pkg/k8sutil/cr.go
+++ b/pkg/k8sutil/cr.go
@@ -44,7 +44,7 @@ func UpdateCrWithRackAwarenessConfig(pod *corev1.Pod, cr *v1beta1.KafkaCluster, 
 
 	rackAwarenessState, brokers := rackAwarenessLabelsToReadonlyConfig(pod, cr, rackConfigValues)
 	cr.Spec.Brokers = brokers
-	return rackAwarenessState, updateCr(cr, client)
+	return rackAwarenessState, UpdateCr(cr, client)
 }
 
 func rackAwarenessLabelsToReadonlyConfig(pod *corev1.Pod, cr *v1beta1.KafkaCluster, rackConfigValues []string) (v1beta1.RackAwarenessState, []v1beta1.Broker) {
@@ -83,7 +83,7 @@ func AddNewBrokerToCr(broker v1beta1.Broker, crName, namespace string, client ru
 	}
 	cr.Spec.Brokers = append(cr.Spec.Brokers, broker)
 
-	return updateCr(cr, client)
+	return UpdateCr(cr, client)
 }
 
 // RemoveBrokerFromCr modifies the CR and removes the given broker from the cluster
@@ -101,7 +101,7 @@ func RemoveBrokerFromCr(brokerId, crName, namespace string, client runtimeClient
 		}
 	}
 	cr.Spec.Brokers = tmpBrokers
-	return updateCr(cr, client)
+	return UpdateCr(cr, client)
 }
 
 // AddPvToSpecificBroker adds a new PV to a specific broker
@@ -120,7 +120,7 @@ func AddPvToSpecificBroker(brokerId, crName, namespace string, storageConfig *v1
 		}
 	}
 
-	return updateCr(cr, client)
+	return UpdateCr(cr, client)
 }
 
 // GetCr returns the given cr object
@@ -134,7 +134,7 @@ func GetCr(name, namespace string, client runtimeClient.Client) (*v1beta1.KafkaC
 	return cr, nil
 }
 
-func updateCr(cr *v1beta1.KafkaCluster, client runtimeClient.Client) error {
+func UpdateCr(cr *v1beta1.KafkaCluster, client runtimeClient.Client) error {
 	typeMeta := cr.TypeMeta
 	err := client.Update(context.TODO(), cr)
 	if err != nil {
@@ -149,5 +149,5 @@ func updateCr(cr *v1beta1.KafkaCluster, client runtimeClient.Client) error {
 func UpdateCrWithRollingUpgrade(errorCount int, cr *v1beta1.KafkaCluster, client runtimeClient.Client) error {
 
 	cr.Status.RollingUpgrade.ErrorCount = errorCount
-	return updateCr(cr, client)
+	return UpdateCr(cr, client)
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -194,7 +194,24 @@ func GetBrokerConfig(broker v1beta1.Broker, clusterSpec v1beta1.KafkaClusterSpec
 	if err != nil {
 		return nil, errors.WrapIf(err, "could not merge brokerConfig with ConfigGroup")
 	}
+
+	bConfig.StorageConfigs = dedupStorageConfigs(bConfig.StorageConfigs)
+
 	return bConfig, nil
+}
+
+func dedupStorageConfigs(elements []v1beta1.StorageConfig) []v1beta1.StorageConfig {
+	encountered := make(map[string]struct{})
+	result := []v1beta1.StorageConfig{}
+
+	for _, v := range elements {
+		if _, ok := encountered[v.MountPath]; !ok {
+			encountered[v.MountPath] = struct{}{}
+			result = append(result, v)
+		}
+	}
+
+	return result
 }
 
 // GetBrokerImage returns the used broker image

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -18,10 +18,9 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/banzaicloud/kafka-operator/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-
-	"github.com/banzaicloud/kafka-operator/api/v1beta1"
 )
 
 func TestGetBrokerConfig(t *testing.T) {
@@ -71,6 +70,83 @@ func TestGetBrokerConfig(t *testing.T) {
 				StorageConfigs: []v1beta1.StorageConfig{
 					{
 						MountPath: "kafka-test1/log",
+						PvcSpec: &corev1.PersistentVolumeClaimSpec{
+							AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("10Gi")},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	result, err := GetBrokerConfig(broker, cluster)
+	if err != nil {
+		t.Error("Error GetBrokerConfig throw an unexpected error")
+	}
+	if !reflect.DeepEqual(result, expected) {
+		t.Error("Expected:", expected, "Got:", result)
+	}
+}
+
+func TestGetBrokerConfigUniqueStorage(t *testing.T) {
+	expected := &v1beta1.BrokerConfig{
+		StorageConfigs: []v1beta1.StorageConfig{
+			{
+				MountPath: "kafka-test/log",
+				PvcSpec: &corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("20Gi")},
+					},
+				},
+			},
+			{
+				MountPath: "kafka-test1/log",
+				PvcSpec: &corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("10Gi")},
+					},
+				},
+			},
+		},
+	}
+	broker := v1beta1.Broker{
+		Id:                0,
+		BrokerConfigGroup: "default",
+		BrokerConfig: &v1beta1.BrokerConfig{
+			StorageConfigs: []v1beta1.StorageConfig{
+				{
+					MountPath: "kafka-test/log",
+					PvcSpec: &corev1.PersistentVolumeClaimSpec{
+						AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("20Gi")},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	cluster := v1beta1.KafkaClusterSpec{
+		BrokerConfigGroups: map[string]v1beta1.BrokerConfig{
+			"default": {
+				StorageConfigs: []v1beta1.StorageConfig{
+					{
+						MountPath: "kafka-test1/log",
+						PvcSpec: &corev1.PersistentVolumeClaimSpec{
+							AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("10Gi")},
+							},
+						},
+					},
+					{
+						MountPath: "kafka-test/log",
 						PvcSpec: &corev1.PersistentVolumeClaimSpec{
 							AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 							Resources: corev1.ResourceRequirements{


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
This implements the resizePvc command from alertmanager. This will add the additional space set in the alert to the existing pvc for the specific broker it alerts for.


### Why?
I have a setup where we want to retain data by time and not size, we tried the addPvc but that is slow and more disruptive than just resizing the pvc. I have tested this with GKE and EKS and it works as expected. 

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
