### PR TITLE
Update SSL and listener related configs dynamically

### DIFF
--- a/pkg/resources/kafka/configmap_test.go
+++ b/pkg/resources/kafka/configmap_test.go
@@ -46,13 +46,10 @@ func TestGenerateBrokerConfig(t *testing.T) {
 			clusterWideConfig:       ``,
 			perBrokerConfig:         ``,
 			perBrokerReadOnlyConfig: ``,
-			expectedConfig: `advertised.listeners=INTERNAL://kafka-0.kafka.svc.cluster.local:9092
-broker.id=0
+			expectedConfig: `broker.id=0
 cruise.control.metrics.reporter.bootstrap.servers=INTERNAL://kafka-0.kafka.svc.cluster.local:9092
 cruise.control.metrics.reporter.kubernetes.mode=true
 inter.broker.listener.name=INTERNAL
-listener.security.protocol.map=INTERNAL:PLAINTEXT
-listeners=INTERNAL://:9092
 metric.reporters=com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporter
 zookeeper.connect=example.zk:2181/`,
 		},
@@ -65,13 +62,10 @@ zookeeper.connect=example.zk:2181/`,
 			clusterWideConfig:       ``,
 			perBrokerConfig:         ``,
 			perBrokerReadOnlyConfig: ``,
-			expectedConfig: `advertised.listeners=INTERNAL://kafka-0.kafka.svc.cluster.local:9092
-broker.id=0
+			expectedConfig: `broker.id=0
 cruise.control.metrics.reporter.bootstrap.servers=INTERNAL://kafka-0.kafka.svc.cluster.local:9092
 cruise.control.metrics.reporter.kubernetes.mode=true
 inter.broker.listener.name=INTERNAL
-listener.security.protocol.map=INTERNAL:PLAINTEXT
-listeners=INTERNAL://:9092
 metric.reporters=com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporter
 zookeeper.connect=example.zk:2181/kafka`,
 		},
@@ -84,13 +78,10 @@ zookeeper.connect=example.zk:2181/kafka`,
 			clusterWideConfig:       ``,
 			perBrokerConfig:         ``,
 			perBrokerReadOnlyConfig: ``,
-			expectedConfig: `advertised.listeners=INTERNAL://kafka-0.kafka.svc.cluster.local:9092
-broker.id=0
+			expectedConfig: `broker.id=0
 cruise.control.metrics.reporter.bootstrap.servers=INTERNAL://kafka-0.kafka.svc.cluster.local:9092
 cruise.control.metrics.reporter.kubernetes.mode=true
 inter.broker.listener.name=INTERNAL
-listener.security.protocol.map=INTERNAL:PLAINTEXT
-listeners=INTERNAL://:9092
 metric.reporters=com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporter
 zookeeper.connect=example.zk:2181/`,
 		},
@@ -103,13 +94,10 @@ zookeeper.connect=example.zk:2181/`,
 			clusterWideConfig:       ``,
 			perBrokerConfig:         ``,
 			perBrokerReadOnlyConfig: ``,
-			expectedConfig: `advertised.listeners=INTERNAL://kafka-0.kafka.svc.cluster.local:9092
-broker.id=0
+			expectedConfig: `broker.id=0
 cruise.control.metrics.reporter.bootstrap.servers=INTERNAL://kafka-0.kafka.svc.cluster.local:9092
 cruise.control.metrics.reporter.kubernetes.mode=true
 inter.broker.listener.name=INTERNAL
-listener.security.protocol.map=INTERNAL:PLAINTEXT
-listeners=INTERNAL://:9092
 metric.reporters=com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporter
 zookeeper.connect=example.zk:2181,example.zk-1:2181/kafka`,
 		},
@@ -127,13 +115,10 @@ zookeeper.connect=example.zk:2181,example.zk-1:2181/kafka`,
 					MountPath: "/kafka-logs",
 				},
 			},
-			expectedConfig: `advertised.listeners=INTERNAL://kafka-0.kafka.svc.cluster.local:9092
-broker.id=0
+			expectedConfig: `broker.id=0
 cruise.control.metrics.reporter.bootstrap.servers=INTERNAL://kafka-0.kafka.svc.cluster.local:9092
 cruise.control.metrics.reporter.kubernetes.mode=true
 inter.broker.listener.name=INTERNAL
-listener.security.protocol.map=INTERNAL:PLAINTEXT
-listeners=INTERNAL://:9092
 log.dirs=/kafka-logs/kafka
 metric.reporters=com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporter
 zookeeper.connect=example.zk:2181/`,
@@ -147,13 +132,10 @@ zookeeper.connect=example.zk:2181/`,
 			clusterWideConfig:       ``,
 			perBrokerConfig:         ``,
 			perBrokerReadOnlyConfig: ``,
-			expectedConfig: `advertised.listeners=INTERNAL://kafka-0.kafka.svc.foo.bar:9092
-broker.id=0
+			expectedConfig: `broker.id=0
 cruise.control.metrics.reporter.bootstrap.servers=INTERNAL://kafka-0.kafka.svc.foo.bar:9092
 cruise.control.metrics.reporter.kubernetes.mode=true
 inter.broker.listener.name=INTERNAL
-listener.security.protocol.map=INTERNAL:PLAINTEXT
-listeners=INTERNAL://:9092
 metric.reporters=com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporter
 zookeeper.connect=example.zk:2181/`,
 		},
@@ -174,15 +156,12 @@ compression.type=snappy
 			perBrokerReadOnlyConfig: `
 auto.create.topics.enable=true
 `,
-			expectedConfig: `advertised.listeners=INTERNAL://kafka-0.kafka.svc.cluster.local:9092
-auto.create.topics.enable=true
+			expectedConfig: `auto.create.topics.enable=true
 broker.id=0
 control.plane.listener.name=thisisatest
 cruise.control.metrics.reporter.bootstrap.servers=INTERNAL://kafka-0.kafka.svc.cluster.local:9092
 cruise.control.metrics.reporter.kubernetes.mode=true
 inter.broker.listener.name=INTERNAL
-listener.security.protocol.map=INTERNAL:PLAINTEXT
-listeners=INTERNAL://:9092
 metric.reporters=com.linkedin.kafka.cruisecontrol.metricsreporter.CruiseControlMetricsReporter
 zookeeper.connect=example.zk:2181/`,
 		},
@@ -232,7 +211,7 @@ zookeeper.connect=example.zk:2181/`,
 					},
 				},
 			}
-			generatedConfig := r.generateBrokerConfig(0, r.KafkaCluster.Spec.Brokers[0].BrokerConfig, []string{}, "", "", []string{}, logf.NullLogger{})
+			generatedConfig := r.generateBrokerConfig(0, r.KafkaCluster.Spec.Brokers[0].BrokerConfig, "", []string{}, logf.NullLogger{})
 
 			if generatedConfig != test.expectedConfig {
 				t.Errorf("the expected config is %s, received: %s", test.expectedConfig, generatedConfig)

--- a/pkg/resources/kafka/perbrokerconfigs.go
+++ b/pkg/resources/kafka/perbrokerconfigs.go
@@ -1,0 +1,108 @@
+// Copyright © 2020 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kafka
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/banzaicloud/kafka-operator/pkg/util"
+	"github.com/imdario/mergo"
+	"strings"
+	"text/template"
+
+	"github.com/banzaicloud/kafka-operator/api/v1alpha1"
+	"github.com/banzaicloud/kafka-operator/api/v1beta1"
+	"github.com/go-logr/logr"
+)
+
+var dynamicConfig = `
+{{ .ListenerDynamicConfig }}
+{{ if .KafkaCluster.Spec.ListenersConfig.SSLSecrets }}
+ssl.keystore.location={{ .ServerKeystorePath }}/{{ .KeyStoreFile }}
+ssl.truststore.location={{ .ServerKeystorePath }}/{{ .TrustStoreFile }}
+ssl.keystore.password={{ .ServerKeystorePassword }}
+ssl.truststore.password={{ .ServerKeystorePassword }}
+ssl.client.auth=required
+{{ end }}
+{{ .AdvertisedListenersConfig }}
+`
+
+func (r *Reconciler) generateDynamicConfigs(id int32, loadBalancerIPs []string, serverPass string, log logr.Logger) string {
+	var out bytes.Buffer
+	t := template.Must(template.New("dynamicConfig-config").Parse(dynamicConfig))
+	if err := t.Execute(&out, map[string]interface{}{
+		"KafkaCluster":              r.KafkaCluster,
+		"ListenerDynamicConfig":     generateListenerSpecificDynamicConfig(&r.KafkaCluster.Spec.ListenersConfig),
+		"ServerKeystorePath":        serverKeystorePath,
+		"ClientKeystorePath":        clientKeystorePath,
+		"KeyStoreFile":              v1alpha1.TLSJKSKeyStore,
+		"TrustStoreFile":            v1alpha1.TLSJKSTrustStore,
+		"ServerKeystorePassword":    serverPass,
+		"AdvertisedListenersConfig": generateAdvertisedListenerConfig(id, r.KafkaCluster.Spec.ListenersConfig, loadBalancerIPs, r.KafkaCluster.Spec.GetKubernetesClusterDomain(), r.KafkaCluster.Namespace, r.KafkaCluster.Name, r.KafkaCluster.Spec.HeadlessServiceEnabled),
+	}); err != nil {
+		log.Error(err, "error occurred during parsing the dynamic config template")
+	}
+	return out.String()
+}
+
+func (r *Reconciler) getDynamicConfigs(brokerId int32, loadBalancerIPs []string, serverPass string, brokerConfig *v1beta1.BrokerConfig, log logr.Logger) map[string]string {
+	overridablePerBrokerConfig := util.ParsePropertiesFormat(brokerConfig.Config)
+	generatedPerBrokerConfig := util.ParsePropertiesFormat(r.generateDynamicConfigs(brokerId, loadBalancerIPs, serverPass, log))
+
+	if err := mergo.Merge(&generatedPerBrokerConfig, overridablePerBrokerConfig); err != nil {
+		log.Error(err, "error occurred during merging per-broker configs")
+	}
+
+	return generatedPerBrokerConfig
+}
+
+func generateListenerSpecificDynamicConfig(l *v1beta1.ListenersConfig) string {
+	var securityProtocolMapConfig []string
+	var listenerConfig []string
+
+	for _, iListener := range l.InternalListeners {
+		UpperedListenerType := strings.ToUpper(iListener.Type)
+		UpperedListenerName := strings.ToUpper(iListener.Name)
+		securityProtocolMapConfig = append(securityProtocolMapConfig, fmt.Sprintf("%s:%s", UpperedListenerName, UpperedListenerType))
+		listenerConfig = append(listenerConfig, fmt.Sprintf("%s://:%d", UpperedListenerName, iListener.ContainerPort))
+	}
+	for _, eListener := range l.ExternalListeners {
+		UpperedListenerType := strings.ToUpper(eListener.Type)
+		UpperedListenerName := strings.ToUpper(eListener.Name)
+		securityProtocolMapConfig = append(securityProtocolMapConfig, fmt.Sprintf("%s:%s", UpperedListenerName, UpperedListenerType))
+		listenerConfig = append(listenerConfig, fmt.Sprintf("%s://:%d", UpperedListenerName, eListener.ContainerPort))
+	}
+	return "listener.security.protocol.map=" + strings.Join(securityProtocolMapConfig, ",") + "\n" +
+		"listeners=" + strings.Join(listenerConfig, ",")
+}
+
+func generateAdvertisedListenerConfig(id int32, l v1beta1.ListenersConfig, loadBalancerIPs []string, domain, namespace, crName string, headlessServiceEnabled bool) string {
+	advertisedListenerConfig := []string{}
+	for _, eListener := range l.ExternalListeners {
+		// use first element of loadBalancerIPs slice for external listener name
+		advertisedListenerConfig = append(advertisedListenerConfig,
+			fmt.Sprintf("%s://%s:%d", strings.ToUpper(eListener.Name), loadBalancerIPs[0], eListener.ExternalStartingPort+id))
+	}
+	for _, iListener := range l.InternalListeners {
+		if headlessServiceEnabled {
+			advertisedListenerConfig = append(advertisedListenerConfig,
+				fmt.Sprintf("%s://%s-%d.%s-headless.%s.svc.%s:%d", strings.ToUpper(iListener.Name), crName, id, crName, namespace, domain, iListener.ContainerPort))
+		} else {
+			advertisedListenerConfig = append(advertisedListenerConfig,
+				fmt.Sprintf("%s://%s-%d.%s.svc.%s:%d", strings.ToUpper(iListener.Name), crName, id, namespace, domain, iListener.ContainerPort))
+		}
+	}
+	return fmt.Sprintf("advertised.listeners=%s\n", strings.Join(advertisedListenerConfig, ","))
+}

--- a/pkg/resources/kafka/perbrokerconfigs_test.go
+++ b/pkg/resources/kafka/perbrokerconfigs_test.go
@@ -1,0 +1,187 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kafka
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/banzaicloud/kafka-operator/api/v1beta1"
+	"github.com/banzaicloud/kafka-operator/pkg/resources"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+func TestGeneratePerBrokerConfig(t *testing.T) {
+	tests := []struct {
+		testName                string
+		brokerId                int32
+		loadBalancerIPs         []string
+		serverPass              string
+		sslSecrets              *v1beta1.SSLSecrets
+		externalListeners       []v1beta1.ExternalListenerConfig
+		brokerConfig            v1beta1.BrokerConfig
+		kubernetesClusterDomain string
+		headlessServiceEnabled  bool
+		expectedOutput          map[string]string
+	}{
+		{
+			testName: "basicConfig",
+			expectedOutput: map[string]string{
+				"advertised.listeners":           "INTERNAL://kafka_cluster-0.kafka.svc.cluster.local:9092",
+				"listener.security.protocol.map": "INTERNAL:PLAINTEXT",
+				"listeners":                      "INTERNAL://:9092",
+			},
+		},
+		{
+			testName: "customBrokerId",
+			brokerId: 1,
+			expectedOutput: map[string]string{
+				"advertised.listeners":           "INTERNAL://kafka_cluster-1.kafka.svc.cluster.local:9092",
+				"listener.security.protocol.map": "INTERNAL:PLAINTEXT",
+				"listeners":                      "INTERNAL://:9092",
+			},
+		},
+		{
+			testName:   "sslSecretsWithServerPass",
+			serverPass: "test",
+			sslSecrets: &v1beta1.SSLSecrets{
+				TLSSecretName:   "testsecret",
+				JKSPasswordName: "testpwd",
+				Create:          false,
+				PKIBackend:      "envoy",
+			},
+			expectedOutput: map[string]string{
+				"advertised.listeners":           "INTERNAL://kafka_cluster-0.kafka.svc.cluster.local:9092",
+				"listener.security.protocol.map": "INTERNAL:PLAINTEXT",
+				"listeners":                      "INTERNAL://:9092",
+				"ssl.client.auth":                "required",
+				"ssl.keystore.location":          "/var/run/secrets/java.io/keystores/server/keystore.jks",
+				"ssl.keystore.password":          "test",
+				"ssl.truststore.location":        "/var/run/secrets/java.io/keystores/server/truststore.jks",
+				"ssl.truststore.password":        "test",
+			},
+		},
+		{
+			testName:        "externalListenerWithLoadBalancerIP",
+			loadBalancerIPs: []string{"localhost"},
+			externalListeners: []v1beta1.ExternalListenerConfig{{
+				CommonListenerSpec: v1beta1.CommonListenerSpec{
+					Type:          "plaintext",
+					Name:          "external",
+					ContainerPort: 9093,
+				},
+			}},
+			expectedOutput: map[string]string{
+				"advertised.listeners":           "EXTERNAL://localhost:0,INTERNAL://kafka_cluster-0.kafka.svc.cluster.local:9092",
+				"listener.security.protocol.map": "INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT",
+				"listeners":                      "INTERNAL://:9092,EXTERNAL://:9093",
+			},
+		},
+		{
+			testName:                "customClusterDomain",
+			kubernetesClusterDomain: "test1",
+			expectedOutput: map[string]string{
+				"advertised.listeners":           "INTERNAL://kafka_cluster-0.kafka.svc.test1:9092",
+				"listener.security.protocol.map": "INTERNAL:PLAINTEXT",
+				"listeners":                      "INTERNAL://:9092",
+			},
+		},
+		{
+			testName:                "headlessMode",
+			headlessServiceEnabled:  true,
+			kubernetesClusterDomain: "test2",
+			expectedOutput: map[string]string{
+				"advertised.listeners":           "INTERNAL://kafka_cluster-0.kafka_cluster-headless.kafka.svc.test2:9092",
+				"listener.security.protocol.map": "INTERNAL:PLAINTEXT",
+				"listeners":                      "INTERNAL://:9092",
+			},
+		},
+		{
+			testName: "customUserConfig",
+			brokerConfig: v1beta1.BrokerConfig{
+				Config: "sasl.enabled.mechanisms=PLAIN",
+			},
+			expectedOutput: map[string]string{
+				"advertised.listeners":           "INTERNAL://kafka_cluster-0.kafka.svc.cluster.local:9092",
+				"listener.security.protocol.map": "INTERNAL:PLAINTEXT",
+				"listeners":                      "INTERNAL://:9092",
+				"sasl.enabled.mechanisms":        "PLAIN",
+			},
+		},
+		{
+			testName: "nonOverridableConfig",
+			brokerConfig: v1beta1.BrokerConfig{
+				Config: "advanced.listeners:should-not-override",
+			},
+			expectedOutput: map[string]string{
+				"advertised.listeners":           "INTERNAL://kafka_cluster-0.kafka.svc.cluster.local:9092",
+				"listener.security.protocol.map": "INTERNAL:PLAINTEXT",
+				"listeners":                      "INTERNAL://:9092",
+			},
+		},
+	}
+
+	t.Parallel()
+
+	for _, test := range tests {
+		test := test
+
+		t.Run(test.testName, func(t *testing.T) {
+			r := Reconciler{
+				Scheme: scheme.Scheme,
+				Reconciler: resources.Reconciler{
+					KafkaCluster: &v1beta1.KafkaCluster{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "kafka_cluster",
+							Namespace: "kafka",
+						},
+						Spec: v1beta1.KafkaClusterSpec{
+							HeadlessServiceEnabled:  test.headlessServiceEnabled,
+							KubernetesClusterDomain: test.kubernetesClusterDomain,
+							ListenersConfig: v1beta1.ListenersConfig{
+								InternalListeners: []v1beta1.InternalListenerConfig{
+									{CommonListenerSpec: v1beta1.CommonListenerSpec{
+										Type:          "plaintext",
+										Name:          "internal",
+										ContainerPort: 9092,
+									},
+										UsedForInnerBrokerCommunication: true,
+									},
+								},
+								ExternalListeners: test.externalListeners,
+								SSLSecrets:        test.sslSecrets,
+							},
+							Brokers: []v1beta1.Broker{
+								{
+									Id: 0,
+								},
+								{
+									Id: 1,
+								},
+							},
+						},
+					},
+				},
+			}
+			generatedConfig := r.getDynamicConfigs(test.brokerId, test.loadBalancerIPs, test.serverPass, &test.brokerConfig, logf.NullLogger{})
+
+			if !reflect.DeepEqual(generatedConfig, test.expectedOutput) {
+				t.Errorf("the expected config is %s, received: %s", test.expectedOutput, generatedConfig)
+			}
+		})
+	}
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0

### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
This PR moves changes specific already existing per-boker Kafka configurations to be updated dynamically instead of doing a broker restart.
According to the 2.6.0 Kafka [documentation](https://kafka.apache.org/documentation/#dynamicbrokerconfigs) these configs are labelled as per-broker:
- listener related configs
`listener.security.protocol.map`, `listeners` can be set dynamically (but `inter.broker.listener.name` could be not!)
- SSL related configs
`ssl.keystore.location`, `ssl.truststore.location`, `ssl.keystore.password`, `ssl.truststore.password`, `ssl.client.auth` can all be set dynamically
- advertised listener
`advertised.listeners` can be set dynamically
We should move these to the dynamically updated configurations in the controller.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
This is a faster way to update the configuration: less downtime, no unnecessary broker restarts etc.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Implementation tested
- [x] Unit tests added and passing
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline