### PR TITLE
Bound acl and topics information to mocked Kafka client instance

### DIFF
--- a/pkg/kafkaclient/topics_test.go
+++ b/pkg/kafkaclient/topics_test.go
@@ -103,6 +103,14 @@ func TestCreateTopic(t *testing.T) {
 
 func TestDeleteTopic(t *testing.T) {
 	client := newOpenedMockClient()
+	if err := client.CreateTopic(&CreateTopicOptions{
+		Name:              "test-topic",
+		Partitions:        1,
+		ReplicationFactor: 1,
+	}); err != nil {
+		t.Error("Expected no error during creation, got:", err)
+	}
+
 	if err := client.DeleteTopic("test-topic", false); err != nil {
 		t.Error("Expected no error, got:", err)
 	}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | Introduced in #508
| License         | Apache 2.0

### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Fix for a concurrent modification of a map in the tests.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Occasionally you can see the following error in the logs:
```
fatal error: concurrent map writes

goroutine 50 [running]:
runtime.throw(0x2a49a6e, 0x15)
	/usr/local/Cellar/go/1.15.3/libexec/src/runtime/panic.go:1116 +0x72 fp=0xc0010a3018 sp=0xc0010a2fe8 pc=0x10392f2
runtime.mapdelete_faststr(0x27619a0, 0xc0004280f0, 0xc0016e7096, 0xa)
	/usr/local/Cellar/go/1.15.3/libexec/src/runtime/map_faststr.go:377 +0x34c fp=0xc0010a3080 sp=0xc0010a3018 pc=0x1016c8c
github.com/banzaicloud/kafka-operator/pkg/kafkaclient.(*mockClusterAdmin).DeleteTopic(0xc001804cf0, 0xc0016e7096, 0xa, 0xc0004280f0, 0xc0016cf7e8)
	/git/kafka-operator/pkg/kafkaclient/mock_client.go:136 +0x9c fp=0xc0010a30c0 sp=0xc0010a3080 pc=0x2191efc
        ...
```

The referenced code piece is introduced in #508. The mocked client returns a map that other code iterates through and performs deletion on the map. Since we returned the map by address and not by value, this results in a concurrent modification.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline