### PR TITLE
Remove helm 2 support from chart since it causing upgrading issues

### DIFF
--- a/charts/kafka-operator/Chart.yaml
+++ b/charts/kafka-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kafka-operator
-version: 0.2.22
+version: 0.3.0
 description: kafka-operator manages Kafka deployments on Kubernetes
 sources:
   - https://github.com/banzaicloud/kafka-operator

--- a/charts/kafka-operator/crds/operator-kafka-crd.yaml
+++ b/charts/kafka-operator/crds/operator-kafka-crd.yaml
@@ -1,11 +1,8 @@
-
----
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.2.5
-    helm.sh/hook: crd-install
   creationTimestamp: null
   name: kafkaclusters.kafka.banzaicloud.io
 spec:

--- a/charts/kafka-operator/crds/operator-kafka-topic-crd.yaml
+++ b/charts/kafka-operator/crds/operator-kafka-topic-crd.yaml
@@ -1,11 +1,8 @@
-
----
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.2.5
-    helm.sh/hook: crd-install
   creationTimestamp: null
   name: kafkatopics.kafka.banzaicloud.io
 spec:

--- a/charts/kafka-operator/crds/operator-kafka-user-crd.yaml
+++ b/charts/kafka-operator/crds/operator-kafka-user-crd.yaml
@@ -1,11 +1,8 @@
-
----
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.2.5
-    helm.sh/hook: crd-install
   creationTimestamp: null
   name: kafkausers.kafka.banzaicloud.io
 spec:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes|
| New feature?    | no|
| API breaks?     | no|
| Deprecations?   | no|
| Related tickets | fixes #444 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
This PR drops helm 2.x support on charts and fixes the upgrade issue which caused CRD deletions.
Just a quick explanation:
- It turned out helm 3 lacks the whole crd lifecycle process.
- Also if you had the crds under /templates and you move things out to crds dir like the helm 3 best practices suggests.
Helm will follow the following flow: 1. checks the crds in the crds dir, awesome everything is there. 2. applies the templates from the templates dir, ohh no no more crds here just delete them.
- Also it turns out it cannot handle helm 2 annotations. If the annotation is present the rendering simply fails silently. It cause CRD deletion because none of the CRDs will be generated inside the template dir.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)