### PR TITLE
Add operator.annotations also to Deployment object

### DIFF
--- a/charts/kafka-operator/templates/operator-deployment-with-webhook.yaml
+++ b/charts/kafka-operator/templates/operator-deployment-with-webhook.yaml
@@ -81,6 +81,10 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
     app.kubernetes.io/component: operator
+  {{- with .Values.operator.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | n/a
| License         | Apache 2.0


### What's in this PR?
Add `.Values.operator.annotations` to Deployment object. Not just pods


### Why?
To allow other k8s  tooling manipulate with the deployment.

Simple usacase: kube-janitor cleans ups development deployments after specified ttl in annotations. By not providing this annotation users cannot have stable kafkaclusters.
