### PR TITLE
Fix resizepvc alert command, do not mutate the brokerConfigGroups specs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,5 +14,8 @@ indent_style = tab
 [*.yaml]
 indent_size = 2
 
+[*.yml]
+indent_size = 2
+
 [{Makefile,*.mk}]
 indent_style = tab

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,24 @@
+name: Docker
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - "^v?[0-9]+.[0-9]+.[0-9]+"
+jobs:
+  docker:
+    name: Docker
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Build kafka-operator
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ github.actor }}
+          password: ${{ secrets.CR_PAT }}
+          registry: ghcr.io
+          repository: banzaicloud/kafka-operator
+          dockerfile: Dockerfile
+          tag_with_ref: true
+          add_git_labels: true

--- a/config/samples/kafkacluster-prometheus.yaml
+++ b/config/samples/kafkacluster-prometheus.yaml
@@ -126,18 +126,16 @@ spec:
         summary: 'low partition count'
         command: 'downScale'
     - alert: RemainingDiskSpaceLow
-      expr: kubelet_volume_stats_available_bytes{persistentvolumeclaim=~"kafka-.*"} / kubelet_volume_stats_capacity_bytes{persistentvolumeclaim=~"kafka-.*"} * 100 < 30
+      expr: (kubelet_volume_stats_available_bytes{job="kubelet",metrics_path="/metrics",namespace=~".*",persistentvolumeclaim=~"kafka-.*"}/ kubelet_volume_stats_capacity_bytes{job="kubelet",metrics_path="/metrics",namespace=~".*",persistentvolumeclaim=~"kafka-.*"})< 0.15 and predict_linear(kubelet_volume_stats_available_bytes{job="kubelet",metrics_path="/metrics",namespace=~".*",persistentvolumeclaim=~"kafka-.*"}[6h], 4 * 24 * 3600) < 0
       for: 2m
       labels:
         severity: alert
         alertGroup: kafka
       annotations:
-        description: 'broker {{ $labels.brokerId }} has low disk space'
+        description: 'broker has low disk space'
         summary: 'low diskspace'
-        storageClass: 'gp2'
-        mountPathPrefix: '/kafkalog'
-        diskSize: '10G'
-        command: 'addPvc'
+        command: "resizePvc"
+        incrementBy: "10G"
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/internal/alertmanager/currentalert/current_alerts.go
+++ b/internal/alertmanager/currentalert/current_alerts.go
@@ -129,13 +129,16 @@ func (a *currentAlerts) HandleAlert(alertFp model.Fingerprint, client client.Cli
 			IgnoreCCStatus: a.IgnoreCCStatus,
 			Log:            log,
 		}
+		// if alertProcessed is false without an error the alert is skipped because
+		// - cluster is not ready
+		// - alert has to be skipped because of broker upscale/downscale limits
+		// - unknown command is presented
+		// on every other case examineAlert will throw an error
 		alertProcessed, err := e.examineAlert(rollingUpgradeAlertCount)
 		if err != nil {
 			return nil, err
 		}
-		if !alertProcessed {
-			a.alerts[alertFp].Processed = true
-		}
+		a.alerts[alertFp].Processed = alertProcessed
 	}
 	return a.alerts[alertFp], nil
 }

--- a/internal/alertmanager/currentalert/process.go
+++ b/internal/alertmanager/currentalert/process.go
@@ -152,7 +152,7 @@ func (e *examiner) processAlert(ds disableScaling) (bool, error) {
 		}
 		if ds.Down {
 			e.Log.Info("downscale is skipped due to downscale limit")
-			return true, nil
+			return false, nil
 		}
 		err := downScale(e.Log, e.Alert.Labels, e.Client)
 		if err != nil {
@@ -167,7 +167,7 @@ func (e *examiner) processAlert(ds disableScaling) (bool, error) {
 		}
 		if ds.Up {
 			e.Log.Info("upscale is skipped due to upscale limit")
-			return true, nil
+			return false, nil
 		}
 		err := upScale(e.Log, e.Alert.Labels, e.Alert.Annotations, e.Client)
 		if err != nil {

--- a/internal/alertmanager/currentalert/process.go
+++ b/internal/alertmanager/currentalert/process.go
@@ -173,7 +173,8 @@ func (e *examiner) processAlert(ds disableScaling) (bool, error) {
 		if err != nil {
 			return false, err
 		}
-
+		//Used only for testing purposes
+	case "testing":
 		return true, nil
 	}
 	return false, nil

--- a/internal/alertmanager/currentalert/process_test.go
+++ b/internal/alertmanager/currentalert/process_test.go
@@ -173,7 +173,7 @@ func Test_resizePvc(t *testing.T) {
 					},
 					Brokers: []v1beta1.Broker{
 						{
-							Id:                int32(0),
+							Id: int32(0),
 							BrokerConfig: &v1beta1.BrokerConfig{
 								StorageConfigs: []v1beta1.StorageConfig{
 									{


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |yes|
| New feature?    | no|
| API breaks?     | no|
| Deprecations?   | no|
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
This PR fixes the resizepvc alert command, since it mutated the brokerConfigGroups as well. It lead to unnecessary updates to unaffected  brokers PV.
PR also adds github actions dockerimage build and pushes to the new github registry.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [x] Check alert manager processed feature durability
