### PR TITLE
Allow to override log4j configuration for kafkaclusters.

### DIFF
--- a/charts/kafka-operator/templates/crds.yaml
+++ b/charts/kafka-operator/templates/crds.yaml
@@ -100,6 +100,10 @@ spec:
                     type: string
                   kafkaJvmPerfOpts:
                     type: string
+                  log4jConfig:
+                    description: With the use of this config broker log4jConfig can
+                      be reconfigured if left empty the default config will be used
+                    type: string
                   nodeAffinity:
                     description: Node affinity is a group of node affinity scheduling
                       rules.

--- a/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
+++ b/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
@@ -101,6 +101,10 @@ spec:
                     type: string
                   kafkaJvmPerfOpts:
                     type: string
+                  log4jConfig:
+                    description: With the use of this config broker log4jConfig can
+                      be reconfigured, if left empty the default config will be used
+                    type: string
                   nodeAffinity:
                     description: Node affinity is a group of node affinity scheduling
                       rules.
@@ -559,6 +563,11 @@ spec:
                       kafkaHeapOpts:
                         type: string
                       kafkaJvmPerfOpts:
+                        type: string
+                      log4jConfig:
+                        description: With the use of this config broker log4jConfig
+                          can be reconfigured, if left empty the default config will
+                          be used
                         type: string
                       nodeAffinity:
                         description: Node affinity is a group of node affinity scheduling

--- a/pkg/resources/cruisecontrol/configmap.go
+++ b/pkg/resources/cruisecontrol/configmap.go
@@ -49,7 +49,7 @@ func (r *Reconciler) configMap(clientPass, capacityConfig string) runtime.Object
 				generateSSLConfig(&r.KafkaCluster.Spec.ListenersConfig, clientPass),
 			"capacity.json":       capacityConfig,
 			"clusterConfigs.json": r.KafkaCluster.Spec.CruiseControlConfig.ClusterConfig,
-			"log4j.properties": r.KafkaCluster.Spec.CruiseControlConfig.GetCCLog4jConfig(),
+			"log4j.properties":    r.KafkaCluster.Spec.CruiseControlConfig.GetCCLog4jConfig(),
 		},
 	}
 	return configMap

--- a/pkg/resources/cruisecontrol/deployment.go
+++ b/pkg/resources/cruisecontrol/deployment.go
@@ -178,12 +178,14 @@ func GeneratePodAnnotations(kafkaCluster *v1beta1.KafkaCluster, log logr.Logger,
 	hashedCruiseControlCapacityJson := sha256.Sum256([]byte(capacityConfig))
 	hashedCruiseControlConfigJson := sha256.Sum256([]byte(kafkaCluster.Spec.CruiseControlConfig.Config))
 	hashedCruiseControlClusterConfigJson := sha256.Sum256([]byte(kafkaCluster.Spec.CruiseControlConfig.ClusterConfig))
+	hashedCruiseControlLogConfigJson := sha256.Sum256([]byte(kafkaCluster.Spec.CruiseControlConfig.GetCCLog4jConfig()))
 
 	annotations := []map[string]string{
 		{
 			"cruiseControlCapacity.json":      hex.EncodeToString(hashedCruiseControlCapacityJson[:]),
 			"cruiseControlConfig.json":        hex.EncodeToString(hashedCruiseControlConfigJson[:]),
 			"cruiseControlClusterConfig.json": hex.EncodeToString(hashedCruiseControlClusterConfigJson[:]),
+			"cruiseControlLogConfig.json":     hex.EncodeToString(hashedCruiseControlLogConfigJson[:]),
 		},
 		kafkaCluster.Spec.CruiseControlConfig.GetCruiseControlAnnotations(),
 	}

--- a/pkg/resources/kafka/configmap.go
+++ b/pkg/resources/kafka/configmap.go
@@ -110,7 +110,7 @@ func generateSuperUsers(users []string) (suStrings []string) {
 }
 
 func (r *Reconciler) configMap(id int32, brokerConfig *v1beta1.BrokerConfig, loadBalancerIPs []string, serverPass, clientPass string, superUsers []string, log logr.Logger) runtime.Object {
-	return &corev1.ConfigMap{
+	brokerConf := &corev1.ConfigMap{
 		ObjectMeta: templates.ObjectMeta(
 			fmt.Sprintf(brokerConfigTemplate+"-%d", r.KafkaCluster.Name, id),
 			util.MergeLabels(
@@ -121,6 +121,10 @@ func (r *Reconciler) configMap(id int32, brokerConfig *v1beta1.BrokerConfig, loa
 		),
 		Data: map[string]string{"broker-config": r.generateBrokerConfig(id, brokerConfig, loadBalancerIPs, serverPass, clientPass, superUsers, log)},
 	}
+	if brokerConfig.Log4jConfig != "" {
+		brokerConf.Data["log4j.properties"] = brokerConfig.Log4jConfig
+	}
+	return brokerConf
 }
 
 func generateAdvertisedListenerConfig(id int32, l v1beta1.ListenersConfig, loadBalancerIPs []string, domain, namespace, crName string, headlessServiceEnabled bool) string {

--- a/pkg/resources/kafka/pod.go
+++ b/pkg/resources/kafka/pod.go
@@ -353,6 +353,13 @@ func generateEnvConfig(brokerConfig *v1beta1.BrokerConfig, defaultEnvVars, clust
 		envs[v.Name] = v
 	}
 
+	if brokerConfig.Log4jConfig != "" {
+		envs["KAFKA_LOG4J_OPTS"] = corev1.EnvVar{
+			Name:  "KAFKA_LOG4J_OPTS",
+			Value: "-Dlog4j.configuration=file:/config/log4j.properties",
+		}
+	}
+
 	if _, ok := envs["KAFKA_HEAP_OPTS"]; !ok || brokerConfig.KafkaHeapOpts != "" {
 		envs["KAFKA_HEAP_OPTS"] = corev1.EnvVar{
 			Name:  "KAFKA_HEAP_OPTS",

--- a/pkg/sdk/v1beta1/kafkacluster_types.go
+++ b/pkg/sdk/v1beta1/kafkacluster_types.go
@@ -104,6 +104,9 @@ type BrokerConfig struct {
 	Tolerations        []corev1.Toleration           `json:"tolerations,omitempty"`
 	KafkaHeapOpts      string                        `json:"kafkaHeapOpts,omitempty"`
 	KafkaJVMPerfOpts   string                        `json:"kafkaJvmPerfOpts,omitempty"`
+	// With the use of this config broker log4jConfig can be reconfigured, if left empty
+	// the default config will be used
+	Log4jConfig string `json:"log4jConfig,omitempty"`
 	// Custom annotations for the broker pods - e.g.: Prometheus scraping annotations:
 	// prometheus.io/scrape: "true"
 	// prometheus.io/port: "9020"


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no|
| New feature?    |yes|
| API breaks?     | no|
| Deprecations?   | no|
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
This PR adds the option to set the log4j setting for the kafka brokers. It also adds hash to CC deployment to retrigger CC when the log4j config changed for CC.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
