### PR TITLE
Reset HealthCheckNodePort field during object reconcile

### DIFF
--- a/pkg/k8sutil/resource.go
+++ b/pkg/k8sutil/resource.go
@@ -123,6 +123,7 @@ func Reconcile(log logr.Logger, client runtimeClient.Client, desired runtime.Obj
 				svc := desired.(*corev1.Service)
 				svc.ResourceVersion = current.(*corev1.Service).ResourceVersion
 				svc.Spec.ClusterIP = current.(*corev1.Service).Spec.ClusterIP
+				svc.Spec.HealthCheckNodePort = current.(*corev1.Service).Spec.HealthCheckNodePort
 				desired = svc
 			}
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #546 
| License         | Apache 2.0

### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Setting the `spec.HealthCheckNodePort` field of a service that is reconciled by the operator.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
As `HealthCheckNodePort` has to be repopulated, as it can not be changed after creation. See #546 for the bug report.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline