### PR TITLE
Update kube-rbac-proxy to v0.8.0

### DIFF
--- a/charts/kafka-operator/README.md
+++ b/charts/kafka-operator/README.md
@@ -65,7 +65,7 @@ Parameter | Description | Default
 `prometheusMetrics.authProxy.serviceAccount.create` | If true, create the service account (see `prometheusMetrics.authProxy.serviceAccount.name`) used by prometheus auth proxy | `true`
 `prometheusMetrics.authProxy.serviceAccount.name` | ServiceAccount used by prometheus auth proxy | `kafka-operator-authproxy`
 `prometheusMetrics.authProxy.image.repository` | Auth proxy container image repository | `gcr.io/kubebuilder/kube-rbac-proxy`
-`prometheusMetrics.authProxy.image.tag` | Auth proxy container image tag | `v0.4.0`
+`prometheusMetrics.authProxy.image.tag` | Auth proxy container image tag | `v0.8.0`
 `prometheusMetrics.authProxy.image.pullPolicy` | Auth proxy container image pull policy | `IfNotPresent`
 `rbac.enabled` | Create rbac service account and roles | `true`
 `imagePullSecrets` | Image pull secrets can be set | `[]`

--- a/charts/kafka-operator/values.yaml
+++ b/charts/kafka-operator/values.yaml
@@ -51,7 +51,7 @@ prometheusMetrics:
     enabled: true
     image:
       repository: gcr.io/kubebuilder/kube-rbac-proxy
-      tag: v0.5.0
+      tag: v0.8.0
       pullPolicy: IfNotPresent
     serviceAccount:
       create: true

--- a/config/overlays/auth-proxy-enabled/manager_auth_proxy_patch.yaml
+++ b/config/overlays/auth-proxy-enabled/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.4.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/config/overlays/certmanager-with-auth-proxy/auth-proxy/manager_auth_proxy_patch.yaml
+++ b/config/overlays/certmanager-with-auth-proxy/auth-proxy/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.4.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"


### PR DESCRIPTION
This PR updated the kube-rbac-proxy version to v0.8.0