### PR TITLE
Clean removal of brokers from envoy ingress controller on cluster scale-down

### DIFF
--- a/pkg/resources/envoy/configmap.go
+++ b/pkg/resources/envoy/configmap.go
@@ -63,7 +63,7 @@ func GenerateEnvoyConfig(kc *v1beta1.KafkaCluster, log logr.Logger) string {
 	var listeners []*envoyapi.Listener
 	var clusters []*envoyapi.Cluster
 
-	for _, brokerId := range util.GetBrokerIdsFromStatus(kc.Status.BrokersState) {
+	for _, brokerId := range util.GetBrokerIdsFromStatus(kc.Status.BrokersState, log) {
 		listeners = append(listeners, &envoyapi.Listener{
 			Address: &envoycore.Address{
 				Address: &envoycore.Address_SocketAddress{

--- a/pkg/resources/envoy/deployment.go
+++ b/pkg/resources/envoy/deployment.go
@@ -33,7 +33,7 @@ import (
 func (r *Reconciler) deployment(log logr.Logger) runtime.Object {
 
 	exposedPorts := getExposedContainerPorts(r.KafkaCluster.Spec.ListenersConfig.ExternalListeners,
-		util.GetBrokerIdsFromStatus(r.KafkaCluster.Status.BrokersState))
+		util.GetBrokerIdsFromStatus(r.KafkaCluster.Status.BrokersState, log))
 	volumes := []corev1.Volume{
 		{
 			Name: envoyVolumeAndConfigName,

--- a/pkg/resources/envoy/loadbalancer.go
+++ b/pkg/resources/envoy/loadbalancer.go
@@ -33,7 +33,7 @@ import (
 func (r *Reconciler) loadBalancer(log logr.Logger) runtime.Object {
 
 	exposedPorts := getExposedServicePorts(r.KafkaCluster.Spec.ListenersConfig.ExternalListeners,
-		util.GetBrokerIdsFromStatus(r.KafkaCluster.Status.BrokersState))
+		util.GetBrokerIdsFromStatus(r.KafkaCluster.Status.BrokersState, log))
 
 	service := &corev1.Service{
 		ObjectMeta: templates.ObjectMetaWithAnnotations(envoyutils.EnvoyServiceName, map[string]string{},

--- a/pkg/resources/istioingress/gateway.go
+++ b/pkg/resources/istioingress/gateway.go
@@ -45,14 +45,14 @@ func generateServers(kc *v1beta1.KafkaCluster, externalListenerConfig v1beta1.Ex
 		protocol = v1alpha3.ProtocolTLS
 	}
 
-	brokerIds := util.GetBrokerIdsFromStatus(kc.Status.BrokersState)
+	brokerIds := util.GetBrokerIdsFromStatus(kc.Status.BrokersState, log)
 
 	for _, brokerId := range brokerIds {
 		servers = append(servers, v1alpha3.Server{
 			Port: &v1alpha3.Port{
 				Number:   int(externalListenerConfig.ExternalStartingPort) + brokerId,
 				Protocol: protocol,
-				Name:     fmt.Sprintf("broker-%d", brokerId),
+				Name:     fmt.Sprintf("tcp-broker-%d", brokerId),
 			},
 			TLS:   tlsConfig,
 			Hosts: []string{"*"},
@@ -63,7 +63,7 @@ func generateServers(kc *v1beta1.KafkaCluster, externalListenerConfig v1beta1.Ex
 			Port: &v1alpha3.Port{
 				Number:   int(kc.Spec.ListenersConfig.InternalListeners[0].ContainerPort),
 				Protocol: protocol,
-				Name:     allBrokers,
+				Name:     "tcp-" + allBrokers,
 			},
 			Hosts: []string{"*"},
 			TLS:   tlsConfig,

--- a/pkg/resources/istioingress/meshgateway.go
+++ b/pkg/resources/istioingress/meshgateway.go
@@ -49,14 +49,14 @@ func (r *Reconciler) meshgateway(log logr.Logger, externalListenerConfig v1beta1
 				},
 				ServiceType: corev1.ServiceTypeLoadBalancer,
 			},
-			Ports: generateExternalPorts(util.GetBrokerIdsFromStatus(r.KafkaCluster.Status.BrokersState),
+			Ports: generateExternalPorts(util.GetBrokerIdsFromStatus(r.KafkaCluster.Status.BrokersState, log),
 				externalListenerConfig),
 			Type: istioOperatorApi.GatewayTypeIngress,
 		},
 	}
 	if !r.KafkaCluster.Spec.HeadlessServiceEnabled && len(r.KafkaCluster.Spec.ListenersConfig.ExternalListeners) > 0 {
 		mgateway.Spec.Ports = append(mgateway.Spec.Ports, corev1.ServicePort{
-			Name:       allBrokers,
+			Name:       "tcp-" + allBrokers,
 			TargetPort: intstr.FromInt(int(r.KafkaCluster.Spec.ListenersConfig.InternalListeners[0].ContainerPort)),
 			Port:       r.KafkaCluster.Spec.ListenersConfig.InternalListeners[0].ContainerPort,
 		})
@@ -68,7 +68,7 @@ func generateExternalPorts(brokerIds []int, externalListenerConfig v1beta1.Exter
 	generatedPorts := make([]corev1.ServicePort, 0)
 	for _, brokerId := range brokerIds {
 		generatedPorts = append(generatedPorts, corev1.ServicePort{
-			Name:       fmt.Sprintf("broker-%d", brokerId),
+			Name:       fmt.Sprintf("tcp-broker-%d", brokerId),
 			TargetPort: intstr.FromInt(int(externalListenerConfig.ExternalStartingPort) + brokerId),
 			Port:       externalListenerConfig.ExternalStartingPort + int32(brokerId),
 		})

--- a/pkg/resources/istioingress/virtualservice.go
+++ b/pkg/resources/istioingress/virtualservice.go
@@ -54,7 +54,7 @@ func (r *Reconciler) virtualService(log logr.Logger, externalListenerConfig v1be
 func generateTlsRoutes(kc *v1beta1.KafkaCluster, externalListenerConfig v1beta1.ExternalListenerConfig, log logr.Logger) []v1alpha3.TLSRoute {
 	tlsRoutes := make([]v1alpha3.TLSRoute, 0)
 
-	brokerIds := util.GetBrokerIdsFromStatus(kc.Status.BrokersState)
+	brokerIds := util.GetBrokerIdsFromStatus(kc.Status.BrokersState, log)
 
 	for _, brokerId := range brokerIds {
 		tlsRoutes = append(tlsRoutes, v1alpha3.TLSRoute{
@@ -99,7 +99,7 @@ func generateTlsRoutes(kc *v1beta1.KafkaCluster, externalListenerConfig v1beta1.
 func generateTcpRoutes(kc *v1beta1.KafkaCluster, externalListenerConfig v1beta1.ExternalListenerConfig, log logr.Logger) []v1alpha3.TCPRoute {
 	tcpRoutes := make([]v1alpha3.TCPRoute, 0)
 
-	brokerIds := util.GetBrokerIdsFromStatus(kc.Status.BrokersState)
+	brokerIds := util.GetBrokerIdsFromStatus(kc.Status.BrokersState, log)
 
 	for _, brokerId := range brokerIds {
 		tcpRoutes = append(tcpRoutes, v1alpha3.TCPRoute{

--- a/pkg/resources/kafka/kafka.go
+++ b/pkg/resources/kafka/kafka.go
@@ -198,8 +198,6 @@ func (r *Reconciler) Reconcile(log logr.Logger) error {
 		}
 		lbIPs = append(lbIPs, lbIP)
 	}
-	//TODO remove after testing
-	//lBIp := "192.168.0.1"
 
 	// Setup the PKI if using SSL
 	if r.KafkaCluster.Spec.ListenersConfig.SSLSecrets != nil {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -187,6 +187,7 @@ func GetBrokerIdsFromStatus(brokerStatuses map[string]v1beta1.BrokerState, log l
 		id, err := strconv.Atoi(brokerId)
 		if err != nil {
 			log.Error(err, "could not parse brokerId properly")
+			continue
 		}
 		brokerIds = append(brokerIds, id)
 	}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -180,6 +180,16 @@ func AreStringSlicesIdentical(a, b []string) bool {
 	return reflect.DeepEqual(a, b)
 }
 
+func GetBrokerIdsFromStatus(brokerStatuses map[string]v1beta1.BrokerState) []int {
+	brokerIds := make([]int, 0, len(brokerStatuses))
+	for brokerId, _ := range brokerStatuses {
+		id, _ := strconv.Atoi(brokerId)
+		brokerIds = append(brokerIds, id)
+	}
+	sort.Ints(brokerIds)
+	return brokerIds
+}
+
 // GetBrokerConfig compose the brokerConfig for a given broker
 func GetBrokerConfig(broker v1beta1.Broker, clusterSpec v1beta1.KafkaClusterSpec) (*v1beta1.BrokerConfig, error) {
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"emperror.dev/errors"
+	"github.com/go-logr/logr"
 	"github.com/imdario/mergo"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -180,10 +181,13 @@ func AreStringSlicesIdentical(a, b []string) bool {
 	return reflect.DeepEqual(a, b)
 }
 
-func GetBrokerIdsFromStatus(brokerStatuses map[string]v1beta1.BrokerState) []int {
+func GetBrokerIdsFromStatus(brokerStatuses map[string]v1beta1.BrokerState, log logr.Logger) []int {
 	brokerIds := make([]int, 0, len(brokerStatuses))
-	for brokerId, _ := range brokerStatuses {
-		id, _ := strconv.Atoi(brokerId)
+	for brokerId := range brokerStatuses {
+		id, err := strconv.Atoi(brokerId)
+		if err != nil {
+			log.Error(err, "could not parse brokerId properly")
+		}
 		brokerIds = append(brokerIds, id)
 	}
 	sort.Ints(brokerIds)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |yes|
| New feature?    | no|
| API breaks?     | no|
| Deprecations?   | no|
| Related tickets | fixes #440 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Like described in issue 440, this PR instead of using spec to determine which broker is available at the moment. It uses the Status field which is a more reliable source for this information.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)