### PR TITLE
Merge the configured and the running broker ids when reconciling services

### DIFF
--- a/pkg/resources/envoy/configmap.go
+++ b/pkg/resources/envoy/configmap.go
@@ -71,7 +71,7 @@ func GenerateEnvoyConfig(kc *v1beta1.KafkaCluster, log logr.Logger) string {
 	var listeners []*envoyapi.Listener
 	var clusters []*envoyapi.Cluster
 
-	for _, brokerId := range util.GetBrokerIdsFromStatus(kc.Status.BrokersState, log) {
+	for _, brokerId := range util.GetBrokerIdsFromStatusAndSpec(kc.Status.BrokersState, kc.Spec.Brokers, log) {
 		listeners = append(listeners, &envoyapi.Listener{
 			Address: &envoycore.Address{
 				Address: &envoycore.Address_SocketAddress{

--- a/pkg/resources/envoy/deployment.go
+++ b/pkg/resources/envoy/deployment.go
@@ -33,7 +33,7 @@ import (
 func (r *Reconciler) deployment(log logr.Logger) runtime.Object {
 
 	exposedPorts := getExposedContainerPorts(r.KafkaCluster.Spec.ListenersConfig.ExternalListeners,
-		util.GetBrokerIdsFromStatus(r.KafkaCluster.Status.BrokersState, log))
+		util.GetBrokerIdsFromStatusAndSpec(r.KafkaCluster.Status.BrokersState, r.KafkaCluster.Spec.Brokers, log))
 	volumes := []corev1.Volume{
 		{
 			Name: envoyVolumeAndConfigName,

--- a/pkg/resources/envoy/loadbalancer.go
+++ b/pkg/resources/envoy/loadbalancer.go
@@ -33,7 +33,7 @@ import (
 func (r *Reconciler) loadBalancer(log logr.Logger) runtime.Object {
 
 	exposedPorts := getExposedServicePorts(r.KafkaCluster.Spec.ListenersConfig.ExternalListeners,
-		util.GetBrokerIdsFromStatus(r.KafkaCluster.Status.BrokersState, log))
+		util.GetBrokerIdsFromStatusAndSpec(r.KafkaCluster.Status.BrokersState, r.KafkaCluster.Spec.Brokers, log))
 
 	service := &corev1.Service{
 		ObjectMeta: templates.ObjectMetaWithAnnotations(envoyutils.EnvoyServiceName, map[string]string{},

--- a/pkg/resources/istioingress/gateway.go
+++ b/pkg/resources/istioingress/gateway.go
@@ -45,7 +45,7 @@ func generateServers(kc *v1beta1.KafkaCluster, externalListenerConfig v1beta1.Ex
 		protocol = v1alpha3.ProtocolTLS
 	}
 
-	brokerIds := util.GetBrokerIdsFromStatus(kc.Status.BrokersState, log)
+	brokerIds := util.GetBrokerIdsFromStatusAndSpec(kc.Status.BrokersState, kc.Spec.Brokers, log)
 
 	for _, brokerId := range brokerIds {
 		servers = append(servers, v1alpha3.Server{

--- a/pkg/resources/istioingress/meshgateway.go
+++ b/pkg/resources/istioingress/meshgateway.go
@@ -49,7 +49,7 @@ func (r *Reconciler) meshgateway(log logr.Logger, externalListenerConfig v1beta1
 				},
 				ServiceType: corev1.ServiceTypeLoadBalancer,
 			},
-			Ports: generateExternalPorts(util.GetBrokerIdsFromStatus(r.KafkaCluster.Status.BrokersState, log),
+			Ports: generateExternalPorts(util.GetBrokerIdsFromStatusAndSpec(r.KafkaCluster.Status.BrokersState, r.KafkaCluster.Spec.Brokers, log),
 				externalListenerConfig),
 			Type: istioOperatorApi.GatewayTypeIngress,
 		},

--- a/pkg/resources/istioingress/virtualservice.go
+++ b/pkg/resources/istioingress/virtualservice.go
@@ -54,7 +54,7 @@ func (r *Reconciler) virtualService(log logr.Logger, externalListenerConfig v1be
 func generateTlsRoutes(kc *v1beta1.KafkaCluster, externalListenerConfig v1beta1.ExternalListenerConfig, log logr.Logger) []v1alpha3.TLSRoute {
 	tlsRoutes := make([]v1alpha3.TLSRoute, 0)
 
-	brokerIds := util.GetBrokerIdsFromStatus(kc.Status.BrokersState, log)
+	brokerIds := util.GetBrokerIdsFromStatusAndSpec(kc.Status.BrokersState, kc.Spec.Brokers, log)
 
 	for _, brokerId := range brokerIds {
 		tlsRoutes = append(tlsRoutes, v1alpha3.TLSRoute{
@@ -99,7 +99,7 @@ func generateTlsRoutes(kc *v1beta1.KafkaCluster, externalListenerConfig v1beta1.
 func generateTcpRoutes(kc *v1beta1.KafkaCluster, externalListenerConfig v1beta1.ExternalListenerConfig, log logr.Logger) []v1alpha3.TCPRoute {
 	tcpRoutes := make([]v1alpha3.TCPRoute, 0)
 
-	brokerIds := util.GetBrokerIdsFromStatus(kc.Status.BrokersState, log)
+	brokerIds := util.GetBrokerIdsFromStatusAndSpec(kc.Status.BrokersState, kc.Spec.Brokers, log)
 
 	for _, brokerId := range brokerIds {
 		tcpRoutes = append(tcpRoutes, v1alpha3.TCPRoute{

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -181,11 +181,11 @@ func AreStringSlicesIdentical(a, b []string) bool {
 
 // returns the union of the ids of the configured (Spec.Brokers) and the running (BrokerState) brokers
 func GetBrokerIdsFromStatusAndSpec(brokerStatuses map[string]v1beta1.BrokerState, brokers []v1beta1.Broker, log logr.Logger) []int {
-	brokerIdMap := make(map[int]bool)
+	brokerIdMap := make(map[int]struct{})
 
 	// add brokers from spec
 	for _, broker := range brokers {
-		brokerIdMap[int(broker.Id)] = true
+		brokerIdMap[int(broker.Id)] = struct{}{}
 	}
 
 	// add brokers from status
@@ -195,11 +195,11 @@ func GetBrokerIdsFromStatusAndSpec(brokerStatuses map[string]v1beta1.BrokerState
 			log.Error(err, "could not parse brokerId properly")
 			continue
 		}
-		brokerIdMap[id] = true
+		brokerIdMap[id] = struct{}{}
 	}
 
 	// collect unique broker ids
-	brokerIds := make([]int, 0)
+	brokerIds := make([]int, 0, len(brokerIdMap))
 	for id := range brokerIdMap {
 		brokerIds = append(brokerIds, id)
 	}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes regression from #457 
| License         | Apache 2.0

### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Fixes a regression introduced by #457.

Tested locally in docker-desktop.
After specifying external listener config in cold start the reconcile succeeds.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
See more information at #440.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline