### PR TITLE
Add debug logs when pod is deleted by the operator

### DIFF
--- a/pkg/resources/kafka/kafka.go
+++ b/pkg/resources/kafka/kafka.go
@@ -751,12 +751,12 @@ func (r *Reconciler) reconcileKafkaPod(log logr.Logger, desiredPod *corev1.Pod) 
 		if k8sutil.IsPodContainsTerminatedContainer(currentPod) {
 			for _, containerState := range currentPod.Status.ContainerStatuses {
 				if containerState.State.Terminated != nil {
-					log.Info("terminated container for broker pod", "pod", currentPod.ObjectMeta.Name, "brokerId", currentPod.Labels["brokerId"],
+					log.Info("terminated container for broker pod", "pod", currentPod.GetName(), "brokerId", currentPod.Labels["brokerId"],
 						"containerName", containerState.Name, "exitCode", containerState.State.Terminated.ExitCode, "reason", containerState.State.Terminated.Reason)
 				}
 			}
 		}
-		log.Info("broker pod deleted", "pod", currentPod.ObjectMeta.Name, "brokerId", currentPod.Labels["brokerId"])
+		log.Info("broker pod deleted", "pod", currentPod.GetName(), "brokerId", currentPod.Labels["brokerId"])
 	}
 	return nil
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0

### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
A few lines of logs have been added in this PR to trace when a kafka broker pod (and service, PVC etc.) is deleted by the operator.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Currently the operator does not display much info, if it deletes a Broker *on purpose*. That is what this PR intended to change.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
