### PR TITLE
adding broker dns records when using regular services

### DIFF
--- a/pkg/util/pki/common.go
+++ b/pkg/util/pki/common.go
@@ -142,6 +142,15 @@ func clusterDNSNames(cluster *v1beta1.KafkaCluster) (names []string) {
 			fmt.Sprintf("%s.%s.svc", fmt.Sprintf(kafka.AllBrokerServiceTemplate, cluster.Name), cluster.Namespace),
 		)
 
+		// Per Broker notation
+		for _, broker := range cluster.Spec.Brokers {
+			names = append(names,
+				fmt.Sprintf("%s-%d.%s.svc.%s", cluster.Name, broker.Id, cluster.Namespace, cluster.Spec.GetKubernetesClusterDomain()),
+				fmt.Sprintf("%s-%d.%s.svc", cluster.Name, broker.Id, cluster.Namespace),
+				fmt.Sprintf("*.%s-%d.%s", cluster.Name, broker.Id, cluster.Namespace),
+			)
+		}
+
 		// Namespace notation
 		names = append(names,
 			fmt.Sprintf("*.%s.%s", fmt.Sprintf(kafka.AllBrokerServiceTemplate, cluster.Name), cluster.Namespace),

--- a/pkg/util/pki/pki_common_test.go
+++ b/pkg/util/pki/pki_common_test.go
@@ -88,6 +88,11 @@ func TestLabelsForKafkaPKI(t *testing.T) {
 
 func TestGetInternalDNSNames(t *testing.T) {
 	cluster := testCluster(t)
+	cluster.Spec.Brokers = []v1beta1.Broker{
+		{
+			Id: 0,
+		},
+	}
 
 	cluster.Spec.HeadlessServiceEnabled = true
 	headlessNames := GetInternalDNSNames(cluster)
@@ -111,6 +116,9 @@ func TestGetInternalDNSNames(t *testing.T) {
 		"test-cluster-all-broker.test-namespace.svc.cluster.local",
 		"*.test-cluster-all-broker.test-namespace.svc",
 		"test-cluster-all-broker.test-namespace.svc",
+		"test-cluster-0.test-namespace.svc.cluster.local",
+		"test-cluster-0.test-namespace.svc",
+		"*.test-cluster-0.test-namespace",
 		"*.test-cluster-all-broker.test-namespace",
 		"test-cluster-all-broker.test-namespace",
 		"test-cluster-all-broker",


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
`SSL` as external listener type combined with `headlessServiceEnabled: false`  caused a name resolvation error which stopped the cluster from start



### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)


