### PR TITLE
Use pretty log encoding

### DIFF
--- a/charts/kafka-operator/templates/operator-deployment.yaml
+++ b/charts/kafka-operator/templates/operator-deployment.yaml
@@ -78,6 +78,9 @@ spec:
           {{- if .Values.operator.verboseLogging }}
             - --verbose
           {{- end }}
+          {{ - if .Values.operator.developmentLogging }}
+            - --development
+          {{ - end }}
           image: "{{ .Values.operator.image.repository }}:{{ .Values.operator.image.tag }}"
           imagePullPolicy: {{ .Values.operator.image.pullPolicy }}
           name: manager

--- a/charts/kafka-operator/templates/operator-deployment.yaml
+++ b/charts/kafka-operator/templates/operator-deployment.yaml
@@ -78,9 +78,9 @@ spec:
           {{- if .Values.operator.verboseLogging }}
             - --verbose
           {{- end }}
-          {{ - if .Values.operator.developmentLogging }}
+          {{- if .Values.operator.developmentLogging }}
             - --development
-          {{ - end }}
+          {{- end }}
           image: "{{ .Values.operator.image.repository }}:{{ .Values.operator.image.tag }}"
           imagePullPolicy: {{ .Values.operator.image.pullPolicy }}
           name: manager

--- a/charts/kafka-operator/values.yaml
+++ b/charts/kafka-operator/values.yaml
@@ -20,6 +20,7 @@ operator:
   # set of namespaces where the operator watches resources
   namespaces: ""
   verboseLogging: false
+  developmentLogging: false
   resources:
     limits:
       cpu: 200m

--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/spf13/cast v1.3.1 // indirect
 	github.com/spf13/viper v1.7.1 // indirect
 	go.uber.org/atomic v1.5.1 // indirect
+	go.uber.org/zap v1.10.0
 	google.golang.org/appengine v1.6.6 // indirect
 	google.golang.org/grpc v1.27.1 // indirect
 	k8s.io/api v0.18.9

--- a/main.go
+++ b/main.go
@@ -43,11 +43,11 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	banzaicloudv1alpha1 "github.com/banzaicloud/kafka-operator/api/v1alpha1"
 	banzaicloudv1beta1 "github.com/banzaicloud/kafka-operator/api/v1beta1"
 	"github.com/banzaicloud/kafka-operator/controllers"
+	"github.com/banzaicloud/kafka-operator/pkg/util"
 	"github.com/banzaicloud/kafka-operator/pkg/webhook"
 	// +kubebuilder:scaffold:imports
 )
@@ -77,6 +77,7 @@ func main() {
 		enableLeaderElection bool
 		webhookCertDir       string
 		webhookDisabled      bool
+		developmentLogging   bool
 		verboseLogging       bool
 		certManagerEnabled   bool
 	)
@@ -87,11 +88,12 @@ func main() {
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 	flag.BoolVar(&webhookDisabled, "disable-webhooks", false, "Disable webhooks used to validate custom resources")
 	flag.StringVar(&webhookCertDir, "tls-cert-dir", "/etc/webhook/certs", "The directory with a tls.key and tls.crt for serving HTTPS requests")
+	flag.BoolVar(&developmentLogging, "development", false, "Enable development logging")
 	flag.BoolVar(&verboseLogging, "verbose", false, "Enable verbose logging")
 	flag.BoolVar(&certManagerEnabled, "cert-manager-enabled", false, "Enable cert-manager integration")
 	flag.Parse()
 
-	ctrl.SetLogger(zap.Logger(verboseLogging))
+	ctrl.SetLogger(util.CreateLogger(verboseLogging, developmentLogging))
 
 	//When operator is started to watch resources in a specific set of namespaces, we use the MultiNamespacedCacheBuilder cache.
 	//In this scenario, it is also suggested to restrict the provided authorization to this namespace by replacing the default

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -322,3 +322,24 @@ func TestMergeAnnotations(t *testing.T) {
 		t.Error("Annotations didn't combine correctly")
 	}
 }
+
+func TestCreateLogger(t *testing.T) {
+	logger := CreateLogger(false, false)
+	if logger == nil {
+		t.Fatal("created Logger instance should not be nil")
+	}
+	if logger.V(1).Enabled() {
+		t.Error("debug level should not be enabled")
+	}
+	if !logger.V(0).Enabled() {
+		t.Error("info level should be enabled")
+	}
+
+	logger = CreateLogger(true, true)
+	if !logger.V(1).Enabled() {
+		t.Error("debug level should be enabled")
+	}
+	if !logger.V(0).Enabled() {
+		t.Error("info level should be enabled")
+	}
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
The currently used log encoding is not really suitable for easy reading. I suggest to configure the encoding object provided by zap.
Existing logs:
```
{"level":"info","ts":1603284010.713752,"logger":"controller-runtime.metrics","msg":"metrics server is starting to listen","addr":":8080"}
{"level":"info","ts":1603284010.714328,"logger":"controller-runtime.webhook","msg":"registering webhook","path":"/validate"}
{"level":"info","ts":1603284010.714356,"logger":"setup","msg":"starting manager"}
{"level":"info","ts":1603284010.714595,"logger":"controller-runtime.manager","msg":"starting metrics server","path":"/metrics"}
```
New logs:
```
2020-10-21T14:16:38.154+0200	INFO	controller-runtime.metrics	metrics server is starting to listen	{"addr": ":8080"}
2020-10-21T14:16:38.155+0200	INFO	controller-runtime.webhook	registering webhook	{"path": "/validate"}
2020-10-21T14:16:38.155+0200	INFO	setup	starting manager
2020-10-21T14:16:38.155+0200	INFO	controller-runtime.manager	starting metrics server	{"path": "/metrics"}
```

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
It helps everyone to understand the logs faster.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline

