### PR TITLE
Fix ingress controller behaviour in case of downscale

### DIFF
--- a/config/samples/simplekafkacluster-with-brokerbindings.yaml
+++ b/config/samples/simplekafkacluster-with-brokerbindings.yaml
@@ -6,7 +6,6 @@ metadata:
   name: kafka
 spec:
   headlessServiceEnabled: true
-  zkPath: "/toyota"
   zkAddresses:
     - "zookeeper-client.zookeeper:2181"
   propagateLabels: false
@@ -35,7 +34,7 @@ spec:
       brokerConfigGroup: "default"
       brokerConfig:
         brokerIngressMapping:
-          - " ingress-az1"
+          - "ingress-az1"
     - id: 1
       brokerConfigGroup: "default"
       brokerConfig:
@@ -62,7 +61,7 @@ spec:
         externalStartingPort: 19090
         containerPort: 9094
         config:
-          defaultIngressConfig: "az2"
+          defaultIngressConfig: "ingress-az1"
           ingressConfig:
             ingress-az1:
               envoyConfig:

--- a/pkg/util/kafka/common.go
+++ b/pkg/util/kafka/common.go
@@ -249,6 +249,7 @@ func GatherBrokerConfigIfAvailable(kafkaClusterSpec v1beta1.KafkaClusterSpec, br
 			return brokerConfig, nil
 		}
 	}
-
-	return nil, errors.NewWithDetails("broker config was not found", "brokerId", brokerId)
+	// When broker is missing from the spec no broker config is available.
+	// That means broker is under deletion, which is not an error.
+	return nil, nil
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |yes|
| New feature?    | no|
| API breaks?     | no|
| Deprecations?   | no|
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
This PR fixes the ingress controller behaviour. In case of downscale the ingress controller gets terminated before the broker which means that broker gets unavailable despite of it is available inside the cluster. With this fix the ingress controller gets reconfigured after the broker has been deleted.


- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)