### PR TITLE
Add namespace name to the generated urisan field

### DIFF
--- a/pkg/pki/certmanagerpki/certmanager.go
+++ b/pkg/pki/certmanagerpki/certmanager.go
@@ -22,7 +22,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const spiffeIdTemplate = "spiffe://%s/%s"
+const spiffeIdTemplate = "spiffe://%s/ns/%s/kafkauser/%s"
 
 var namespaceCertManager string
 

--- a/pkg/pki/certmanagerpki/certmanager_user.go
+++ b/pkg/pki/certmanagerpki/certmanager_user.go
@@ -168,7 +168,7 @@ func (c *certManager) clusterCertificateForUser(
 			SecretName:  user.Spec.SecretName,
 			KeyEncoding: certv1.PKCS8,
 			CommonName:  user.GetName(),
-			URISANs:     []string{fmt.Sprintf(spiffeIdTemplate, clusterDomain, user.GetName())},
+			URISANs:     []string{fmt.Sprintf(spiffeIdTemplate, clusterDomain, user.GetNamespace(), user.GetName())},
 			Usages:      []certv1.KeyUsage{certv1.UsageClientAuth, certv1.UsageServerAuth},
 			IssuerRef: certmeta.ObjectReference{
 				Name: caName,


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no|
| New feature?    | yes|
| API breaks?     | no|
| Deprecations?   | no|
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
This PR is an addendum to one of our latest commit to add the namespace field as well to the urisan field when generating a new kafkauser certificate.

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
