### PR TITLE
Accepting existing serviceAccountName for both AuthProxy and Operator

### DIFF
--- a/charts/kafka-operator/templates/_helpers.tpl
+++ b/charts/kafka-operator/templates/_helpers.tpl
@@ -46,9 +46,9 @@ Compute operator deployment serviceAccountName key
 Compute operator prometheus metrics auth proxy service account
 */}}
 {{- define "operator.metricsAuthProxy.serviceAccountName" -}}
-{{- if .Values.prometheusMetrics.authProxy.serviceAccount.name -}}
+{{- if .Values.prometheusMetrics.authProxy.serviceAccount.create -}}
 {{ default "default" .Values.prometheusMetrics.authProxy.serviceAccount.name }}
 {{- else -}}
-{{- printf "%s" "default" }}
+{{ default "default" .Values.prometheusMetrics.authProxy.serviceAccount.name }}
 {{- end -}}
 {{- end -}}

--- a/charts/kafka-operator/templates/_helpers.tpl
+++ b/charts/kafka-operator/templates/_helpers.tpl
@@ -35,10 +35,10 @@ Create chart name and version as used by the chart label.
 Compute operator deployment serviceAccountName key
 */}}
 {{- define "operator.serviceAccountName" -}}
-{{- if .Values.operator.serviceAccount.name -}}
+{{- if .Values.operator.serviceAccount.create -}}
 {{ default "default" .Values.operator.serviceAccount.name }}
 {{- else -}}
-{{- printf "%s" "default" }}
+{{ default "default" .Values.operator.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
 

--- a/charts/kafka-operator/templates/_helpers.tpl
+++ b/charts/kafka-operator/templates/_helpers.tpl
@@ -35,7 +35,7 @@ Create chart name and version as used by the chart label.
 Compute operator deployment serviceAccountName key
 */}}
 {{- define "operator.serviceAccountName" -}}
-{{- if .Values.operator.serviceAccount.create -}}
+{{- if .Values.operator.serviceAccount.name -}}
 {{ default "default" .Values.operator.serviceAccount.name }}
 {{- else -}}
 {{- printf "%s" "default" }}
@@ -46,7 +46,7 @@ Compute operator deployment serviceAccountName key
 Compute operator prometheus metrics auth proxy service account
 */}}
 {{- define "operator.metricsAuthProxy.serviceAccountName" -}}
-{{- if .Values.prometheusMetrics.authProxy.serviceAccount.create -}}
+{{- if .Values.prometheusMetrics.authProxy.serviceAccount.name -}}
 {{ default "default" .Values.prometheusMetrics.authProxy.serviceAccount.name }}
 {{- else -}}
 {{- printf "%s" "default" }}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Accepting existing `serviceAccountName` for both `operator` and `authProxy`

### Why?
This gives the advantages of adding more permissions or apiGroups in case you have a sidecar container and you need to add those to your pods, for instance, Istio injection.