### PR TITLE
[COSMETIC] - Remove leading spaces from cruise-control config files and update log4j log format

### DIFF
--- a/pkg/resources/cruisecontrol/configmap.go
+++ b/pkg/resources/cruisecontrol/configmap.go
@@ -41,10 +41,10 @@ func (r *Reconciler) configMap(clientPass, capacityConfig string) runtime.Object
 		),
 		Data: map[string]string{
 			"cruisecontrol.properties": r.KafkaCluster.Spec.CruiseControlConfig.Config + fmt.Sprintf(`
-    # The Kafka cluster to control.
-    bootstrap.servers=%s:%d
-    # The zookeeper connect of the Kafka cluster
-    zookeeper.connect=%s
+# The Kafka cluster to control.
+bootstrap.servers=%s:%d
+# The zookeeper connect of the Kafka cluster
+zookeeper.connect=%s
 `, generateBootstrapServer(r.KafkaCluster.Spec.HeadlessServiceEnabled, r.KafkaCluster.Name), r.KafkaCluster.Spec.ListenersConfig.InternalListeners[0].ContainerPort, zookeeperutils.PrepareConnectionAddress(r.KafkaCluster.Spec.ZKAddresses, r.KafkaCluster.Spec.GetZkPath())) +
 				generateSSLConfig(&r.KafkaCluster.Spec.ListenersConfig, clientPass),
 			"capacity.json":       capacityConfig,

--- a/pkg/sdk/v1beta1/kafkacluster_types.go
+++ b/pkg/sdk/v1beta1/kafkacluster_types.go
@@ -601,10 +601,10 @@ func (cConfig *CruiseControlConfig) GetCCLog4jConfig() string {
 		return cConfig.Log4jConfig
 	}
 	return `log4j.rootLogger = INFO, FILE
-    log4j.appender.FILE=org.apache.log4j.FileAppender
-    log4j.appender.FILE.File=/dev/stdout
-    log4j.appender.FILE.layout=org.apache.log4j.PatternLayout
-    log4j.appender.FILE.layout.conversionPattern=%-6r [%15.15t] %-5p %30.30c %x - %m%n`
+log4j.appender.FILE=org.apache.log4j.FileAppender
+log4j.appender.FILE.File=/dev/stdout
+log4j.appender.FILE.layout=org.apache.log4j.PatternLayout
+log4j.appender.FILE.layout.conversionPattern=%-6r [%15.15t] %-5p %30.30c %x - %m%n`
 }
 
 // GetImage returns the used image for Prometheus JMX exporter


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?

- Remove leadings spaces from generated CruiseControl `cruisecontrol.properties` and `log4j.properties` files
- Update cruise-control log4j log format to more canonical `[%d] %p %m (%c)%n` 

### Why?
Cosmetic changes

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)

