### PR TITLE
Clone envoy annotation map instead of return

### DIFF
--- a/pkg/resources/istioingress/meshgateway.go
+++ b/pkg/resources/istioingress/meshgateway.go
@@ -47,7 +47,7 @@ func (r *Reconciler) meshgateway(log logr.Logger, externalListenerConfig v1beta1
 						Resources:      r.KafkaCluster.Spec.IstioIngressConfig.GetResources(),
 						NodeSelector:   r.KafkaCluster.Spec.IstioIngressConfig.NodeSelector,
 						Tolerations:    r.KafkaCluster.Spec.IstioIngressConfig.Tolerations,
-						PodAnnotations: r.KafkaCluster.Spec.IstioIngressConfig.Annotations,
+						PodAnnotations: r.KafkaCluster.Spec.IstioIngressConfig.GetAnnotations(),
 					},
 				},
 				ServiceType: corev1.ServiceTypeLoadBalancer,

--- a/pkg/sdk/v1beta1/kafkacluster_types.go
+++ b/pkg/sdk/v1beta1/kafkacluster_types.go
@@ -222,12 +222,12 @@ type IstioIngressConfig struct {
 }
 
 func (iIConfig *IstioIngressConfig) GetAnnotations() map[string]string {
-	return CloneAnnotationMap(iIConfig.Annotations)
+	return cloneAnnotationMap(iIConfig.Annotations)
 }
 
 // GetVirtualServiceAnnotations returns a copy of the VirtualServiceAnnotations field
 func (iIConfig *IstioIngressConfig) GetVirtualServiceAnnotations() map[string]string {
-	return CloneAnnotationMap(iIConfig.VirtualServiceAnnotations)
+	return cloneAnnotationMap(iIConfig.VirtualServiceAnnotations)
 }
 
 // MonitoringConfig defines the config for monitoring Kafka and Cruise Control
@@ -254,7 +254,7 @@ type ListenersConfig struct {
 
 // GetServiceAnnotations returns a copy of the ServiceAnnotations field.
 func (c ListenersConfig) GetServiceAnnotations() map[string]string {
-	return CloneAnnotationMap(c.ServiceAnnotations)
+	return cloneAnnotationMap(c.ServiceAnnotations)
 }
 
 func (c ExternalListenerConfig) GetAccessMethod() corev1.ServiceType {
@@ -273,7 +273,7 @@ func (c ExternalListenerConfig) GetAnyCastPort() int32 {
 
 // GetServiceAnnotations returns a copy of the ServiceAnnotations field.
 func (c ExternalListenerConfig) GetServiceAnnotations() map[string]string {
-	return CloneAnnotationMap(c.ServiceAnnotations)
+	return cloneAnnotationMap(c.ServiceAnnotations)
 }
 
 // SSLSecrets defines the Kafka SSL secrets
@@ -485,7 +485,7 @@ func (eConfig *EnvoyConfig) GetLoadBalancerSourceRanges() []string {
 
 //GetAnnotations returns Annotations to use for Envoy generated LoadBalancer
 func (eConfig *EnvoyConfig) GetAnnotations() map[string]string {
-	return CloneAnnotationMap(eConfig.Annotations)
+	return cloneAnnotationMap(eConfig.Annotations)
 }
 
 // GetReplicas returns replicas used by the Envoy deployment
@@ -557,12 +557,12 @@ func (bConfig *BrokerConfig) GetImagePullSecrets() []corev1.LocalObjectReference
 
 // GetBrokerAnnotations return the annotations which applied to broker pods
 func (bConfig *BrokerConfig) GetBrokerAnnotations() map[string]string {
-	return CloneAnnotationMap(bConfig.BrokerAnnotations)
+	return cloneAnnotationMap(bConfig.BrokerAnnotations)
 }
 
 // GetCruiseControlAnnotations return the annotations which applied to CruiseControl pod
 func (cConfig *CruiseControlConfig) GetCruiseControlAnnotations() map[string]string {
-	return CloneAnnotationMap(cConfig.CruiseControlAnnotations)
+	return cloneAnnotationMap(cConfig.CruiseControlAnnotations)
 }
 
 //GetImagePullSecrets returns the list of Secrets needed to pull Containers images from private repositories
@@ -921,7 +921,7 @@ func (mConfig *MonitoringConfig) GetCCJMXExporterConfig() string {
 `
 }
 
-func CloneAnnotationMap(original map[string]string) map[string]string {
+func cloneAnnotationMap(original map[string]string) map[string]string {
 	m := make(map[string]string, len(original))
 	for k, v := range original {
 		m[k] = v

--- a/pkg/sdk/v1beta1/kafkacluster_types.go
+++ b/pkg/sdk/v1beta1/kafkacluster_types.go
@@ -499,7 +499,13 @@ func (eConfig *EnvoyConfig) GetLoadBalancerSourceRanges() []string {
 
 //GetAnnotations returns Annotations to use for Envoy generated LoadBalancer
 func (eConfig *EnvoyConfig) GetAnnotations() map[string]string {
-	return eConfig.Annotations
+	annotations := make(map[string]string, len(eConfig.Annotations))
+
+	for key, value := range eConfig.Annotations {
+		annotations[key] = value
+	}
+
+	return annotations
 }
 
 // GetReplicas returns replicas used by the Envoy deployment

--- a/pkg/sdk/v1beta1/kafkacluster_types.go
+++ b/pkg/sdk/v1beta1/kafkacluster_types.go
@@ -221,15 +221,13 @@ type IstioIngressConfig struct {
 	VirtualServiceAnnotations map[string]string            `json:"virtualServiceAnnotations,omitempty"`
 }
 
+func (iIConfig *IstioIngressConfig) GetAnnotations() map[string]string {
+	return CloneAnnotationMap(iIConfig.Annotations)
+}
+
 // GetVirtualServiceAnnotations returns a copy of the VirtualServiceAnnotations field
 func (iIConfig *IstioIngressConfig) GetVirtualServiceAnnotations() map[string]string {
-	annotations := make(map[string]string, len(iIConfig.VirtualServiceAnnotations))
-
-	for key, value := range iIConfig.VirtualServiceAnnotations {
-		annotations[key] = value
-	}
-
-	return annotations
+	return CloneAnnotationMap(iIConfig.VirtualServiceAnnotations)
 }
 
 // MonitoringConfig defines the config for monitoring Kafka and Cruise Control
@@ -256,13 +254,7 @@ type ListenersConfig struct {
 
 // GetServiceAnnotations returns a copy of the ServiceAnnotations field.
 func (c ListenersConfig) GetServiceAnnotations() map[string]string {
-	annotations := make(map[string]string, len(c.ServiceAnnotations))
-
-	for key, value := range c.ServiceAnnotations {
-		annotations[key] = value
-	}
-
-	return annotations
+	return CloneAnnotationMap(c.ServiceAnnotations)
 }
 
 func (c ExternalListenerConfig) GetAccessMethod() corev1.ServiceType {
@@ -281,13 +273,7 @@ func (c ExternalListenerConfig) GetAnyCastPort() int32 {
 
 // GetServiceAnnotations returns a copy of the ServiceAnnotations field.
 func (c ExternalListenerConfig) GetServiceAnnotations() map[string]string {
-	annotations := make(map[string]string, len(c.ServiceAnnotations))
-
-	for key, value := range c.ServiceAnnotations {
-		annotations[key] = value
-	}
-
-	return annotations
+	return CloneAnnotationMap(c.ServiceAnnotations)
 }
 
 // SSLSecrets defines the Kafka SSL secrets
@@ -499,13 +485,7 @@ func (eConfig *EnvoyConfig) GetLoadBalancerSourceRanges() []string {
 
 //GetAnnotations returns Annotations to use for Envoy generated LoadBalancer
 func (eConfig *EnvoyConfig) GetAnnotations() map[string]string {
-	annotations := make(map[string]string, len(eConfig.Annotations))
-
-	for key, value := range eConfig.Annotations {
-		annotations[key] = value
-	}
-
-	return annotations
+	return CloneAnnotationMap(eConfig.Annotations)
 }
 
 // GetReplicas returns replicas used by the Envoy deployment
@@ -577,12 +557,12 @@ func (bConfig *BrokerConfig) GetImagePullSecrets() []corev1.LocalObjectReference
 
 // GetBrokerAnnotations return the annotations which applied to broker pods
 func (bConfig *BrokerConfig) GetBrokerAnnotations() map[string]string {
-	return bConfig.BrokerAnnotations
+	return CloneAnnotationMap(bConfig.BrokerAnnotations)
 }
 
 // GetCruiseControlAnnotations return the annotations which applied to CruiseControl pod
 func (cConfig *CruiseControlConfig) GetCruiseControlAnnotations() map[string]string {
-	return cConfig.CruiseControlAnnotations
+	return CloneAnnotationMap(cConfig.CruiseControlAnnotations)
 }
 
 //GetImagePullSecrets returns the list of Secrets needed to pull Containers images from private repositories
@@ -939,4 +919,12 @@ func (mConfig *MonitoringConfig) GetCCJMXExporterConfig() string {
 	return `
     lowercaseOutputName: true
 `
+}
+
+func CloneAnnotationMap(original map[string]string) map[string]string {
+	m := make(map[string]string, len(original))
+	for k, v := range original {
+		m[k] = v
+	}
+	return m
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #539, relates to #550
| License         | Apache 2.0

### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Small change that clones the `KafkaCluster.EnvoyConfig.Annotations map[string]string` instead of directly returning it. This causes a bug that `KafkaCluster` CR containing the original reference of the map also gets updated when the annotations are updated by the `Annotator` during reconcile.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Fixes #539 as this prevents the update of CR with the `banzaicloud.com/last-applied` annotation.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->
Reproduced #539 on master locally, but could not reproduce it after this patch. This needs confirmation by @lengrongfu.

#550 is not really feasible as the controller needs the last-applied annotation to effectively calculate diffs between updates.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline