### PR TITLE
Bump chart version to release bug fix release v0.15.1

### DIFF
--- a/charts/kafka-operator/Chart.yaml
+++ b/charts/kafka-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: kafka-operator
-version: 0.4.5
+version: 0.4.6
 description: kafka-operator manages Kafka deployments on Kubernetes
 sources:
   - https://github.com/banzaicloud/kafka-operator
-appVersion: v0.15.0
+appVersion: v0.15.1


### PR DESCRIPTION
This PR bumps the chart version and the operator version as well to prepare the v0.15.1 release.