### PR TITLE
Fix envoyConfig configuration in case of headless service disabled

### DIFF
--- a/pkg/resources/kafka/kafka.go
+++ b/pkg/resources/kafka/kafka.go
@@ -384,7 +384,7 @@ OUTERLOOP:
 			if err != nil {
 				return errors.WrapIfWithDetails(err, "could not delete broker", "id", broker.Labels["brokerId"])
 			}
-			log.Info("broker pod deleted", "brokerId",  broker.Labels["brokerId"], "pod", broker.GetName())
+			log.Info("broker pod deleted", "brokerId", broker.Labels["brokerId"], "pod", broker.GetName())
 			configMapName := fmt.Sprintf(brokerConfigTemplate+"-%s", r.KafkaCluster.Name, broker.Labels["brokerId"])
 			err = r.Client.Delete(context.TODO(), &corev1.ConfigMap{ObjectMeta: templates.ObjectMeta(configMapName, LabelsForKafka(r.KafkaCluster.Name), r.KafkaCluster)})
 			if err != nil {

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -180,7 +180,7 @@ empty.config=
 	if props["broker.id"] != "1" ||
 		props["advertised.listener"] != "broker-1:29092" ||
 		props["empty.config"] != "" ||
-		props["trailing.whitespace"] != "foobar"{
+		props["trailing.whitespace"] != "foobar" {
 		t.Error("Error properties not loaded correctly")
 	}
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes|
| New feature?    | no|
| API breaks?     | no|
| Deprecations?   | no|
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
This PR fixes the envoy ingresscontroller configuration when using kafka cluster with headless service disabled.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)