### PR TITLE
Multiple external listener

### DIFF
--- a/pkg/pki/certmanagerpki/certmanager_pki_test.go
+++ b/pkg/pki/certmanagerpki/certmanager_pki_test.go
@@ -20,13 +20,14 @@ import (
 	"reflect"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+
 	"github.com/banzaicloud/kafka-operator/api/v1alpha1"
 	"github.com/banzaicloud/kafka-operator/pkg/errorfactory"
 	certutil "github.com/banzaicloud/kafka-operator/pkg/util/cert"
 	pkicommon "github.com/banzaicloud/kafka-operator/pkg/util/pki"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/kubernetes/scheme"
-	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 var log = ctrl.Log.WithName("testing")
@@ -96,33 +97,33 @@ func TestReconcilePKI(t *testing.T) {
 	ctx := context.Background()
 
 	manager.client.Create(ctx, newServerSecret())
-	if err := manager.ReconcilePKI(ctx, log, scheme.Scheme, []string{}); err != nil {
+	if err := manager.ReconcilePKI(ctx, log, scheme.Scheme, map[string]string{}); err != nil {
 		if reflect.TypeOf(err) != reflect.TypeOf(errorfactory.ResourceNotReady{}) {
 			t.Error("Expected not ready error, got:", reflect.TypeOf(err))
 		}
 	}
 
 	manager.client.Create(ctx, newControllerSecret())
-	if err := manager.ReconcilePKI(ctx, log, scheme.Scheme, []string{}); err != nil {
+	if err := manager.ReconcilePKI(ctx, log, scheme.Scheme, map[string]string{}); err != nil {
 		if reflect.TypeOf(err) != reflect.TypeOf(errorfactory.ResourceNotReady{}) {
 			t.Error("Expected not ready error, got:", reflect.TypeOf(err))
 		}
 	}
 
 	manager.client.Create(ctx, newCASecret())
-	if err := manager.ReconcilePKI(ctx, log, scheme.Scheme, []string{}); err != nil {
+	if err := manager.ReconcilePKI(ctx, log, scheme.Scheme, map[string]string{}); err != nil {
 		t.Error("Expected successful reconcile, got:", err)
 	}
 
 	cluster.Spec.ListenersConfig.SSLSecrets.Create = false
 	manager = newMock(cluster)
-	if err := manager.ReconcilePKI(ctx, log, scheme.Scheme, []string{}); err == nil {
+	if err := manager.ReconcilePKI(ctx, log, scheme.Scheme, map[string]string{}); err == nil {
 		t.Error("Expected error got nil")
 	} else if reflect.TypeOf(err) != reflect.TypeOf(errorfactory.ResourceNotReady{}) {
 		t.Error("Expected not ready error, got:", reflect.TypeOf(err))
 	}
 	manager.client.Create(ctx, newPreCreatedSecret())
-	if err := manager.ReconcilePKI(ctx, log, scheme.Scheme, []string{}); err != nil {
+	if err := manager.ReconcilePKI(ctx, log, scheme.Scheme, map[string]string{}); err != nil {
 		t.Error("Expected successful reconcile, got:", err)
 	}
 }

--- a/pkg/pki/pki_manager.go
+++ b/pkg/pki/pki_manager.go
@@ -72,7 +72,7 @@ func newMockPKIManager(client client.Client, cluster *v1beta1.KafkaCluster) pki.
 	return &mockPKIManager{client: client, cluster: cluster}
 }
 
-func (m *mockPKIManager) ReconcilePKI(ctx context.Context, logger logr.Logger, scheme *runtime.Scheme, externalHostnames []string) error {
+func (m *mockPKIManager) ReconcilePKI(ctx context.Context, logger logr.Logger, scheme *runtime.Scheme, externalHostnames map[string]string) error {
 	return nil
 }
 

--- a/pkg/pki/pki_manager_test.go
+++ b/pkg/pki/pki_manager_test.go
@@ -19,11 +19,12 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/banzaicloud/kafka-operator/api/v1alpha1"
-	"github.com/banzaicloud/kafka-operator/api/v1beta1"
 	"github.com/go-logr/logr"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/banzaicloud/kafka-operator/api/v1alpha1"
+	"github.com/banzaicloud/kafka-operator/api/v1beta1"
 )
 
 var log logr.Logger
@@ -59,7 +60,7 @@ func TestGetPKIManager(t *testing.T) {
 
 	// Test mock functions
 	var err error
-	if err = mock.ReconcilePKI(ctx, log, scheme.Scheme, []string{}); err != nil {
+	if err = mock.ReconcilePKI(ctx, log, scheme.Scheme, map[string]string{}); err != nil {
 		t.Error("Expected nil error got:", err)
 	}
 
@@ -89,7 +90,7 @@ func TestGetPKIManager(t *testing.T) {
 	}
 
 	// Default should be cert-manager also
-	cluster.Spec.ListenersConfig.SSLSecrets.PKIBackend = v1beta1.PKIBackend("")
+	cluster.Spec.ListenersConfig.SSLSecrets.PKIBackend = ""
 	certmanager = GetPKIManager(&mockClient{}, cluster, v1beta1.PKIBackendProvided)
 	pkiType = reflect.TypeOf(certmanager).String()
 	expected = "*certmanagerpki.certManager"

--- a/pkg/pki/vaultpki/vault_pki.go
+++ b/pkg/pki/vaultpki/vault_pki.go
@@ -19,10 +19,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/banzaicloud/kafka-operator/api/v1alpha1"
-	"github.com/banzaicloud/kafka-operator/pkg/errorfactory"
-	"github.com/banzaicloud/kafka-operator/pkg/resources/templates"
-	pkicommon "github.com/banzaicloud/kafka-operator/pkg/util/pki"
 	"github.com/go-logr/logr"
 	vaultapi "github.com/hashicorp/vault/api"
 	corev1 "k8s.io/api/core/v1"
@@ -30,9 +26,14 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"github.com/banzaicloud/kafka-operator/api/v1alpha1"
+	"github.com/banzaicloud/kafka-operator/pkg/errorfactory"
+	"github.com/banzaicloud/kafka-operator/pkg/resources/templates"
+	pkicommon "github.com/banzaicloud/kafka-operator/pkg/util/pki"
 )
 
-func (v *vaultPKI) FinalizePKI(ctx context.Context, logger logr.Logger) error {
+func (v *vaultPKI) FinalizePKI(_ context.Context, _ logr.Logger) error {
 	vault, err := v.getClient()
 	if err != nil {
 		return err
@@ -46,7 +47,7 @@ func (v *vaultPKI) FinalizePKI(ctx context.Context, logger logr.Logger) error {
 	}
 	for _, user := range users {
 		if user != "broker" && user != "controller" {
-			err = fmt.Errorf("Non broker/controller user exists: %s", user)
+			err = fmt.Errorf("non broker/controller user exists: %s", user)
 			return errorfactory.New(errorfactory.ResourceNotReady{}, err, "pki still contains user certificates")
 		}
 	}
@@ -55,7 +56,7 @@ func (v *vaultPKI) FinalizePKI(ctx context.Context, logger logr.Logger) error {
 }
 
 // ReconcilePKI will use the user-provided paths to ensure broker/operator users for a new KafkaCluster
-func (v *vaultPKI) ReconcilePKI(ctx context.Context, logger logr.Logger, scheme *runtime.Scheme, externalHostnames []string) (err error) {
+func (v *vaultPKI) ReconcilePKI(ctx context.Context, logger logr.Logger, scheme *runtime.Scheme, externalHostnames map[string]string) (err error) {
 	log := logger.WithName("vault_pki")
 
 	log.Info("Retrieving vault client")
@@ -151,7 +152,8 @@ func (v *vaultPKI) reconcileBootstrapSecrets(ctx context.Context, scheme *runtim
 	return
 }
 
-func (v *vaultPKI) reconcileBrokerCert(ctx context.Context, vault *vaultapi.Client, externalHostnames []string) (*pkicommon.UserCertificate, error) {
+func (v *vaultPKI) reconcileBrokerCert(
+	ctx context.Context, vault *vaultapi.Client, externalHostnames map[string]string) (*pkicommon.UserCertificate, error) {
 	return v.reconcileStartupUser(ctx, vault, pkicommon.BrokerUserForCluster(v.cluster, externalHostnames))
 }
 

--- a/pkg/pki/vaultpki/vault_test.go
+++ b/pkg/pki/vaultpki/vault_test.go
@@ -21,20 +21,20 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/banzaicloud/kafka-operator/api/v1beta1"
-	"github.com/banzaicloud/kafka-operator/pkg/errorfactory"
-	certutil "github.com/banzaicloud/kafka-operator/pkg/util/cert"
-	pkicommon "github.com/banzaicloud/kafka-operator/pkg/util/pki"
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/builtin/logical/pki"
 	"github.com/hashicorp/vault/http"
 	"github.com/hashicorp/vault/sdk/logical"
 	"github.com/hashicorp/vault/vault"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+
+	"github.com/banzaicloud/kafka-operator/api/v1beta1"
+	"github.com/banzaicloud/kafka-operator/pkg/errorfactory"
+	certutil "github.com/banzaicloud/kafka-operator/pkg/util/cert"
+	pkicommon "github.com/banzaicloud/kafka-operator/pkg/util/pki"
 )
 
 var log = logf.Log.WithName("testing")
@@ -43,7 +43,7 @@ func newMockCluster() *v1beta1.KafkaCluster {
 	cluster := &v1beta1.KafkaCluster{}
 	cluster.Name = "test"
 	cluster.Namespace = "test-namespace"
-	cluster.UID = types.UID("test-uid")
+	cluster.UID = "test-uid"
 	cluster.Spec = v1beta1.KafkaClusterSpec{}
 	cluster.Spec.ListenersConfig = v1beta1.ListenersConfig{}
 	cluster.Spec.ListenersConfig.InternalListeners = []v1beta1.InternalListenerConfig{
@@ -164,7 +164,7 @@ func TestAll(t *testing.T) {
 		t.Fatal("Failed to convert test cert to JKS")
 	}
 
-	if err := mock.ReconcilePKI(ctx, log, scheme.Scheme, []string{}); err == nil {
+	if err := mock.ReconcilePKI(ctx, log, scheme.Scheme, map[string]string{}); err == nil {
 		t.Error("Expected resource not ready, got nil")
 	} else if reflect.TypeOf(err) != reflect.TypeOf(errorfactory.ResourceNotReady{}) {
 		t.Error("Expected resource not ready, got:", err)
@@ -188,7 +188,7 @@ func TestAll(t *testing.T) {
 	}))
 
 	// Should be safe to do multiple times
-	if err := mock.ReconcilePKI(ctx, log, scheme.Scheme, []string{}); err != nil {
+	if err := mock.ReconcilePKI(ctx, log, scheme.Scheme, map[string]string{}); err != nil {
 		t.Error("Expected no error, got:", err)
 	}
 
@@ -197,7 +197,7 @@ func TestAll(t *testing.T) {
 		t.Error("Expected no error, got:", err)
 	}
 
-	if err := mock.ReconcilePKI(ctx, log, scheme.Scheme, []string{}); err != nil {
+	if err := mock.ReconcilePKI(ctx, log, scheme.Scheme, map[string]string{}); err != nil {
 		t.Error("Expected no error, got:", err)
 	}
 

--- a/pkg/resources/envoy/configmap.go
+++ b/pkg/resources/envoy/configmap.go
@@ -39,7 +39,8 @@ import (
 func (r *Reconciler) configMap(log logr.Logger, extListener v1beta1.ExternalListenerConfig) runtime.Object {
 	configMap := &corev1.ConfigMap{
 		ObjectMeta: templates.ObjectMeta(
-			fmt.Sprintf(envoyVolumeAndConfigName, extListener.Name, r.KafkaCluster.GetName()), labelSelector, r.KafkaCluster),
+			fmt.Sprintf(envoyVolumeAndConfigName, extListener.Name, r.KafkaCluster.GetName()),
+			labelsForEnvoyIngress(r.KafkaCluster.GetName(), extListener.Name), r.KafkaCluster),
 		Data: map[string]string{"envoy.yaml": GenerateEnvoyConfig(r.KafkaCluster, extListener, log)},
 	}
 	return configMap

--- a/pkg/resources/envoy/deployment.go
+++ b/pkg/resources/envoy/deployment.go
@@ -59,15 +59,15 @@ func (r *Reconciler) deployment(log logr.Logger, extListener v1beta1.ExternalLis
 	return &appsv1.Deployment{
 		ObjectMeta: templates.ObjectMeta(
 			fmt.Sprintf(envoyDeploymentName, extListener.Name, r.KafkaCluster.GetName()),
-			labelSelector, r.KafkaCluster),
+			labelsForEnvoyIngress(r.KafkaCluster.GetName(), extListener.Name), r.KafkaCluster),
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
-				MatchLabels: labelSelector,
+				MatchLabels: labelsForEnvoyIngress(r.KafkaCluster.GetName(), extListener.Name),
 			},
 			Replicas: util.Int32Pointer(r.KafkaCluster.Spec.EnvoyConfig.GetReplicas()),
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels:      labelSelector,
+					Labels:      labelsForEnvoyIngress(r.KafkaCluster.GetName(), extListener.Name),
 					Annotations: generatePodAnnotations(r.KafkaCluster, extListener, log),
 				},
 				Spec: corev1.PodSpec{

--- a/pkg/resources/envoy/envoy.go
+++ b/pkg/resources/envoy/envoy.go
@@ -31,8 +31,10 @@ const (
 	envoyDeploymentName      = "envoy-%s-%s"
 )
 
-var labelSelector = map[string]string{
-	"app": "envoy",
+// labelsForEnvoyIngress returns the labels for selecting the resources
+// belonging to the given kafka CR name.
+func labelsForEnvoyIngress(crName, eLName string) map[string]string {
+	return map[string]string{"app": "envoyingress", "eListenerName": eLName, "kafka_cr": crName}
 }
 
 // Reconciler implements the Component Reconciler

--- a/pkg/resources/envoy/loadbalancer.go
+++ b/pkg/resources/envoy/loadbalancer.go
@@ -38,7 +38,8 @@ func (r *Reconciler) loadBalancer(log logr.Logger, extListener v1beta1.ExternalL
 	service := &corev1.Service{
 		ObjectMeta: templates.ObjectMetaWithAnnotations(
 			fmt.Sprintf(envoyutils.EnvoyServiceName, extListener.Name, r.KafkaCluster.GetName()),
-			map[string]string{}, r.KafkaCluster.Spec.EnvoyConfig.GetAnnotations(), r.KafkaCluster),
+			labelsForEnvoyIngress(r.KafkaCluster.GetName(), extListener.Name),
+			r.KafkaCluster.Spec.EnvoyConfig.GetAnnotations(), r.KafkaCluster),
 		Spec: corev1.ServiceSpec{
 			Selector:                 map[string]string{"app": "envoy"},
 			Type:                     corev1.ServiceTypeLoadBalancer,

--- a/pkg/resources/envoy/loadbalancer.go
+++ b/pkg/resources/envoy/loadbalancer.go
@@ -41,7 +41,7 @@ func (r *Reconciler) loadBalancer(log logr.Logger, extListener v1beta1.ExternalL
 			labelsForEnvoyIngress(r.KafkaCluster.GetName(), extListener.Name),
 			r.KafkaCluster.Spec.EnvoyConfig.GetAnnotations(), r.KafkaCluster),
 		Spec: corev1.ServiceSpec{
-			Selector:                 map[string]string{"app": "envoy"},
+			Selector:                 labelsForEnvoyIngress(r.KafkaCluster.GetName(), extListener.Name),
 			Type:                     corev1.ServiceTypeLoadBalancer,
 			Ports:                    exposedPorts,
 			LoadBalancerSourceRanges: r.KafkaCluster.Spec.EnvoyConfig.GetLoadBalancerSourceRanges(),

--- a/pkg/resources/istioingress/istioingress.go
+++ b/pkg/resources/istioingress/istioingress.go
@@ -34,7 +34,7 @@ const (
 // labelsForIstioIngress returns the labels for selecting the resources
 // belonging to the given kafka CR name.
 func labelsForIstioIngress(crName, eLName string) map[string]string {
-	return map[string]string{"app": "istioingress", "eListenerName": eLName}
+	return map[string]string{"app": "istioingress", "eListenerName": eLName, "kafka_cr": crName}
 }
 
 // Reconciler implements the Component Reconciler

--- a/pkg/resources/istioingress/meshgateway.go
+++ b/pkg/resources/istioingress/meshgateway.go
@@ -31,7 +31,9 @@ import (
 
 func (r *Reconciler) meshgateway(log logr.Logger, externalListenerConfig v1beta1.ExternalListenerConfig) runtime.Object {
 	mgateway := &istioOperatorApi.MeshGateway{
-		ObjectMeta: templates.ObjectMeta(fmt.Sprintf(istioingressutils.MeshGatewayNameTemplate, r.KafkaCluster.Name), labelsForIstioIngress(r.KafkaCluster.Name, externalListenerConfig.Name), r.KafkaCluster),
+		ObjectMeta: templates.ObjectMeta(
+			fmt.Sprintf(istioingressutils.MeshGatewayNameTemplate, externalListenerConfig.Name, r.KafkaCluster.Name),
+			labelsForIstioIngress(r.KafkaCluster.Name, externalListenerConfig.Name), r.KafkaCluster),
 		Spec: istioOperatorApi.MeshGatewaySpec{
 			MeshGatewayConfiguration: istioOperatorApi.MeshGatewayConfiguration{
 				Labels:             labelsForIstioIngress(r.KafkaCluster.Name, externalListenerConfig.Name),

--- a/pkg/resources/kafka/configmap_test.go
+++ b/pkg/resources/kafka/configmap_test.go
@@ -17,11 +17,12 @@ package kafka
 import (
 	"testing"
 
-	"github.com/banzaicloud/kafka-operator/api/v1beta1"
-	"github.com/banzaicloud/kafka-operator/pkg/resources"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/banzaicloud/kafka-operator/api/v1beta1"
+	"github.com/banzaicloud/kafka-operator/pkg/resources"
 )
 
 func TestGenerateBrokerConfig(t *testing.T) {
@@ -232,7 +233,7 @@ zookeeper.connect=example.zk:2181/`,
 					},
 				},
 			}
-			generatedConfig := r.generateBrokerConfig(0, r.KafkaCluster.Spec.Brokers[0].BrokerConfig, []string{}, "", "", []string{}, logf.NullLogger{})
+			generatedConfig := r.generateBrokerConfig(0, r.KafkaCluster.Spec.Brokers[0].BrokerConfig, map[string]string{}, "", "", []string{}, logf.NullLogger{})
 
 			if generatedConfig != test.expectedConfig {
 				t.Errorf("the expected config is %s, received: %s", test.expectedConfig, generatedConfig)

--- a/pkg/resources/kafka/kafka.go
+++ b/pkg/resources/kafka/kafka.go
@@ -652,7 +652,7 @@ func (r *Reconciler) reconcileKafkaPod(log logr.Logger, desiredPod *corev1.Pod) 
 		//Since toleration does not support patchStrategy:"merge,retainKeys", we need to add all toleration from the current pod if the toleration is set in the CR
 		if len(desiredPod.Spec.Tolerations) > 0 {
 			desiredPod.Spec.Tolerations = append(desiredPod.Spec.Tolerations, currentPod.Spec.Tolerations...)
-			uniqueTolerations := make([]corev1.Toleration, len(desiredPod.Spec.Tolerations), 0)
+			uniqueTolerations := make([]corev1.Toleration, 0, len(desiredPod.Spec.Tolerations))
 			keys := make(map[corev1.Toleration]bool)
 			for _, t := range desiredPod.Spec.Tolerations {
 				if _, value := keys[t]; !value {

--- a/pkg/resources/kafka/kafka.go
+++ b/pkg/resources/kafka/kafka.go
@@ -115,7 +115,7 @@ func getLoadBalancerIP(client client.Client, namespace, ingressController, crNam
 	foundLBService := &corev1.Service{}
 	var iControllerServiceName string
 	if ingressController == istioingressutils.IngressControllerName {
-		iControllerServiceName = fmt.Sprintf(istioingressutils.MeshGatewayNameTemplate, crName)
+		iControllerServiceName = fmt.Sprintf(istioingressutils.MeshGatewayNameTemplate, extListenerName, crName)
 	} else if ingressController == envoyutils.IngressControllerName {
 		iControllerServiceName = fmt.Sprintf(envoyutils.EnvoyServiceName, extListenerName, crName)
 	}

--- a/pkg/util/envoy/common.go
+++ b/pkg/util/envoy/common.go
@@ -16,7 +16,7 @@ package envoy
 
 const (
 	// EnvoyServiceName name for loadbalancer service
-	EnvoyServiceName = "envoy-loadbalancer"
+	EnvoyServiceName = "envoy-loadbalancer-%s-%s"
 	// IngressControllerName name for envoy ingress service
 	IngressControllerName = "envoy"
 )

--- a/pkg/util/istioingress/common.go
+++ b/pkg/util/istioingress/common.go
@@ -18,5 +18,5 @@ const (
 	// IngressControllerName name for istioingress ingress service
 	IngressControllerName = "istioingress"
 	// IngressControllerName name for istioingress gateway service
-	MeshGatewayNameTemplate = "%s-meshgateway"
+	MeshGatewayNameTemplate = "meshgateway-%s-%s"
 )

--- a/pkg/util/pki/pki_common_test.go
+++ b/pkg/util/pki/pki_common_test.go
@@ -122,7 +122,7 @@ func TestGetInternalDNSNames(t *testing.T) {
 
 func TestBrokerUserForCluster(t *testing.T) {
 	cluster := testCluster(t)
-	user := BrokerUserForCluster(cluster, []string{})
+	user := BrokerUserForCluster(cluster, map[string]string{})
 
 	expected := &v1alpha1.KafkaUser{
 		ObjectMeta: templates.ObjectMeta(GetCommonName(cluster),


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no|
| New feature?    |yes|
| API breaks?     | no|
| Deprecations?   | no|
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

This PR adds support for multiple external listener endpoints for Kafka.
This is a long limitation of the operator which allowed only one external listener per cluster.
Since Kafka is not handling advertised.listeners config as a read-only config any more this listener setting will only work when creating a new cluster with the operator. Adding a new listener to a running cluster will not work since it will trigger a rolling update which will fail. We are working on a different PR which treats these settings as a dynamic config to overcome this limitation. Also we know that we should allow to support multiple settings per listener, that will come soon as well.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
