### PR TITLE
Use v1 instead of v1beta in the overlays for kustomize

### DIFF
--- a/config/base/webhook/manifests.yaml
+++ b/config/base/webhook/manifests.yaml
@@ -7,7 +7,7 @@ metadata:
   name: validating-webhook-configuration
 webhooks:
 - admissionReviewVersions:
-  - v1alpha1
+  - v1
   clientConfig:
     service:
       name: webhook-service

--- a/config/base/webhook/webhook_in_kafkatopics.yaml
+++ b/config/base/webhook/webhook_in_kafkatopics.yaml
@@ -1,6 +1,6 @@
 # The following patch enables conversion webhook for CRD
 # CRD conversion requires k8s 1.13 or later.
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: kafkatopics.kafka.banzaicloud.io

--- a/config/overlays/basic/webhookcainjection_patch.yaml
+++ b/config/overlays/basic/webhookcainjection_patch.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validating-webhook-configuration

--- a/config/overlays/certmanager-enabled/webhookcainjection_patch.yaml
+++ b/config/overlays/certmanager-enabled/webhookcainjection_patch.yaml
@@ -7,7 +7,7 @@
 #   annotations:
 #     cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validating-webhook-configuration

--- a/config/overlays/certmanager-with-auth-proxy/certmanager/webhookcainjection_patch.yaml
+++ b/config/overlays/certmanager-with-auth-proxy/certmanager/webhookcainjection_patch.yaml
@@ -7,7 +7,7 @@
 #   annotations:
 #     cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validating-webhook-configuration

--- a/pkg/sdk/v1alpha1/kafkatopic_types.go
+++ b/pkg/sdk/v1alpha1/kafkatopic_types.go
@@ -37,7 +37,7 @@ type KafkaTopicStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // +k8s:openapi-gen=true
-// +kubebuilder:webhook:failurePolicy="fail",sideEffects="None",name="kafkatopics.kafka.banzaicloud.io",path="/validate",mutating=false,resources={"kafkatopics"},verbs={"create","update"},groups={"kafka.banzaicloud.io"},versions={"v1alpha1"},admissionReviewVersions={"v1alpha1"}
+// +kubebuilder:webhook:failurePolicy="fail",sideEffects="None",name="kafkatopics.kafka.banzaicloud.io",path="/validate",mutating=false,resources={"kafkatopics"},verbs={"create","update"},groups={"kafka.banzaicloud.io"},versions={"v1alpha1"},admissionReviewVersions={"v1"}
 
 // KafkaTopic is the Schema for the kafkatopics API
 // +kubebuilder:object:root=true


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | #567
| License         | Apache 2.0

### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
A bug fix which replaces a few places where `v1beta1` is kept instead of `v1` in the kustomize yamls.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Currently `make deploy` fails with several errors because of the version mismatch.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline