### PR TITLE
Fix Operator does not restart pod when initcontainer fails with error

### DIFF
--- a/pkg/k8sutil/resource.go
+++ b/pkg/k8sutil/resource.go
@@ -161,6 +161,12 @@ func CheckIfObjectUpdated(log logr.Logger, desiredType reflect.Type, current, de
 }
 
 func IsPodContainsTerminatedContainer(pod *corev1.Pod) bool {
+	for _, initContainerState := range pod.Status.InitContainerStatuses {
+		if initContainerState.State.Terminated != nil &&
+			strings.Contains(initContainerState.State.Terminated.Reason, "Error") {
+			return true
+		}
+	}
 	for _, containerState := range pod.Status.ContainerStatuses {
 		if containerState.State.Terminated != nil {
 			return true


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |yes|
| New feature?    | no|
| API breaks?     | no|
| Deprecations?   | no|
| Related tickets | fixes #432
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
This PR  fix the operator to proceed when the initcontainer fails with error.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
