### PR TITLE
Fix default value for crd.enabled in README.md

### DIFF
--- a/charts/kafka-operator/README.md
+++ b/charts/kafka-operator/README.md
@@ -75,7 +75,7 @@ Parameter | Description | Default
 `tolerations` | Operator pod tolerations can be set | `[]`
 `affinity` | Operator pod affinity can be set | `{}`
 `nameOverride` | Release name can be overwritten | `""`
-`crd.enabled` | Whether to enable CRD installation(used for upgrade only) | `true`
+`crd.enabled` | Whether to enable CRD installation(used for upgrade only) | `false`
 `fullnameOverride` | Release full name can be overwritten | `""`
 `certManager.namespace` | Operator will look for the cert manager in this namespace | `cert-manager`
 `certManager.enabled` | Operator will integrate with the cert manager | `false`


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Fix the documenation.


### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
`crd.enabled` default value was changed to false in [this commit](https://github.com/banzaicloud/kafka-operator/commit/d3b226aa6041020b8306d398d223f952fdd0ec23#diff-6fe0c8aae215aaea444d971b10395ae2). So I would like to up-to-date the documentation.



### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] User guide and development docs updated (if needed)

