### PR TITLE
Anycast broker port support for external listeners

### DIFF
--- a/charts/kafka-operator/templates/crds.yaml
+++ b/charts/kafka-operator/templates/crds.yaml
@@ -4803,6 +4803,12 @@ spec:
                           - LoadBalancer
                           - NodePort
                         type: string
+                      anyCastPort:
+                        description: AnyCastPort allows you to specify a port which
+                          allows kafka cluster access without specifying the exact
+                          broker
+                        format: int32
+                        type: integer
                       containerPort:
                         format: int32
                         type: integer

--- a/charts/kafka-operator/templates/crds.yaml
+++ b/charts/kafka-operator/templates/crds.yaml
@@ -4804,9 +4804,8 @@ spec:
                           - NodePort
                         type: string
                       anyCastPort:
-                        description: AnyCastPort allows you to specify a port which
-                          allows kafka cluster access without specifying the exact
-                          broker
+                        description: configuring AnyCastPort allows kafka cluster
+                          access without specifying the exact broker
                         format: int32
                         type: integer
                       containerPort:

--- a/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
+++ b/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
@@ -4804,6 +4804,10 @@ spec:
                         - LoadBalancer
                         - NodePort
                         type: string
+                      anyCastPort:
+                        description: TODO write some description
+                        format: int32
+                        type: integer
                       containerPort:
                         format: int32
                         type: integer

--- a/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
+++ b/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
@@ -4805,7 +4805,9 @@ spec:
                         - NodePort
                         type: string
                       anyCastPort:
-                        description: TODO write some description
+                        description: AnyCastPort allows you to specify a port which
+                          allows kafka cluster access without specifying the exact
+                          broker
                         format: int32
                         type: integer
                       containerPort:

--- a/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
+++ b/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
@@ -4805,9 +4805,8 @@ spec:
                         - NodePort
                         type: string
                       anyCastPort:
-                        description: AnyCastPort allows you to specify a port which
-                          allows kafka cluster access without specifying the exact
-                          broker
+                        description: configuring AnyCastPort allows kafka cluster
+                          access without specifying the exact broker
                         format: int32
                         type: integer
                       containerPort:

--- a/config/samples/simplekafkacluster.yaml
+++ b/config/samples/simplekafkacluster.yaml
@@ -15,7 +15,7 @@ spec:
     auto.create.topics.enable=false
     cruise.control.metrics.topic.auto.create=true
     cruise.control.metrics.topic.num.partitions=1
-    cruise.control.metrics.topic.replication.factor=2
+c    cruise.control.metrics.topic.replication.factor=2
   brokerConfigGroups:
     default:
       storageConfigs:

--- a/config/samples/simplekafkacluster.yaml
+++ b/config/samples/simplekafkacluster.yaml
@@ -15,7 +15,7 @@ spec:
     auto.create.topics.enable=false
     cruise.control.metrics.topic.auto.create=true
     cruise.control.metrics.topic.num.partitions=1
-c    cruise.control.metrics.topic.replication.factor=2
+    cruise.control.metrics.topic.replication.factor=2
   brokerConfigGroups:
     default:
       storageConfigs:

--- a/controllers/tests/kafkacluster_controller_istioingress_test.go
+++ b/controllers/tests/kafkacluster_controller_istioingress_test.go
@@ -129,7 +129,7 @@ var _ = Describe("KafkaClusterIstioIngressController", func() {
 					TargetPort: intstr.FromInt(11202),
 				},
 				corev1.ServicePort{
-					Name:       "tcp-all-brokers",
+					Name:       "tcp-all-broker",
 					Port:       29092,
 					TargetPort: intstr.FromInt(29092),
 				}))
@@ -156,7 +156,7 @@ var _ = Describe("KafkaClusterIstioIngressController", func() {
 					Port: &v1alpha3.Port{
 						Number:   29092,
 						Protocol: "TCP",
-						Name:     "tcp-all-brokers",
+						Name:     "tcp-all-broker",
 					},
 					Hosts: []string{"*"},
 				}))

--- a/pkg/resources/cruisecontrol/configmap.go
+++ b/pkg/resources/cruisecontrol/configmap.go
@@ -84,7 +84,7 @@ func generateBootstrapServerPort(log logr.Logger, listenerConfig []v1beta1.Inter
 		}
 	}
 	// This should never happen since there should be least one listener for inner broker communication
-	log.V(1).Info("listener for inner communication not found falling back")
+	log.V(1).Info("listener for inner communication not found, falling back to first listener")
 	return listenerConfig[0].ContainerPort
 }
 

--- a/pkg/resources/cruisecontrol/configmap.go
+++ b/pkg/resources/cruisecontrol/configmap.go
@@ -46,8 +46,8 @@ bootstrap.servers=%s:%d
 # The zookeeper connect of the Kafka cluster
 zookeeper.connect=%s
 `, generateBootstrapServer(r.KafkaCluster.Spec.HeadlessServiceEnabled, r.KafkaCluster.Name),
-generateBootstrapServerPort(log, r.KafkaCluster.Spec.ListenersConfig.InternalListeners),
-zookeeperutils.PrepareConnectionAddress(r.KafkaCluster.Spec.ZKAddresses, r.KafkaCluster.Spec.GetZkPath())) +
+				generateBootstrapServerPort(log, r.KafkaCluster.Spec.ListenersConfig.InternalListeners),
+				zookeeperutils.PrepareConnectionAddress(r.KafkaCluster.Spec.ZKAddresses, r.KafkaCluster.Spec.GetZkPath())) +
 				generateSSLConfig(&r.KafkaCluster.Spec.ListenersConfig, clientPass),
 			"capacity.json":       capacityConfig,
 			"clusterConfigs.json": r.KafkaCluster.Spec.CruiseControlConfig.ClusterConfig,

--- a/pkg/resources/cruisecontrol/configmap_test.go
+++ b/pkg/resources/cruisecontrol/configmap_test.go
@@ -369,13 +369,13 @@ func TestGenerateCapacityConfig(t *testing.T) {
 		test := test
 
 		t.Run(test.testName, func(t *testing.T) {
-			var actual CruiseControlCapacityConfig
+			var actual CapacityConfig
 			err := json.Unmarshal([]byte(GenerateCapacityConfig(&test.kafkaCluster, log.NullLogger{}, nil)), &actual)
 			if err != nil {
 				t.Error(err, "could not actual unmarshal json")
 			}
 
-			var expected CruiseControlCapacityConfig
+			var expected CapacityConfig
 			err = json.Unmarshal([]byte(test.expectedConfiguration), &expected)
 			if err != nil {
 				t.Error(err, "could not unmarshal expected json")

--- a/pkg/resources/cruisecontrol/cruisecontrol.go
+++ b/pkg/resources/cruisecontrol/cruisecontrol.go
@@ -19,17 +19,18 @@ import (
 	"fmt"
 
 	"emperror.dev/errors"
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	"github.com/banzaicloud/kafka-operator/api/v1alpha1"
 	"github.com/banzaicloud/kafka-operator/api/v1beta1"
 	"github.com/banzaicloud/kafka-operator/pkg/errorfactory"
 	"github.com/banzaicloud/kafka-operator/pkg/k8sutil"
 	"github.com/banzaicloud/kafka-operator/pkg/resources"
 	pkicommon "github.com/banzaicloud/kafka-operator/pkg/util/pki"
-	"github.com/go-logr/logr"
-	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -121,7 +122,7 @@ func (r *Reconciler) Reconcile(log logr.Logger) error {
 			}
 			capacityConfig := GenerateCapacityConfig(r.KafkaCluster, log, config)
 
-			o = r.configMap(clientPass, capacityConfig)
+			o = r.configMap(clientPass, capacityConfig, log)
 			err = k8sutil.Reconcile(log, r.Client, o, r.KafkaCluster)
 			if err != nil {
 				return errors.WrapIfWithDetails(err, "failed to reconcile resource", "resource", o.GetObjectKind().GroupVersionKind())

--- a/pkg/resources/envoy/configmap.go
+++ b/pkg/resources/envoy/configmap.go
@@ -165,7 +165,8 @@ func GenerateEnvoyConfig(kc *v1beta1.KafkaCluster, elistener v1beta1.ExternalLis
 				{
 					Address: &envoycore.Address_SocketAddress{
 						SocketAddress: &envoycore.SocketAddress{
-							Address: fmt.Sprintf(kafkautils.AllBrokerServiceTemplate, kc.Name),
+							Address: fmt.Sprintf(
+								kafkautils.AllBrokerServiceTemplate+".%s.svc.%s", kc.GetName(), kc.GetNamespace(), kc.Spec.GetKubernetesClusterDomain()),
 							PortSpecifier: &envoycore.SocketAddress_PortValue{
 								PortValue: uint32(elistener.ContainerPort),
 							},

--- a/pkg/resources/envoy/deployment.go
+++ b/pkg/resources/envoy/deployment.go
@@ -25,6 +25,7 @@ import (
 	"github.com/banzaicloud/kafka-operator/api/v1beta1"
 	"github.com/banzaicloud/kafka-operator/pkg/resources/templates"
 	"github.com/banzaicloud/kafka-operator/pkg/util"
+	kafkautils "github.com/banzaicloud/kafka-operator/pkg/util/kafka"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -36,6 +37,14 @@ func (r *Reconciler) deployment(log logr.Logger, extListener v1beta1.ExternalLis
 	configMapName := fmt.Sprintf(envoyVolumeAndConfigName, extListener.Name, r.KafkaCluster.GetName())
 	exposedPorts := getExposedContainerPorts(extListener,
 		util.GetBrokerIdsFromStatusAndSpec(r.KafkaCluster.Status.BrokersState, r.KafkaCluster.Spec.Brokers, log))
+
+	if !r.KafkaCluster.Spec.HeadlessServiceEnabled {
+		exposedPorts = append(exposedPorts, corev1.ContainerPort{
+			Name:       fmt.Sprintf(kafkautils.AllBrokerServiceTemplate, "tcp"),
+			ContainerPort: extListener.GetAnyCastPort(),
+			Protocol: corev1.ProtocolTCP,
+		})
+	}
 	volumes := []corev1.Volume{
 		{
 			Name: configMapName,

--- a/pkg/resources/envoy/deployment.go
+++ b/pkg/resources/envoy/deployment.go
@@ -40,9 +40,9 @@ func (r *Reconciler) deployment(log logr.Logger, extListener v1beta1.ExternalLis
 
 	if !r.KafkaCluster.Spec.HeadlessServiceEnabled {
 		exposedPorts = append(exposedPorts, corev1.ContainerPort{
-			Name:       fmt.Sprintf(kafkautils.AllBrokerServiceTemplate, "tcp"),
+			Name:          fmt.Sprintf(kafkautils.AllBrokerServiceTemplate, "tcp"),
 			ContainerPort: extListener.GetAnyCastPort(),
-			Protocol: corev1.ProtocolTCP,
+			Protocol:      corev1.ProtocolTCP,
 		})
 	}
 	volumes := []corev1.Volume{

--- a/pkg/resources/envoy/envoy.go
+++ b/pkg/resources/envoy/envoy.go
@@ -30,6 +30,7 @@ const (
 	// The deployment and configmap name should made from the external listener name the cluster name to avoid all naming collision
 	envoyVolumeAndConfigName = "envoy-config-%s-%s"
 	envoyDeploymentName      = "envoy-%s-%s"
+	allBrokerEnvoyConfigName = "all-brokers"
 )
 
 // labelsForEnvoyIngress returns the labels for selecting the resources

--- a/pkg/resources/istioingress/gateway.go
+++ b/pkg/resources/istioingress/gateway.go
@@ -59,17 +59,15 @@ func generateServers(kc *v1beta1.KafkaCluster, externalListenerConfig v1beta1.Ex
 			Hosts: []string{"*"},
 		})
 	}
-	if !kc.Spec.HeadlessServiceEnabled && len(kc.Spec.ListenersConfig.ExternalListeners) > 0 {
-		servers = append(servers, v1alpha3.Server{
-			Port: &v1alpha3.Port{
-				Number:   int(externalListenerConfig.GetAnyCastPort()),
-				Protocol: protocol,
-				Name:     fmt.Sprintf(kafkautil.AllBrokerServiceTemplate, "tcp"),
-			},
-			Hosts: []string{"*"},
-			TLS:   tlsConfig,
-		})
-	}
+	servers = append(servers, v1alpha3.Server{
+		Port: &v1alpha3.Port{
+			Number:   int(externalListenerConfig.GetAnyCastPort()),
+			Protocol: protocol,
+			Name:     fmt.Sprintf(kafkautil.AllBrokerServiceTemplate, "tcp"),
+		},
+		Hosts: []string{"*"},
+		TLS:   tlsConfig,
+	})
 
 	return servers
 }

--- a/pkg/resources/istioingress/gateway.go
+++ b/pkg/resources/istioingress/gateway.go
@@ -24,6 +24,7 @@ import (
 	"github.com/banzaicloud/kafka-operator/api/v1beta1"
 	"github.com/banzaicloud/kafka-operator/pkg/resources/templates"
 	"github.com/banzaicloud/kafka-operator/pkg/util"
+	kafkautil "github.com/banzaicloud/kafka-operator/pkg/util/kafka"
 )
 
 func (r *Reconciler) gateway(log logr.Logger, externalListenerConfig v1beta1.ExternalListenerConfig) runtime.Object {
@@ -61,9 +62,9 @@ func generateServers(kc *v1beta1.KafkaCluster, externalListenerConfig v1beta1.Ex
 	if !kc.Spec.HeadlessServiceEnabled && len(kc.Spec.ListenersConfig.ExternalListeners) > 0 {
 		servers = append(servers, v1alpha3.Server{
 			Port: &v1alpha3.Port{
-				Number:   int(kc.Spec.ListenersConfig.InternalListeners[0].ContainerPort),
+				Number:   int(externalListenerConfig.GetAnyCastPort()),
 				Protocol: protocol,
-				Name:     "tcp-" + allBrokers,
+				Name:     fmt.Sprintf(kafkautil.AllBrokerServiceTemplate, "tcp"),
 			},
 			Hosts: []string{"*"},
 			TLS:   tlsConfig,

--- a/pkg/resources/istioingress/istioingress.go
+++ b/pkg/resources/istioingress/istioingress.go
@@ -29,7 +29,6 @@ const (
 	componentName          = "istioingress"
 	gatewayNameTemplate    = "%s-%s-gateway"
 	virtualServiceTemplate = "%s-%s-virtualservice"
-	allBrokers             = "all-brokers"
 )
 
 // labelsForIstioIngress returns the labels for selecting the resources

--- a/pkg/resources/istioingress/meshgateway.go
+++ b/pkg/resources/istioingress/meshgateway.go
@@ -27,6 +27,7 @@ import (
 	"github.com/banzaicloud/kafka-operator/pkg/resources/templates"
 	"github.com/banzaicloud/kafka-operator/pkg/util"
 	istioingressutils "github.com/banzaicloud/kafka-operator/pkg/util/istioingress"
+	kafkautils "github.com/banzaicloud/kafka-operator/pkg/util/kafka"
 )
 
 func (r *Reconciler) meshgateway(log logr.Logger, externalListenerConfig v1beta1.ExternalListenerConfig) runtime.Object {
@@ -56,11 +57,11 @@ func (r *Reconciler) meshgateway(log logr.Logger, externalListenerConfig v1beta1
 			Type: istioOperatorApi.GatewayTypeIngress,
 		},
 	}
-	if !r.KafkaCluster.Spec.HeadlessServiceEnabled && len(r.KafkaCluster.Spec.ListenersConfig.ExternalListeners) > 0 {
+	if !r.KafkaCluster.Spec.HeadlessServiceEnabled {
 		mgateway.Spec.Ports = append(mgateway.Spec.Ports, corev1.ServicePort{
-			Name:       "tcp-" + allBrokers,
-			TargetPort: intstr.FromInt(int(r.KafkaCluster.Spec.ListenersConfig.InternalListeners[0].ContainerPort)),
-			Port:       r.KafkaCluster.Spec.ListenersConfig.InternalListeners[0].ContainerPort,
+			Name:       fmt.Sprintf(kafkautils.AllBrokerServiceTemplate, "tcp"),
+			TargetPort: intstr.FromInt(int(externalListenerConfig.GetAnyCastPort())),
+			Port:       externalListenerConfig.GetAnyCastPort(),
 		})
 	}
 	return mgateway

--- a/pkg/resources/istioingress/meshgateway.go
+++ b/pkg/resources/istioingress/meshgateway.go
@@ -57,13 +57,7 @@ func (r *Reconciler) meshgateway(log logr.Logger, externalListenerConfig v1beta1
 			Type: istioOperatorApi.GatewayTypeIngress,
 		},
 	}
-	if !r.KafkaCluster.Spec.HeadlessServiceEnabled {
-		mgateway.Spec.Ports = append(mgateway.Spec.Ports, corev1.ServicePort{
-			Name:       fmt.Sprintf(kafkautils.AllBrokerServiceTemplate, "tcp"),
-			TargetPort: intstr.FromInt(int(externalListenerConfig.GetAnyCastPort())),
-			Port:       externalListenerConfig.GetAnyCastPort(),
-		})
-	}
+
 	return mgateway
 }
 
@@ -76,6 +70,12 @@ func generateExternalPorts(brokerIds []int, externalListenerConfig v1beta1.Exter
 			Port:       externalListenerConfig.ExternalStartingPort + int32(brokerId),
 		})
 	}
+
+	generatedPorts = append(generatedPorts, corev1.ServicePort{
+		Name:       fmt.Sprintf(kafkautils.AllBrokerServiceTemplate, "tcp"),
+		TargetPort: intstr.FromInt(int(externalListenerConfig.GetAnyCastPort())),
+		Port:       externalListenerConfig.GetAnyCastPort(),
+	})
 
 	return generatedPorts
 }

--- a/pkg/resources/istioingress/virtualservice.go
+++ b/pkg/resources/istioingress/virtualservice.go
@@ -78,7 +78,7 @@ func generateTlsRoutes(kc *v1beta1.KafkaCluster, externalListenerConfig v1beta1.
 		tlsRoutes = append(tlsRoutes, v1alpha3.TLSRoute{
 			Match: []v1alpha3.TLSMatchAttributes{
 				{
-					Port:     util.IntPointer(int(kc.Spec.ListenersConfig.InternalListeners[0].ContainerPort)),
+					Port:     util.IntPointer(int(externalListenerConfig.GetAnyCastPort())),
 					SniHosts: []string{"*"},
 				},
 			},
@@ -86,7 +86,7 @@ func generateTlsRoutes(kc *v1beta1.KafkaCluster, externalListenerConfig v1beta1.
 				{
 					Destination: &v1alpha3.Destination{
 						Host: fmt.Sprintf(kafkautils.AllBrokerServiceTemplate, kc.Name),
-						Port: &v1alpha3.PortSelector{Number: uint32(kc.Spec.ListenersConfig.ExternalListeners[0].ContainerPort)},
+						Port: &v1alpha3.PortSelector{Number: uint32(externalListenerConfig.ContainerPort)},
 					},
 				},
 			},
@@ -122,14 +122,14 @@ func generateTcpRoutes(kc *v1beta1.KafkaCluster, externalListenerConfig v1beta1.
 		tcpRoutes = append(tcpRoutes, v1alpha3.TCPRoute{
 			Match: []v1alpha3.L4MatchAttributes{
 				{
-					Port: util.IntPointer(int(kc.Spec.ListenersConfig.InternalListeners[0].ContainerPort)),
+					Port: util.IntPointer(int(externalListenerConfig.GetAnyCastPort())),
 				},
 			},
 			Route: []*v1alpha3.RouteDestination{
 				{
 					Destination: &v1alpha3.Destination{
 						Host: fmt.Sprintf(kafkautils.AllBrokerServiceTemplate, kc.Name),
-						Port: &v1alpha3.PortSelector{Number: uint32(kc.Spec.ListenersConfig.ExternalListeners[0].ContainerPort)},
+						Port: &v1alpha3.PortSelector{Number: uint32(externalListenerConfig.ContainerPort)},
 					},
 				},
 			},

--- a/pkg/resources/istioingress/virtualservice.go
+++ b/pkg/resources/istioingress/virtualservice.go
@@ -118,7 +118,7 @@ func generateTcpRoutes(kc *v1beta1.KafkaCluster, externalListenerConfig v1beta1.
 			},
 		})
 	}
-	if !kc.Spec.HeadlessServiceEnabled && len(kc.Spec.ListenersConfig.ExternalListeners) > 0 {
+	if !kc.Spec.HeadlessServiceEnabled {
 		tcpRoutes = append(tcpRoutes, v1alpha3.TCPRoute{
 			Match: []v1alpha3.L4MatchAttributes{
 				{

--- a/pkg/resources/kafka/headlessService.go
+++ b/pkg/resources/kafka/headlessService.go
@@ -39,6 +39,15 @@ func (r *Reconciler) headlessService() runtime.Object {
 		})
 	}
 
+	//Append external listener ports as well to allow using this service for metadata fetch
+	for _, eListeners := range r.KafkaCluster.Spec.ListenersConfig.ExternalListeners {
+		usedPorts = append(usedPorts, corev1.ServicePort{
+			Name:     strings.ReplaceAll(eListeners.GetListenerServiceName(), "_", ""),
+			Port:     eListeners.ContainerPort,
+			Protocol: corev1.ProtocolTCP,
+		})
+	}
+
 	// prometheus metrics port for servicemonitor
 	usedPorts = append(usedPorts, corev1.ServicePort{
 		Name:       "metrics",

--- a/pkg/sdk/v1beta1/kafkacluster_types.go
+++ b/pkg/sdk/v1beta1/kafkacluster_types.go
@@ -322,7 +322,7 @@ type ExternalListenerConfig struct {
 	CommonListenerSpec   `json:",inline"`
 	ExternalStartingPort int32 `json:"externalStartingPort"`
 	//TODO write some description
-	AnyCastPort          *int32 `json:"anyCastPort,omitempty"`
+	AnyCastPort *int32 `json:"anyCastPort,omitempty"`
 	// In case of external listeners using LoadBalancer access method the value of this field is used to advertise the
 	// Kafka broker external listener instead of the public IP of the provisioned LoadBalancer service (e.g. can be used to
 	// advertise the listener using a URL recorded in DNS instead of public IP).

--- a/pkg/sdk/v1beta1/kafkacluster_types.go
+++ b/pkg/sdk/v1beta1/kafkacluster_types.go
@@ -264,6 +264,13 @@ func (c ExternalListenerConfig) GetAccessMethod() corev1.ServiceType {
 	return c.AccessMethod
 }
 
+func (c ExternalListenerConfig) GetAnyCastPort() int32 {
+	if c.AnyCastPort == nil {
+		return 29092
+	}
+	return *c.AnyCastPort
+}
+
 // GetServiceAnnotations returns a copy of the ServiceAnnotations field.
 func (c ExternalListenerConfig) GetServiceAnnotations() map[string]string {
 	annotations := make(map[string]string, len(c.ServiceAnnotations))
@@ -314,6 +321,8 @@ type AlertManagerConfig struct {
 type ExternalListenerConfig struct {
 	CommonListenerSpec   `json:",inline"`
 	ExternalStartingPort int32 `json:"externalStartingPort"`
+	//TODO write some description
+	AnyCastPort          *int32 `json:"anyCastPort,omitempty"`
 	// In case of external listeners using LoadBalancer access method the value of this field is used to advertise the
 	// Kafka broker external listener instead of the public IP of the provisioned LoadBalancer service (e.g. can be used to
 	// advertise the listener using a URL recorded in DNS instead of public IP).

--- a/pkg/sdk/v1beta1/kafkacluster_types.go
+++ b/pkg/sdk/v1beta1/kafkacluster_types.go
@@ -321,7 +321,7 @@ type AlertManagerConfig struct {
 type ExternalListenerConfig struct {
 	CommonListenerSpec   `json:",inline"`
 	ExternalStartingPort int32 `json:"externalStartingPort"`
-	//TODO write some description
+	// AnyCastPort allows you to specify a port which allows kafka cluster access without specifying the exact broker
 	AnyCastPort *int32 `json:"anyCastPort,omitempty"`
 	// In case of external listeners using LoadBalancer access method the value of this field is used to advertise the
 	// Kafka broker external listener instead of the public IP of the provisioned LoadBalancer service (e.g. can be used to

--- a/pkg/sdk/v1beta1/kafkacluster_types.go
+++ b/pkg/sdk/v1beta1/kafkacluster_types.go
@@ -30,6 +30,7 @@ import (
 const (
 	// DefaultServiceAccountName name used for the various ServiceAccounts
 	DefaultServiceAccountName = "default"
+	defaultAnyCastPort        = 29092
 )
 
 // KafkaClusterSpec defines the desired state of KafkaCluster
@@ -266,7 +267,7 @@ func (c ExternalListenerConfig) GetAccessMethod() corev1.ServiceType {
 
 func (c ExternalListenerConfig) GetAnyCastPort() int32 {
 	if c.AnyCastPort == nil {
-		return 29092
+		return defaultAnyCastPort
 	}
 	return *c.AnyCastPort
 }
@@ -321,7 +322,7 @@ type AlertManagerConfig struct {
 type ExternalListenerConfig struct {
 	CommonListenerSpec   `json:",inline"`
 	ExternalStartingPort int32 `json:"externalStartingPort"`
-	// AnyCastPort allows you to specify a port which allows kafka cluster access without specifying the exact broker
+	// configuring AnyCastPort allows kafka cluster access without specifying the exact broker
 	AnyCastPort *int32 `json:"anyCastPort,omitempty"`
 	// In case of external listeners using LoadBalancer access method the value of this field is used to advertise the
 	// Kafka broker external listener instead of the public IP of the provisioned LoadBalancer service (e.g. can be used to

--- a/pkg/sdk/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/sdk/v1beta1/zz_generated.deepcopy.go
@@ -319,6 +319,11 @@ func (in *EnvoyConfig) DeepCopy() *EnvoyConfig {
 func (in *ExternalListenerConfig) DeepCopyInto(out *ExternalListenerConfig) {
 	*out = *in
 	out.CommonListenerSpec = in.CommonListenerSpec
+	if in.AnyCastPort != nil {
+		in, out := &in.AnyCastPort, &out.AnyCastPort
+		*out = new(int32)
+		**out = **in
+	}
 	if in.ServiceAnnotations != nil {
 		in, out := &in.ServiceAnnotations, &out.ServiceAnnotations
 		*out = make(map[string]string, len(*in))


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |yes|
| New feature?    | yes|
| API breaks?     | no|
| Deprecations?   | no|
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
This PR adds support for something called anycast broker port which can be used as a single endpoint for clients.
It supports envoy and istioingress controllers as well.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
