### PR TITLE
fix: KafkaCluster defaults

### DIFF
--- a/charts/kafka-operator/templates/crds.yaml
+++ b/charts/kafka-operator/templates/crds.yaml
@@ -5682,9 +5682,6 @@ spec:
                   type: string
                 pathToJar:
                   type: string
-              required:
-                - jmxImage
-                - pathToJar
               type: object
             oneBrokerPerNode:
               description: If true OneBrokerPerNode ensures that each kafka broker

--- a/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
+++ b/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
@@ -5683,9 +5683,6 @@ spec:
                   type: string
                 pathToJar:
                   type: string
-              required:
-              - jmxImage
-              - pathToJar
               type: object
             oneBrokerPerNode:
               description: If true OneBrokerPerNode ensures that each kafka broker

--- a/pkg/resources/kafka/pod.go
+++ b/pkg/resources/kafka/pod.go
@@ -141,7 +141,7 @@ rm /var/run/wait/do-not-exit-yet`}
 			Containers: []corev1.Container{
 				{
 					Name:  "kafka",
-					Image: util.GetBrokerImage(brokerConfig, r.KafkaCluster.Spec.ClusterImage),
+					Image: util.GetBrokerImage(brokerConfig, r.KafkaCluster.Spec.GetClusterImage()),
 					Lifecycle: &corev1.Lifecycle{
 						PreStop: &corev1.Handler{
 							Exec: &corev1.ExecAction{

--- a/pkg/sdk/v1beta1/kafkacluster_types.go
+++ b/pkg/sdk/v1beta1/kafkacluster_types.go
@@ -477,6 +477,14 @@ func (kSpec *KafkaClusterSpec) GetZkPath() string {
 	}
 }
 
+// GetClusterImage returns the default container image for Kafka Cluster
+func (kSpec *KafkaClusterSpec) GetClusterImage() string {
+	if kSpec.ClusterImage != "" {
+		return kSpec.ClusterImage
+	}
+	return "ghcr.io/banzaicloud/kafka:2.13-2.6.0-bzc.1"
+}
+
 func (cTaskSpec *CruiseControlTaskSpec) GetDurationMinutes() float64 {
 	if cTaskSpec.RetryDurationMinutes == 0 {
 		return 5

--- a/pkg/sdk/v1beta1/kafkacluster_types.go
+++ b/pkg/sdk/v1beta1/kafkacluster_types.go
@@ -234,8 +234,8 @@ func (iIConfig *IstioIngressConfig) GetVirtualServiceAnnotations() map[string]st
 
 // MonitoringConfig defines the config for monitoring Kafka and Cruise Control
 type MonitoringConfig struct {
-	JmxImage               string `json:"jmxImage"`
-	PathToJar              string `json:"pathToJar"`
+	JmxImage               string `json:"jmxImage,omitempty"`
+	PathToJar              string `json:"pathToJar,omitempty"`
 	KafkaJMXExporterConfig string `json:"kafkaJMXExporterConfig,omitempty"`
 	CCJMXExporterConfig    string `json:"cCJMXExporterConfig,omitempty"`
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
It fixes two cases where Kafka Operator does not behave as intended.

### Why?
1. The `jmxImage` and `pathToJar` parameters of the `monitoringConfig` should be optional as the mechanism to use defaults in case neither is provided.

2. Kafka Operator fails to deploy Kafka Broker pods if neither the `clusterImage` nor the per-broker `image` parameter present in the `KakfaCluster` CR while both are optional parameters.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)