### PR TITLE
Use cluster namespace in cluster issuer name to make it unique

### DIFF
--- a/pkg/pki/certmanagerpki/certmanager_pki.go
+++ b/pkg/pki/certmanagerpki/certmanager_pki.go
@@ -230,7 +230,7 @@ func caCertForCluster(cluster *v1beta1.KafkaCluster) *certv1.Certificate {
 
 func mainIssuerForCluster(cluster *v1beta1.KafkaCluster, scheme *runtime.Scheme) *certv1.ClusterIssuer {
 	clusterIssuerMeta := templates.ObjectMeta(
-		fmt.Sprintf(pkicommon.BrokerClusterIssuerTemplate, cluster.Name, cluster.Namespace),
+		fmt.Sprintf(pkicommon.BrokerClusterIssuerTemplate, cluster.Namespace, cluster.Name),
 		pkicommon.LabelsForKafkaPKI(cluster.Name, cluster.Namespace), cluster)
 	clusterIssuerMeta.Namespace = metav1.NamespaceAll
 	issuer := &certv1.ClusterIssuer{

--- a/pkg/pki/certmanagerpki/certmanager_pki.go
+++ b/pkg/pki/certmanagerpki/certmanager_pki.go
@@ -182,7 +182,7 @@ func caSecretForProvidedCert(ctx context.Context, client client.Client, cluster 
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf(pkicommon.BrokerCACertTemplate, cluster.Name),
 			Namespace: namespaceCertManager,
-			Labels:    pkicommon.LabelsForKafkaPKI(cluster.Name),
+			Labels:    pkicommon.LabelsForKafkaPKI(cluster.Name, cluster.Namespace),
 		},
 		Data: map[string][]byte{
 			v1alpha1.CoreCACertKey:  caCert,
@@ -194,7 +194,8 @@ func caSecretForProvidedCert(ctx context.Context, client client.Client, cluster 
 }
 
 func selfSignerForCluster(cluster *v1beta1.KafkaCluster, scheme *runtime.Scheme) *certv1.ClusterIssuer {
-	selfsignerMeta := templates.ObjectMeta(fmt.Sprintf(pkicommon.BrokerSelfSignerTemplate, cluster.Name), pkicommon.LabelsForKafkaPKI(cluster.Name), cluster)
+	selfsignerMeta := templates.ObjectMeta(fmt.Sprintf(pkicommon.BrokerSelfSignerTemplate, cluster.Name),
+		pkicommon.LabelsForKafkaPKI(cluster.Name, cluster.Namespace), cluster)
 	selfsignerMeta.Namespace = metav1.NamespaceAll
 	selfsigner := &certv1.ClusterIssuer{
 		ObjectMeta: selfsignerMeta,
@@ -213,7 +214,7 @@ func caCertForCluster(cluster *v1beta1.KafkaCluster) *certv1.Certificate {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf(pkicommon.BrokerCACertTemplate, cluster.Name),
 			Namespace: namespaceCertManager,
-			Labels:    pkicommon.LabelsForKafkaPKI(cluster.Name),
+			Labels:    pkicommon.LabelsForKafkaPKI(cluster.Name, cluster.Namespace),
 		},
 		Spec: certv1.CertificateSpec{
 			SecretName: fmt.Sprintf(pkicommon.BrokerCACertTemplate, cluster.Name),
@@ -228,7 +229,9 @@ func caCertForCluster(cluster *v1beta1.KafkaCluster) *certv1.Certificate {
 }
 
 func mainIssuerForCluster(cluster *v1beta1.KafkaCluster, scheme *runtime.Scheme) *certv1.ClusterIssuer {
-	clusterIssuerMeta := templates.ObjectMeta(fmt.Sprintf(pkicommon.BrokerIssuerTemplate, cluster.Name), pkicommon.LabelsForKafkaPKI(cluster.Name), cluster)
+	clusterIssuerMeta := templates.ObjectMeta(
+		fmt.Sprintf(pkicommon.BrokerClusterIssuerTemplate, cluster.Name, cluster.Namespace),
+		pkicommon.LabelsForKafkaPKI(cluster.Name, cluster.Namespace), cluster)
 	clusterIssuerMeta.Namespace = metav1.NamespaceAll
 	issuer := &certv1.ClusterIssuer{
 		ObjectMeta: clusterIssuerMeta,
@@ -240,6 +243,5 @@ func mainIssuerForCluster(cluster *v1beta1.KafkaCluster, scheme *runtime.Scheme)
 			},
 		},
 	}
-	controllerutil.SetControllerReference(cluster, issuer, scheme)
 	return issuer
 }

--- a/pkg/pki/certmanagerpki/certmanager_user.go
+++ b/pkg/pki/certmanagerpki/certmanager_user.go
@@ -206,7 +206,8 @@ func (c *certManager) getCA(user *v1alpha1.KafkaUser) (caName, caKind string) {
 		caKind = issuerRef.Kind
 	} else {
 		caKind = certv1.ClusterIssuerKind
-		caName = fmt.Sprintf(pkicommon.BrokerIssuerTemplate, c.cluster.Name)
+		caName = fmt.Sprintf(pkicommon.BrokerClusterIssuerTemplate,
+			c.cluster.Name, c.cluster.Namespace)
 	}
 	// TODO: Do we need to ensure this Issuer is exist?
 	return

--- a/pkg/pki/certmanagerpki/reconcile.go
+++ b/pkg/pki/certmanagerpki/reconcile.go
@@ -32,19 +32,15 @@ import (
 
 // reconcile ensures the given kubernetes object
 func reconcile(ctx context.Context, log logr.Logger, client client.Client, object runtime.Object, cluster *v1beta1.KafkaCluster) (err error) {
-	switch object.(type) {
+	switch o := object.(type) {
 	case *certv1.ClusterIssuer:
-		issuer, _ := object.(*certv1.ClusterIssuer)
-		return reconcileClusterIssuer(ctx, log, client, issuer, cluster)
+		return reconcileClusterIssuer(ctx, log, client, o, cluster)
 	case *certv1.Certificate:
-		cert, _ := object.(*certv1.Certificate)
-		return reconcileCertificate(ctx, log, client, cert, cluster)
+		return reconcileCertificate(ctx, log, client, o, cluster)
 	case *corev1.Secret:
-		secret, _ := object.(*corev1.Secret)
-		return reconcileSecret(ctx, log, client, secret, cluster)
+		return reconcileSecret(ctx, log, client, o, cluster)
 	case *v1alpha1.KafkaUser:
-		user, _ := object.(*v1alpha1.KafkaUser)
-		return reconcileUser(ctx, log, client, user, cluster)
+		return reconcileUser(ctx, log, client, o, cluster)
 	default:
 		panic(fmt.Sprintf("Invalid object type: %v", reflect.TypeOf(object)))
 	}

--- a/pkg/pki/vaultpki/vault_pki.go
+++ b/pkg/pki/vaultpki/vault_pki.go
@@ -97,7 +97,8 @@ func (v *vaultPKI) reconcileBootstrapSecrets(ctx context.Context, scheme *runtim
 	); err != nil {
 		if apierrors.IsNotFound(err) {
 			serverCert := &corev1.Secret{
-				ObjectMeta: templates.ObjectMeta(fmt.Sprintf(pkicommon.BrokerServerCertTemplate, v.cluster.Name), pkicommon.LabelsForKafkaPKI(v.cluster.Name), v.cluster),
+				ObjectMeta: templates.ObjectMeta(fmt.Sprintf(pkicommon.BrokerServerCertTemplate, v.cluster.Name),
+					pkicommon.LabelsForKafkaPKI(v.cluster.Name, v.cluster.Namespace), v.cluster),
 				Data: map[string][]byte{
 					corev1.TLSCertKey:       brokerCert.Certificate,
 					corev1.TLSPrivateKeyKey: brokerCert.Key,
@@ -124,7 +125,8 @@ func (v *vaultPKI) reconcileBootstrapSecrets(ctx context.Context, scheme *runtim
 	); err != nil {
 		if apierrors.IsNotFound(err) {
 			clientCert := &corev1.Secret{
-				ObjectMeta: templates.ObjectMeta(fmt.Sprintf(pkicommon.BrokerControllerTemplate, v.cluster.Name), pkicommon.LabelsForKafkaPKI(v.cluster.Name), v.cluster),
+				ObjectMeta: templates.ObjectMeta(fmt.Sprintf(pkicommon.BrokerControllerTemplate, v.cluster.Name),
+					pkicommon.LabelsForKafkaPKI(v.cluster.Name, v.cluster.Namespace), v.cluster),
 				Data: map[string][]byte{
 					corev1.TLSCertKey:       controllerCert.Certificate,
 					corev1.TLSPrivateKeyKey: controllerCert.Key,

--- a/pkg/util/pki/common.go
+++ b/pkg/util/pki/common.go
@@ -37,6 +37,8 @@ const (
 	BrokerServerCertTemplate = "%s-server-certificate"
 	// BrokerClusterIssuerTemplate is the template used for broker issuer resources
 	BrokerClusterIssuerTemplate = "%s-%s-issuer"
+	// LegacyBrokerClusterIssuerTemplate is the template used earlier for broker issuer resources
+	LegacyBrokerClusterIssuerTemplate = "%s-issuer"
 	// BrokerControllerTemplate is the template used for operator certificate resources
 	BrokerControllerTemplate = "%s-controller"
 	// BrokerControllerFQDNTemplate is combined with the above and cluster namespace
@@ -154,7 +156,7 @@ func clusterDNSNames(cluster *v1beta1.KafkaCluster) (names []string) {
 
 // LabelsForKafkaPKI returns kubernetes labels for a PKI object
 func LabelsForKafkaPKI(name, namespace string) map[string]string {
-	return map[string]string{"app": "kafka", "kafka_issuer": fmt.Sprintf(BrokerClusterIssuerTemplate, name, namespace)}
+	return map[string]string{"app": "kafka", "kafka_issuer": fmt.Sprintf(BrokerClusterIssuerTemplate, namespace, name)}
 }
 
 // BrokerUserForCluster returns a KafkaUser CR for the broker certificates in a KafkaCluster

--- a/pkg/util/pki/pki_common_test.go
+++ b/pkg/util/pki/pki_common_test.go
@@ -78,9 +78,9 @@ func TestGetCommonName(t *testing.T) {
 func TestLabelsForKafkaPKI(t *testing.T) {
 	expected := map[string]string{
 		"app":          "kafka",
-		"kafka_issuer": fmt.Sprintf(BrokerIssuerTemplate, "test"),
+		"kafka_issuer": fmt.Sprintf(BrokerClusterIssuerTemplate, "test", "kafka"),
 	}
-	got := LabelsForKafkaPKI("test")
+	got := LabelsForKafkaPKI("test", "kafka")
 	if !reflect.DeepEqual(got, expected) {
 		t.Error("Expected:", expected, "got:", got)
 	}
@@ -125,7 +125,8 @@ func TestBrokerUserForCluster(t *testing.T) {
 	user := BrokerUserForCluster(cluster, []string{})
 
 	expected := &v1alpha1.KafkaUser{
-		ObjectMeta: templates.ObjectMeta(GetCommonName(cluster), LabelsForKafkaPKI(cluster.Name), cluster),
+		ObjectMeta: templates.ObjectMeta(GetCommonName(cluster),
+			LabelsForKafkaPKI(cluster.Name, cluster.Namespace), cluster),
 		Spec: v1alpha1.KafkaUserSpec{
 			SecretName: fmt.Sprintf(BrokerServerCertTemplate, cluster.Name),
 			DNSNames:   GetInternalDNSNames(cluster),
@@ -148,8 +149,9 @@ func TestControllerUserForCluster(t *testing.T) {
 
 	expected := &v1alpha1.KafkaUser{
 		ObjectMeta: templates.ObjectMeta(
-			fmt.Sprintf(BrokerControllerFQDNTemplate, fmt.Sprintf(BrokerControllerTemplate, cluster.Name), cluster.Namespace, cluster.Spec.GetKubernetesClusterDomain()),
-			LabelsForKafkaPKI(cluster.Name), cluster,
+			fmt.Sprintf(BrokerControllerFQDNTemplate, fmt.Sprintf(BrokerControllerTemplate, cluster.Name),
+				cluster.Namespace, cluster.Spec.GetKubernetesClusterDomain()),
+			LabelsForKafkaPKI(cluster.Name, cluster.Namespace), cluster,
 		),
 		Spec: v1alpha1.KafkaUserSpec{
 			SecretName: fmt.Sprintf(BrokerControllerTemplate, cluster.Name),

--- a/pkg/util/pki/pki_common_test.go
+++ b/pkg/util/pki/pki_common_test.go
@@ -78,7 +78,7 @@ func TestGetCommonName(t *testing.T) {
 func TestLabelsForKafkaPKI(t *testing.T) {
 	expected := map[string]string{
 		"app":          "kafka",
-		"kafka_issuer": fmt.Sprintf(BrokerClusterIssuerTemplate, "test", "kafka"),
+		"kafka_issuer": fmt.Sprintf(BrokerClusterIssuerTemplate, "kafka", "test"),
 	}
 	got := LabelsForKafkaPKI("test", "kafka")
 	if !reflect.DeepEqual(got, expected) {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |yes|
| New feature?    | no|
| API breaks?     | no|
| Deprecations?   | no|
| Related tickets | fixes #372
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
This PR adds unique name to the generated ClusterIssuer. It is useful when you want to separate clusters from each other.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
