### PR TITLE
fix: keystore path in Cruise Cobntrol config

### DIFF
--- a/pkg/resources/cruisecontrol/configmap.go
+++ b/pkg/resources/cruisecontrol/configmap.go
@@ -88,10 +88,10 @@ func generateSSLConfig(l *v1beta1.ListenersConfig, clientPass string, log logr.L
 		if err := sslConf.Set("security.protocol", "SSL"); err != nil {
 			log.Error(err, "settings security.protocol in Cruise Control configuration failed")
 		}
-		if err := sslConf.Set("ssl.truststore.location", v1alpha1.TLSJKSTrustStore); err != nil {
+		if err := sslConf.Set("ssl.truststore.location", keystoreVolumePath+"/"+v1alpha1.TLSJKSTrustStore); err != nil {
 			log.Error(err, "settings ssl.truststore.location in Cruise Control configuration failed")
 		}
-		if err := sslConf.Set("ssl.keystore.location", v1alpha1.TLSJKSKeyStore); err != nil {
+		if err := sslConf.Set("ssl.keystore.location", keystoreVolumePath+"/"+v1alpha1.TLSJKSKeyStore); err != nil {
 			log.Error(err, "settings ssl.keystore.location in Cruise Control configuration failed")
 		}
 		if err := sslConf.Set("ssl.keystore.password", clientPass); err != nil {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0

### What's in this PR?
Fixes issue with filesystem path for Java Keystore in Cruise Control configuration introduced in #542.

### Checklist

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)

