### PR TITLE
Add the ability to not generate CC capacity config hash

### DIFF
--- a/charts/kafka-operator/templates/crds.yaml
+++ b/charts/kafka-operator/templates/crds.yaml
@@ -101,8 +101,7 @@ spec:
                   kafkaJvmPerfOpts:
                     type: string
                   log4jConfig:
-                    description: With the use of this config broker log4jConfig can
-                      be reconfigured if left empty the default config will be used
+                    description: Override for the default log4j configuration
                     type: string
                   nodeAffinity:
                     description: Node affinity is a group of node affinity scheduling

--- a/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
+++ b/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
@@ -102,8 +102,7 @@ spec:
                   kafkaJvmPerfOpts:
                     type: string
                   log4jConfig:
-                    description: With the use of this config broker log4jConfig can
-                      be reconfigured, if left empty the default config will be used
+                    description: Override for the default log4j configuration
                     type: string
                   nodeAffinity:
                     description: Node affinity is a group of node affinity scheduling
@@ -565,9 +564,7 @@ spec:
                       kafkaJvmPerfOpts:
                         type: string
                       log4jConfig:
-                        description: With the use of this config broker log4jConfig
-                          can be reconfigured, if left empty the default config will
-                          be used
+                        description: Override for the default log4j configuration
                         type: string
                       nodeAffinity:
                         description: Node affinity is a group of node affinity scheduling

--- a/pkg/resources/cruisecontrol/cruisecontrol.go
+++ b/pkg/resources/cruisecontrol/cruisecontrol.go
@@ -42,6 +42,7 @@ const (
 	jmxVolumePath               = "/opt/jmx-exporter/"
 	jmxVolumeName               = "jmx-jar-data"
 	metricsPort                 = 9020
+	capacityConfigAnnotation    = "cruise-control.banzaicloud.com/broker-capacity-config"
 )
 
 // Reconciler implements the Component Reconciler
@@ -122,7 +123,7 @@ func (r *Reconciler) Reconcile(log logr.Logger) error {
 				return errors.WrapIfWithDetails(err, "failed to reconcile resource", "resource", o.GetObjectKind().GroupVersionKind())
 			}
 
-			podAnnotations := GeneratePodAnnotations(r.KafkaCluster, log, capacityConfig)
+			podAnnotations := GeneratePodAnnotations(r.KafkaCluster, capacityConfig)
 
 			o = r.deployment(log, podAnnotations)
 			err = k8sutil.Reconcile(log, r.Client, o, r.KafkaCluster)

--- a/pkg/sdk/v1beta1/kafkacluster_types.go
+++ b/pkg/sdk/v1beta1/kafkacluster_types.go
@@ -104,8 +104,7 @@ type BrokerConfig struct {
 	Tolerations        []corev1.Toleration           `json:"tolerations,omitempty"`
 	KafkaHeapOpts      string                        `json:"kafkaHeapOpts,omitempty"`
 	KafkaJVMPerfOpts   string                        `json:"kafkaJvmPerfOpts,omitempty"`
-	// With the use of this config broker log4jConfig can be reconfigured, if left empty
-	// the default config will be used
+	// Override for the default log4j configuration
 	Log4jConfig string `json:"log4jConfig,omitempty"`
 	// Custom annotations for the broker pods - e.g.: Prometheus scraping annotations:
 	// prometheus.io/scrape: "true"


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |no |
| New feature?    |yes|
| API breaks?     | no|
| Deprecations?   | no|
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
This PR fixes the the log4j description thx @hi-im-aren.
Also it adds the ability to instruct the operator not to generate capacity config hash when some CC annotation is set.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
