### PR TITLE
Support adding broker annotations to brokers added by 'upScale' alert command

### DIFF
--- a/config/samples/kafkacluster-prometheus.yaml
+++ b/config/samples/kafkacluster-prometheus.yaml
@@ -86,6 +86,8 @@ spec:
         mountPath: '/kafkalog'
         diskSize: '10G'
         image: 'ghcr.io/banzaicloud/kafka:2.13-2.7.0-bzc.1'
+        # annotations to be applied onto the broker pod
+        # brokerAnnotations: '{ "sidecar.istio.io/logLevel": "trace", "sidecar.istio.io/proxyCPULimit": "50m" }'
         command: 'upScale'
     - alert: BrokerUnderReplicated
       expr: kafka_server_replicamanager_underreplicatedpartitions > 0
@@ -100,6 +102,8 @@ spec:
         mountPath: '/kafkalog'
         diskSize: '10G'
         image: 'ghcr.io/banzaicloud/kafka:2.13-2.7.0-bzc.1'
+        # annotations to be applied onto the broker pod
+        # brokerAnnotations: '{ "sidecar.istio.io/logLevel": "trace", "sidecar.istio.io/proxyCPULimit": "50m" }'
         command: 'upScale'
     - alert: PartitionCountHigh
       expr: max(kafka_server_replicamanager_partitioncount)  by (namespace, kafka_cr) > 100
@@ -114,6 +118,8 @@ spec:
         mountPath: '/kafkalog'
         diskSize: '10G'
         image: 'ghcr.io/banzaicloud/kafka:2.13-2.7.0-bzc.1'
+        # annotations to be applied onto the broker pod
+        # brokerAnnotations: '{ "sidecar.istio.io/logLevel": "trace", "sidecar.istio.io/proxyCPULimit": "50m" }'
         command: 'upScale'
     - alert: PartitionCountLow
       expr: min(kafka_server_replicamanager_partitioncount)  by (namespace, kafka_cr) < 40


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Support of specifying annotations to be applied onto brokers which are added to the cluster by the 'upScale' prometheus alert command.

`config/samples/kafkacluster-prometheus.yaml` includes example of specifying annotations for brokers in the `upScale` command.


### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Currently annotations can only be applied if the broker added by 'upScale' is using a config group. In this case the `brokerAnnotations` defined in the config group is applied.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)

