### PR TITLE
Remove ownerref from cluster scoped clusterissuer

### DIFF
--- a/pkg/resources/templates/templates.go
+++ b/pkg/resources/templates/templates.go
@@ -40,6 +40,15 @@ func ObjectMeta(name string, labels map[string]string, cluster *v1beta1.KafkaClu
 	}
 }
 
+// ObjectMetaWithoutOwnerRef returns a metav1.ObjectMeta object with labels, and name
+func ObjectMetaWithoutOwnerRef(name string, labels map[string]string, cluster *v1beta1.KafkaCluster) metav1.ObjectMeta {
+	return metav1.ObjectMeta{
+		Name:      name,
+		Namespace: cluster.Namespace,
+		Labels:    ObjectMetaLabels(cluster, labels),
+	}
+}
+
 // ObjectMetaWithGeneratedName returns a metav1.ObjectMeta object with labels, ownerReference and generatedname
 func ObjectMetaWithGeneratedName(namePrefix string, labels map[string]string, cluster *v1beta1.KafkaCluster) metav1.ObjectMeta {
 	return metav1.ObjectMeta{


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |yes|
| New feature?    | no|
| API breaks?     | no|
| Deprecations?   | no|
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

This PR removes the ownerref from cluster scoped clusterissuer to prevent [Kub#65200](https://github.com/kubernetes/kubernetes/issues/65200) bug.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
