### PR TITLE
fix go.mod remove operator sdk

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/banzaicloud/istio-operator v0.0.0-20200407070503-3f7dc6953a7b
 	github.com/banzaicloud/k8s-objectmatcher v1.4.1
 	github.com/banzaicloud/kafka-operator/api v0.0.0
-	github.com/banzaicloud/kafka-operator/pkg/sdk v0.4.1
 	github.com/envoyproxy/go-control-plane v0.9.7
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
 	github.com/go-logr/logr v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -131,8 +131,6 @@ github.com/banzaicloud/istio-operator v0.0.0-20200407070503-3f7dc6953a7b h1:Zd2s
 github.com/banzaicloud/istio-operator v0.0.0-20200407070503-3f7dc6953a7b/go.mod h1:ZsHnkYOQmq/OhsTX/apqgSoT2Jt5qkr15zuoVcj48Xk=
 github.com/banzaicloud/k8s-objectmatcher v1.4.1 h1:/HaUqQzTa5E+pLqG9qelRKUdrzU1Nl2BYPHDut7e1oU=
 github.com/banzaicloud/k8s-objectmatcher v1.4.1/go.mod h1:j+N22VwgVfa0ajVtNxOz2G72aSOL21lpB7qV2GDrr/I=
-github.com/banzaicloud/kafka-operator/pkg/sdk v0.4.1 h1:VQZV4/cpDXn9MULMicBhWrc6OcJpI3gjD2tACvPlu6g=
-github.com/banzaicloud/kafka-operator/pkg/sdk v0.4.1/go.mod h1:WIQILFnnAcaz3ksHiAmCLwvqDxNSpwAgImkdTa8UU+U=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=


### PR DESCRIPTION
Remove unnecessary `github.com/banzaicloud/kafka-operator/pkg/sdk` from the go.mod file. It is left there by accident. IDE added that automatically.
