### PR TITLE
Prepare release v0.13.1 by bumping the chart

### DIFF
--- a/charts/kafka-operator/Chart.yaml
+++ b/charts/kafka-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: kafka-operator
-version: 0.4.0
+version: 0.4.1
 description: kafka-operator manages Kafka deployments on Kubernetes
 sources:
   - https://github.com/banzaicloud/kafka-operator
-appVersion: v0.13.0
+appVersion: v0.13.1

--- a/charts/kafka-operator/values.yaml
+++ b/charts/kafka-operator/values.yaml
@@ -12,7 +12,7 @@ operator:
   annotations: {}
   image:
     repository: banzaicloud/kafka-operator
-    tag: v0.13.0
+    tag: v0.13.1
     pullPolicy: IfNotPresent
   vaultAddress: ""
   # vaultSecret containing a `ca.crt` key with the Vault CA Certificate


### PR DESCRIPTION
Bump chart version to 0.4.1 and operator version to v0.13.1 to prepare the new release.