### PR TITLE
Add default broker capacity config for CruiseControl

### DIFF
--- a/controllers/tests/kafkacluster_controller_cruisecontrol_test.go
+++ b/controllers/tests/kafkacluster_controller_cruisecontrol_test.go
@@ -151,6 +151,18 @@ zookeeper.connect=/
                 "NW_OUT": "125000"
             },
             "doc": "Capacity unit used for disk is in MB, cpu is in percentage, network throughput is in KB."
+        },
+        {
+            "brokerId": "-1",
+            "capacity": {
+                "DISK": {
+                    "/kafka-logs/kafka": "10737418240"
+                },
+                "CPU": "100",
+                "NW_IN": "125000",
+                "NW_OUT": "125000"
+            },
+            "doc": "Capacity unit used for disk is in MB, cpu is in percentage, network throughput is in KB."
         }
     ]
 }`))

--- a/pkg/resources/cruisecontrol/configmap_test.go
+++ b/pkg/resources/cruisecontrol/configmap_test.go
@@ -247,6 +247,18 @@ func TestGenerateCapacityConfig(t *testing.T) {
 					   "NW_OUT": "125000"
 					  },
 					  "doc": "Capacity unit used for disk is in MB, cpu is in percentage, network throughput is in KB."
+					 },
+					 {
+					  "brokerId": "-1",
+					  "capacity": {
+					   "DISK": {
+						"/kafka-logs/kafka": "10737418240"
+					   },
+					   "CPU": "100",
+					   "NW_IN": "125000",
+					   "NW_OUT": "125000"
+					  },
+					  "doc": "Capacity unit used for disk is in MB, cpu is in percentage, network throughput is in KB."
 					 }
 					]
                   }`,
@@ -355,6 +367,18 @@ func TestGenerateCapacityConfig(t *testing.T) {
 					   "CPU": "150",
 					   "NW_IN": "200",
 					   "NW_OUT": "200"
+					  },
+					  "doc": "Capacity unit used for disk is in MB, cpu is in percentage, network throughput is in KB."
+					 },
+					 {
+					  "brokerId": "-1",
+					  "capacity": {
+					   "DISK": {
+						"/kafka-logs/kafka": "10737418240"
+					   },
+					   "CPU": "100",
+					   "NW_IN": "125000",
+					   "NW_OUT": "125000"
 					  },
 					  "doc": "Capacity unit used for disk is in MB, cpu is in percentage, network throughput is in KB."
 					 }

--- a/pkg/resources/cruisecontrol/configmap_test.go
+++ b/pkg/resources/cruisecontrol/configmap_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/banzaicloud/kafka-operator/api/v1beta1"
 )
 
-func TestGenerateCapacityConfig(t *testing.T) {
+func TestGenerateCapacityConfig_JBOD(t *testing.T) {
 	quantity, _ := resource.ParseQuantity("10Gi")
 	cpuQuantity, _ := resource.ParseQuantity("2000m")
 
@@ -400,6 +400,342 @@ func TestGenerateCapacityConfig(t *testing.T) {
 			}
 
 			var expected CapacityConfig
+			err = json.Unmarshal([]byte(test.expectedConfiguration), &expected)
+			if err != nil {
+				t.Error(err, "could not unmarshal expected json")
+			}
+
+			if !reflect.DeepEqual(actual, expected) {
+				t.Error("Expected:", expected, ", got:", actual)
+			}
+		})
+	}
+}
+
+func TestGenerateCapacityConfigWithUserProvidedInput(t *testing.T) {
+	cpuQuantity, _ := resource.ParseQuantity("2000m")
+
+	testCases := []struct {
+		testName              string
+		capacityConfig        string
+		expectedConfiguration string
+	}{
+		{
+			testName: "JBOD case, without default broker",
+			capacityConfig: `
+                  {
+				  "brokerCapacities":[
+					{
+					  "brokerId": "0",
+					  "capacity": {
+						"DISK": {"/tmp/kafka-logs": "500000"},
+						"CPU": "100",
+						"NW_IN": "50000",
+						"NW_OUT": "50000"
+					  },
+					  "doc": "This overrides the capacity for broker 0. This broker is not a JBOD broker."
+					},
+					{
+					  "brokerId": "1",
+					  "capacity": {
+						"DISK": {"/tmp/kafka-logs-1": "250000", "/tmp/kafka-logs-2": "250000"},
+						"CPU": "100",
+						"NW_IN": "50000",
+						"NW_OUT": "50000"
+					  },
+					  "doc": "This overrides the capacity for broker 1. This broker is a JBOD broker."
+					}
+				  ]
+				}`,
+			expectedConfiguration: `
+                  {
+				  "brokerCapacities":[
+					{
+					  "brokerId": "0",
+					  "capacity": {
+						"DISK": {"/tmp/kafka-logs": "500000"},
+						"CPU": "100",
+						"NW_IN": "50000",
+						"NW_OUT": "50000"
+					  },
+					  "doc": "This overrides the capacity for broker 0. This broker is not a JBOD broker."
+					},
+					{
+					  "brokerId": "1",
+					  "capacity": {
+						"DISK": {"/tmp/kafka-logs-1": "250000", "/tmp/kafka-logs-2": "250000"},
+						"CPU": "100",
+						"NW_IN": "50000",
+						"NW_OUT": "50000"
+					  },
+					  "doc": "This overrides the capacity for broker 1. This broker is a JBOD broker."
+					},
+					{
+					  "brokerId": "-1",
+					  "capacity": {
+						"DISK": {"/kafka-logs/kafka": "10737418240"},
+						"CPU": "100",
+						"NW_IN": "125000",
+						"NW_OUT": "125000"
+					  },
+					  "doc": "Capacity unit used for disk is in MB, cpu is in percentage, network throughput is in KB."
+					}
+				  ]
+				}`,
+		},
+		{
+			testName: "JBOD case, with default broker",
+			capacityConfig: `
+                  {
+				  "brokerCapacities":[
+					{
+					  "brokerId": "-1",
+					  "capacity": {
+						"DISK": {"/tmp/kafka-logs-1": "100000", "/tmp/kafka-logs-2": "100000", "/tmp/kafka-logs-3": "50000",
+						  "/tmp/kafka-logs-4": "50000", "/tmp/kafka-logs-5": "150000", "/tmp/kafka-logs-6": "50000"},
+						"CPU": "100",
+						"NW_IN": "10000",
+						"NW_OUT": "10000"
+					  },
+					  "doc": "The default capacity for a broker with multiple logDirs each on a separate heterogeneous disk."
+					},
+					{
+					  "brokerId": "0",
+					  "capacity": {
+						"DISK": {"/tmp/kafka-logs": "500000"},
+						"CPU": "100",
+						"NW_IN": "50000",
+						"NW_OUT": "50000"
+					  },
+					  "doc": "This overrides the capacity for broker 0. This broker is not a JBOD broker."
+					},
+					{
+					  "brokerId": "1",
+					  "capacity": {
+						"DISK": {"/tmp/kafka-logs-1": "250000", "/tmp/kafka-logs-2": "250000"},
+						"CPU": "100",
+						"NW_IN": "50000",
+						"NW_OUT": "50000"
+					  },
+					  "doc": "This overrides the capacity for broker 1. This broker is a JBOD broker."
+					}
+				  ]
+				}`,
+			expectedConfiguration: `
+                  {
+				  "brokerCapacities":[
+					{
+					  "brokerId": "-1",
+					  "capacity": {
+						"DISK": {"/tmp/kafka-logs-1": "100000", "/tmp/kafka-logs-2": "100000", "/tmp/kafka-logs-3": "50000",
+						  "/tmp/kafka-logs-4": "50000", "/tmp/kafka-logs-5": "150000", "/tmp/kafka-logs-6": "50000"},
+						"CPU": "100",
+						"NW_IN": "10000",
+						"NW_OUT": "10000"
+					  },
+					  "doc": "The default capacity for a broker with multiple logDirs each on a separate heterogeneous disk."
+					},
+					{
+					  "brokerId": "0",
+					  "capacity": {
+						"DISK": {"/tmp/kafka-logs": "500000"},
+						"CPU": "100",
+						"NW_IN": "50000",
+						"NW_OUT": "50000"
+					  },
+					  "doc": "This overrides the capacity for broker 0. This broker is not a JBOD broker."
+					},
+					{
+					  "brokerId": "1",
+					  "capacity": {
+						"DISK": {"/tmp/kafka-logs-1": "250000", "/tmp/kafka-logs-2": "250000"},
+						"CPU": "100",
+						"NW_IN": "50000",
+						"NW_OUT": "50000"
+					  },
+					  "doc": "This overrides the capacity for broker 1. This broker is a JBOD broker."
+					}
+				  ]
+				}`,
+		},
+		{
+			testName: "without JBOD and default broker",
+			capacityConfig: `
+                  {
+				  "brokerCapacities":[
+					{
+					  "brokerId": "0",
+					  "capacity": {
+						"DISK": "500000",
+						"CPU": "100",
+						"NW_IN": "50000",
+						"NW_OUT": "50000"
+					  },
+					  "doc": "This overrides the capacity for broker 0. This broker is not a JBOD broker."
+					},
+					{
+					  "brokerId": "1",
+					  "capacity": {
+						"DISK": "250000",
+						"CPU": "100",
+						"NW_IN": "50000",
+						"NW_OUT": "50000"
+					  },
+					  "doc": "This overrides the capacity for broker 1. This broker is a JBOD broker."
+					}
+				  ]
+				}`,
+			expectedConfiguration: `
+                  {
+				  "brokerCapacities":[
+					{
+					  "brokerId": "0",
+					  "capacity": {
+						"DISK": "500000",
+						"CPU": "100",
+						"NW_IN": "50000",
+						"NW_OUT": "50000"
+					  },
+					  "doc": "This overrides the capacity for broker 0. This broker is not a JBOD broker."
+					},
+					{
+					  "brokerId": "1",
+					  "capacity": {
+						"DISK": "250000",
+						"CPU": "100",
+						"NW_IN": "50000",
+						"NW_OUT": "50000"
+					  },
+					  "doc": "This overrides the capacity for broker 1. This broker is a JBOD broker."
+					},
+					{
+					  "brokerId": "-1",
+					  "capacity": {
+						"DISK": {"/kafka-logs/kafka": "10737418240"},
+						"CPU": "100",
+						"NW_IN": "125000",
+						"NW_OUT": "125000"
+					  },
+					  "doc": "Capacity unit used for disk is in MB, cpu is in percentage, network throughput is in KB."
+					}
+				  ]
+				}`,
+		},
+		{
+			testName: "without JBOD case, but with default broker",
+			capacityConfig: `
+                  {
+				  "brokerCapacities":[
+					{
+					  "brokerId": "-1",
+					  "capacity": {
+						"DISK": "100000",
+						"CPU": "100",
+						"NW_IN": "10000",
+						"NW_OUT": "10000"
+					  },
+					  "doc": "The default capacity for a broker with multiple logDirs each on a separate heterogeneous disk."
+					},
+					{
+					  "brokerId": "0",
+					  "capacity": {
+						"DISK": "500000",
+						"CPU": "100",
+						"NW_IN": "50000",
+						"NW_OUT": "50000"
+					  },
+					  "doc": "This overrides the capacity for broker 0. This broker is not a JBOD broker."
+					},
+					{
+					  "brokerId": "1",
+					  "capacity": {
+						"DISK": "250000",
+						"CPU": "100",
+						"NW_IN": "50000",
+						"NW_OUT": "50000"
+					  },
+					  "doc": "This overrides the capacity for broker 1. This broker is a JBOD broker."
+					}
+				  ]
+				}`,
+			expectedConfiguration: `
+                  {
+				  "brokerCapacities":[
+					{
+					  "brokerId": "-1",
+					  "capacity": {
+						"DISK": "100000",
+						"CPU": "100",
+						"NW_IN": "10000",
+						"NW_OUT": "10000"
+					  },
+					  "doc": "The default capacity for a broker with multiple logDirs each on a separate heterogeneous disk."
+					},
+					{
+					  "brokerId": "0",
+					  "capacity": {
+						"DISK": "500000",
+						"CPU": "100",
+						"NW_IN": "50000",
+						"NW_OUT": "50000"
+					  },
+					  "doc": "This overrides the capacity for broker 0. This broker is not a JBOD broker."
+					},
+					{
+					  "brokerId": "1",
+					  "capacity": {
+						"DISK": "250000",
+						"CPU": "100",
+						"NW_IN": "50000",
+						"NW_OUT": "50000"
+					  },
+					  "doc": "This overrides the capacity for broker 1. This broker is a JBOD broker."
+					}
+				  ]
+				}`,
+		},
+	}
+
+	t.Parallel()
+
+	for _, test := range testCases {
+		test := test
+
+		t.Run(test.testName, func(t *testing.T) {
+			kafkaCluster := v1beta1.KafkaCluster{
+				Spec: v1beta1.KafkaClusterSpec{
+					Brokers: []v1beta1.Broker{
+						{
+							Id: 0,
+							BrokerConfig: &v1beta1.BrokerConfig{
+								Resources: &v1.ResourceRequirements{
+									Limits: v1.ResourceList{
+										"cpu": cpuQuantity,
+									}},
+							},
+						},
+						{
+							Id: 1,
+						},
+						{
+							Id: 2,
+						},
+						{
+							Id: 4,
+						},
+					},
+					CruiseControlConfig: v1beta1.CruiseControlConfig{
+						CapacityConfig: test.capacityConfig,
+					},
+				},
+			}
+			var actual JBODInvariantCapacityConfig
+			err := json.Unmarshal([]byte(GenerateCapacityConfig(&kafkaCluster, log.NullLogger{}, nil)), &actual)
+			if err != nil {
+				t.Error(err, "could not actual unmarshal json")
+			}
+
+			var expected JBODInvariantCapacityConfig
 			err = json.Unmarshal([]byte(test.expectedConfiguration), &expected)
 			if err != nil {
 				t.Error(err, "could not unmarshal expected json")


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | -
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Adding a default broker capacity config to the CruiseControl `capacity.json` file.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
After ungraceful broker deletion the CruiseControl might not be aware of the brokers currently being deleted. Adding a default capacity entry to the capacity json enables CC to handle these brokers (though the actual value of resources does not matter).

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline