### PR TITLE
Fix nil pointer which occurs when controller is deleted from spec

### DIFF
--- a/pkg/resources/kafka/kafka.go
+++ b/pkg/resources/kafka/kafka.go
@@ -902,15 +902,17 @@ func (r *Reconciler) reorderBrokers(log logr.Logger, brokers []v1beta1.Broker) [
 		return brokers
 	}
 
-	var controllerBroker v1beta1.Broker
+	var controllerBroker *v1beta1.Broker
 	reorderedBrokers := make([]v1beta1.Broker, 0, len(brokers))
-	for _, broker := range brokers {
-		if broker.Id == controllerID {
-			controllerBroker = broker
+	for i := range brokers {
+		if brokers[i].Id == controllerID {
+			controllerBroker = &brokers[i]
 		} else {
-			reorderedBrokers = append(reorderedBrokers, broker)
+			reorderedBrokers = append(reorderedBrokers, brokers[i])
 		}
 	}
-	reorderedBrokers = append(reorderedBrokers, controllerBroker)
+	if controllerBroker != nil {
+		reorderedBrokers = append(reorderedBrokers, *controllerBroker)
+	}
 	return reorderedBrokers
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |yes|
| New feature?    | no|
| API breaks?     | no|
| Deprecations?   | no|
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
This PR fixes a nil pointer exception which occurs when the the controller broker is removed from the cluster.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
