### PR TITLE
Reload Envoy ingress controller configuration on KafkaCluster scale up

### DIFF
--- a/pkg/resources/envoy/configmap.go
+++ b/pkg/resources/envoy/configmap.go
@@ -38,12 +38,12 @@ import (
 func (r *Reconciler) configMap(log logr.Logger) runtime.Object {
 	configMap := &corev1.ConfigMap{
 		ObjectMeta: templates.ObjectMeta(envoyVolumeAndConfigName, labelSelector, r.KafkaCluster),
-		Data:       map[string]string{"envoy.yaml": generateEnvoyConfig(r.KafkaCluster, log)},
+		Data:       map[string]string{"envoy.yaml": GenerateEnvoyConfig(r.KafkaCluster, log)},
 	}
 	return configMap
 }
 
-func generateEnvoyConfig(kc *v1beta1.KafkaCluster, log logr.Logger) string {
+func GenerateEnvoyConfig(kc *v1beta1.KafkaCluster, log logr.Logger) string {
 	//TODO support multiple external listener by removing [0] (baluchicken)
 	adminConfig := envoybootstrap.Admin{
 		AccessLogPath: "/tmp/admin_access.log",


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #438
| License         | Apache 2.0


### What's in this PR?
Maintain a hash for the envoy.yaml config in envoy Deployment
so whenever a change occurs in envoy.yaml the Deployment is rolling restarted.



### Why?
See  #438

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
