### PR TITLE
Add uriSans field to kafkaUser generated certs

### DIFF
--- a/controllers/kafkauser_controller.go
+++ b/controllers/kafkauser_controller.go
@@ -159,7 +159,7 @@ func (r *KafkaUserReconciler) Reconcile(request reconcile.Request) (reconcile.Re
 		// using the vault backend, then tried to delete and fix it. Should probably
 		// have the PKIManager export a GetUserCertificate specifically for deletions
 		// that will allow the error to fall through if the certificate doesn't exist.
-		user, err := pkiManager.ReconcileUserCertificate(ctx, instance, r.Scheme)
+		user, err := pkiManager.ReconcileUserCertificate(ctx, instance, r.Scheme, cluster.Spec.GetKubernetesClusterDomain())
 		if err != nil {
 			switch errors.Cause(err).(type) {
 			case errorfactory.ResourceNotReady:

--- a/pkg/pki/certmanagerpki/certmanager.go
+++ b/pkg/pki/certmanagerpki/certmanager.go
@@ -22,6 +22,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const uriSanTemplate = "spiffe://%s/%s"
+
 var namespaceCertManager string
 
 func init() {

--- a/pkg/pki/certmanagerpki/certmanager.go
+++ b/pkg/pki/certmanagerpki/certmanager.go
@@ -22,7 +22,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const uriSanTemplate = "spiffe://%s/%s"
+const spiffeIdTemplate = "spiffe://%s/%s"
 
 var namespaceCertManager string
 

--- a/pkg/pki/certmanagerpki/certmanager_user.go
+++ b/pkg/pki/certmanagerpki/certmanager_user.go
@@ -36,7 +36,7 @@ import (
 )
 
 // FinalizeUserCertificate for cert-manager backend auto returns because controller references handle cleanup
-func (c *certManager) FinalizeUserCertificate(ctx context.Context, user *v1alpha1.KafkaUser) (err error) {
+func (c *certManager) FinalizeUserCertificate(_ context.Context, _ *v1alpha1.KafkaUser) (err error) {
 	return
 }
 
@@ -168,7 +168,7 @@ func (c *certManager) clusterCertificateForUser(
 			SecretName:  user.Spec.SecretName,
 			KeyEncoding: certv1.PKCS8,
 			CommonName:  user.GetName(),
-			URISANs:     []string{fmt.Sprintf(uriSanTemplate, clusterDomain, user.GetName())},
+			URISANs:     []string{fmt.Sprintf(spiffeIdTemplate, clusterDomain, user.GetName())},
 			Usages:      []certv1.KeyUsage{certv1.UsageClientAuth, certv1.UsageServerAuth},
 			IssuerRef: certmeta.ObjectReference{
 				Name: caName,

--- a/pkg/pki/certmanagerpki/certmanager_user_test.go
+++ b/pkg/pki/certmanagerpki/certmanager_user_test.go
@@ -58,11 +58,12 @@ func TestFinalizeUserCertificate(t *testing.T) {
 }
 
 func TestReconcileUserCertificate(t *testing.T) {
+	clusterDomain := "cluster.local"
 	manager := newMock(newMockCluster())
 	ctx := context.Background()
 
 	manager.client.Create(context.TODO(), newMockUser())
-	if _, err := manager.ReconcileUserCertificate(ctx, newMockUser(), scheme.Scheme); err == nil {
+	if _, err := manager.ReconcileUserCertificate(ctx, newMockUser(), scheme.Scheme, clusterDomain); err == nil {
 		t.Error("Expected resource not ready error, got nil")
 	} else if reflect.TypeOf(err) != reflect.TypeOf(errorfactory.ResourceNotReady{}) {
 		t.Error("Expected resource not ready error, got:", reflect.TypeOf(err))
@@ -73,15 +74,15 @@ func TestReconcileUserCertificate(t *testing.T) {
 	if err := manager.client.Create(context.TODO(), newMockUserSecret()); err != nil {
 		t.Error("could not update test secret")
 	}
-	if _, err := manager.ReconcileUserCertificate(ctx, newMockUser(), scheme.Scheme); err != nil {
+	if _, err := manager.ReconcileUserCertificate(ctx, newMockUser(), scheme.Scheme, clusterDomain); err != nil {
 		t.Error("Expected no error, got:", err)
 	}
 
 	// Test error conditions
 	manager = newMock(newMockCluster())
 	manager.client.Create(context.TODO(), newMockUser())
-	manager.client.Create(context.TODO(), manager.clusterCertificateForUser(newMockUser(), scheme.Scheme))
-	if _, err := manager.ReconcileUserCertificate(ctx, newMockUser(), scheme.Scheme); err == nil {
+	manager.client.Create(context.TODO(), manager.clusterCertificateForUser(newMockUser(), scheme.Scheme, clusterDomain))
+	if _, err := manager.ReconcileUserCertificate(ctx, newMockUser(), scheme.Scheme, clusterDomain); err == nil {
 		t.Error("Expected  error, got nil")
 	}
 }

--- a/pkg/pki/pki_manager.go
+++ b/pkg/pki/pki_manager.go
@@ -80,7 +80,8 @@ func (m *mockPKIManager) FinalizePKI(ctx context.Context, logger logr.Logger) er
 	return nil
 }
 
-func (m *mockPKIManager) ReconcileUserCertificate(ctx context.Context, user *v1alpha1.KafkaUser, scheme *runtime.Scheme) (*pki.UserCertificate, error) {
+func (m *mockPKIManager) ReconcileUserCertificate(
+	ctx context.Context, user *v1alpha1.KafkaUser, scheme *runtime.Scheme, clusterDomain string) (*pki.UserCertificate, error) {
 	return &pki.UserCertificate{}, nil
 }
 

--- a/pkg/pki/pki_manager_test.go
+++ b/pkg/pki/pki_manager_test.go
@@ -67,7 +67,7 @@ func TestGetPKIManager(t *testing.T) {
 		t.Error("Expected nil error got:", err)
 	}
 
-	if _, err = mock.ReconcileUserCertificate(ctx, &v1alpha1.KafkaUser{}, scheme.Scheme); err != nil {
+	if _, err = mock.ReconcileUserCertificate(ctx, &v1alpha1.KafkaUser{}, scheme.Scheme, "cluster.local"); err != nil {
 		t.Error("Expected nil error got:", err)
 	}
 

--- a/pkg/pki/vaultpki/vault_test.go
+++ b/pkg/pki/vaultpki/vault_test.go
@@ -150,6 +150,7 @@ func TestNew(t *testing.T) {
 }
 
 func TestAll(t *testing.T) {
+	clusterDomain := "cluster.local"
 	ctx := context.Background()
 	mock, ln, client := newVaultMock(t)
 	defer ln.Close()
@@ -204,12 +205,12 @@ func TestAll(t *testing.T) {
 		t.Error("Expected no error, got:", err)
 	}
 
-	if _, err := mock.ReconcileUserCertificate(ctx, newMockUser(), scheme.Scheme); err != nil {
+	if _, err := mock.ReconcileUserCertificate(ctx, newMockUser(), scheme.Scheme, clusterDomain); err != nil {
 		t.Error("Expected no error, got:", err)
 	}
 
 	// Safe to do multiple times
-	if _, err := mock.ReconcileUserCertificate(ctx, newMockUser(), scheme.Scheme); err != nil {
+	if _, err := mock.ReconcileUserCertificate(ctx, newMockUser(), scheme.Scheme, clusterDomain); err != nil {
 		t.Error("Expected no error, got:", err)
 	}
 

--- a/pkg/pki/vaultpki/vault_user.go
+++ b/pkg/pki/vaultpki/vault_user.go
@@ -27,7 +27,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-func (v *vaultPKI) ReconcileUserCertificate(ctx context.Context, user *v1alpha1.KafkaUser, scheme *runtime.Scheme) (*pkicommon.UserCertificate, error) {
+func (v *vaultPKI) ReconcileUserCertificate(
+	ctx context.Context, user *v1alpha1.KafkaUser, scheme *runtime.Scheme, clusterDomain string) (*pkicommon.UserCertificate, error) {
 	client, err := v.getClient()
 	if err != nil {
 		return nil, err

--- a/pkg/util/pki/common.go
+++ b/pkg/util/pki/common.go
@@ -61,7 +61,8 @@ type Manager interface {
 	FinalizePKI(ctx context.Context, logger logr.Logger) error
 
 	// ReconcileUserCertificate ensures and returns a user certificate - should be idempotent
-	ReconcileUserCertificate(ctx context.Context, user *v1alpha1.KafkaUser, scheme *runtime.Scheme) (*UserCertificate, error)
+	ReconcileUserCertificate(
+		ctx context.Context, user *v1alpha1.KafkaUser, scheme *runtime.Scheme, clusterDomain string) (*UserCertificate, error)
 
 	// FinalizeUserCertificate removes/revokes a user certificate
 	FinalizeUserCertificate(ctx context.Context, user *v1alpha1.KafkaUser) error


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no|
| New feature?    |yes|
| API breaks?     | no|
| Deprecations?   | no|
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
This PR adds the UriSans field to the kafka user generated certificates in the following format: spiffe://clusterdomain//username


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
