### PR TITLE
Put controller broker at the bottom of the broker list

### DIFF
--- a/pkg/kafkaclient/client.go
+++ b/pkg/kafkaclient/client.go
@@ -44,7 +44,7 @@ type KafkaClient interface {
 	DeleteUserACLs(string) error
 
 	Brokers() map[int32]string
-	DescribeCluster() ([]*sarama.Broker, error)
+	DescribeCluster() ([]*sarama.Broker, int32, error)
 
 	OfflineReplicaCount() (int, error)
 	AllReplicaInSync() (bool, error)
@@ -92,7 +92,7 @@ func (k *kafkaClient) Open() error {
 		return err
 	}
 
-	if k.brokers, err = k.DescribeCluster(); err != nil {
+	if k.brokers, _, err = k.DescribeCluster(); err != nil {
 		k.admin.Close()
 		err = errorfactory.New(errorfactory.BrokersNotReady{}, err, "could not describe kafka cluster")
 		return err
@@ -144,8 +144,8 @@ func (k *kafkaClient) GetBroker(id int32) (broker *sarama.Broker) {
 	return
 }
 
-func (k *kafkaClient) DescribeCluster() (brokers []*sarama.Broker, err error) {
-	brokers, _, err = k.admin.DescribeCluster()
+func (k *kafkaClient) DescribeCluster() (brokers []*sarama.Broker, controllerID int32, err error) {
+	brokers, controllerID, err = k.admin.DescribeCluster()
 	return
 }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0

### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Reordered the list of brokers during reconciliation.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
The recommendation is to leave the controller broker last, so that Kafka won't do lots of controller reelections during rolling upgrades.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline