### PR TITLE
Fix: used port number in 'advertize.listeners' config is wrong when specific external IP is used for NodePort services

### DIFF
--- a/pkg/resources/nodeportExternalAccess/service.go
+++ b/pkg/resources/nodeportExternalAccess/service.go
@@ -32,6 +32,10 @@ import (
 func (r *Reconciler) service(log logr.Logger, id int32,
 	brokerConfig *v1beta1.BrokerConfig, extListener v1beta1.ExternalListenerConfig) runtime.Object {
 
+	nodePort := int32(0)
+	if extListener.ExternalStartingPort > 0 {
+		nodePort = extListener.ExternalStartingPort + id
+	}
 	service := &corev1.Service{
 		ObjectMeta: templates.ObjectMetaWithAnnotations(
 			fmt.Sprintf(serviceName, r.KafkaCluster.GetName(), id, extListener.Name),
@@ -44,7 +48,7 @@ func (r *Reconciler) service(log logr.Logger, id int32,
 			Ports: []corev1.ServicePort{{
 				Name:       fmt.Sprintf("broker-%d", id),
 				Port:       extListener.ContainerPort,
-				NodePort:   extListener.ExternalStartingPort + id,
+				NodePort:   nodePort,
 				TargetPort: intstr.FromInt(int(extListener.ContainerPort)),
 				Protocol:   corev1.ProtocolTCP,
 			},


### PR DESCRIPTION
When Kafka broker is exposed using NodePort type services and the user provides an external IP explicitly for the NodePort type service the port number used in the `advertised.listeners` broker configuration must be the service port (https://kubernetes.io/docs/concepts/services-networking/service/#external-ips) and not the nodePort.
nodePort should be used when no explicit external IP is provided and the broker is reached through the IP of the node where it runs.