### PR TITLE
Enable linter errcheck

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,7 +12,7 @@ linters:
     - depguard
     - dogsled
     # - dupl            # NOTE: intentionally disabled
-#    - errcheck # Note: Fixme with a small refactor
+    - errcheck
     - exhaustive
     - funlen
     # - gochecknoinits  # NOTE: intentionally disabled

--- a/internal/alertmanager/currentalert/current_alerts_test.go
+++ b/internal/alertmanager/currentalert/current_alerts_test.go
@@ -50,7 +50,9 @@ func TestMain(m *testing.M) {
 	t := &envtest.Environment{
 		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "config", "base", "crds")},
 	}
-	v1beta1.AddToScheme(scheme.Scheme)
+	if err := v1beta1.AddToScheme(scheme.Scheme); err != nil {
+		stdlog.Fatal(err)
+	}
 
 	var err error
 	if cfg, err = t.Start(); err != nil {
@@ -58,7 +60,9 @@ func TestMain(m *testing.M) {
 	}
 
 	code := m.Run()
-	t.Stop()
+	if err := t.Stop(); err != nil {
+		stdlog.Fatal(err)
+	}
 	os.Exit(code)
 }
 
@@ -81,7 +85,9 @@ func ensureCreated(t *testing.T, object runtime.Object, mgr manager.Manager) fun
 		t.Fatalf("%+v", err)
 	}
 	return func() {
-		mgr.GetClient().Delete(context.TODO(), object)
+		if err := mgr.GetClient().Delete(context.TODO(), object); err != nil {
+			t.Error("Expected no error, got:", err)
+		}
 	}
 }
 

--- a/internal/alertmanager/currentalert/process_test.go
+++ b/internal/alertmanager/currentalert/process_test.go
@@ -206,7 +206,11 @@ func Test_resizePvc(t *testing.T) {
 			if err != nil {
 				t.Error("Pvc creation failed", err)
 			}
-			defer testClient.Delete(context.Background(), &tt.pvc)
+			defer func() {
+				if err := testClient.Delete(context.Background(), &tt.pvc); err != nil {
+					t.Error("Expected no error, got:", err)
+				}
+			}()
 
 			err = testClient.Create(context.Background(), &tt.cluster)
 			if err != nil {
@@ -228,7 +232,11 @@ func Test_resizePvc(t *testing.T) {
 			if err != nil {
 				t.Errorf("kafka cr was not found, error = %v", err)
 			}
-			defer testClient.Delete(context.Background(), &kafkaCluster)
+			defer func() {
+				if err := testClient.Delete(context.Background(), &kafkaCluster); err != nil {
+					t.Error("Expected no error, got:", err)
+				}
+			}()
 
 			fmt.Println(kafkaCluster.Spec.Brokers)
 			brokerStorageConfig := &kafkaCluster.Spec.Brokers[0].BrokerConfig.StorageConfigs[0]
@@ -560,7 +568,11 @@ func Test_upScale(t *testing.T) {
 				return
 			}
 
-			defer testClient.Delete(context.Background(), &test.kafkaCluster)
+			defer func() {
+				if err := testClient.Delete(context.Background(), &test.kafkaCluster); err != nil {
+					t.Error("Expected no error, got:", err)
+				}
+			}()
 
 			if err := upScale(logf.NullLogger{}, test.alert.Labels, test.alert.Annotations, testClient); err != nil {
 				t.Error(err)

--- a/pkg/pki/certmanagerpki/certmanager_pki_test.go
+++ b/pkg/pki/certmanagerpki/certmanager_pki_test.go
@@ -91,7 +91,7 @@ func newPreCreatedSecret() *corev1.Secret {
 func TestFinalizePKI(t *testing.T) {
 	manager, err := newMock(newMockCluster())
 	if err != nil {
-		t.Error("Expected no error on during initialization, got:", err)
+		t.Error("Expected no error during initialization, got:", err)
 	}
 
 	if err := manager.FinalizePKI(context.Background(), log); err != nil {
@@ -103,7 +103,7 @@ func TestReconcilePKI(t *testing.T) {
 	cluster := newMockCluster()
 	manager, err := newMock(cluster)
 	if err != nil {
-		t.Error("Expected no error on during initialization, got:", err)
+		t.Error("Expected no error during initialization, got:", err)
 	}
 	ctx := context.Background()
 
@@ -135,7 +135,7 @@ func TestReconcilePKI(t *testing.T) {
 	cluster.Spec.ListenersConfig.SSLSecrets.Create = false
 	manager, err = newMock(cluster)
 	if err != nil {
-		t.Error("Expected no error on during mocking the cluster, got:", err)
+		t.Error("Expected no error during mocking the cluster, got:", err)
 	}
 	if err := manager.ReconcilePKI(ctx, log, scheme.Scheme, make(map[string]v1beta1.ListenerStatusList)); err == nil {
 		t.Error("Expected error got nil")

--- a/pkg/pki/certmanagerpki/certmanager_test.go
+++ b/pkg/pki/certmanagerpki/certmanager_test.go
@@ -53,14 +53,23 @@ func newMockCluster() *v1beta1.KafkaCluster {
 	return cluster
 }
 
-func newMock(cluster *v1beta1.KafkaCluster) *certManager {
-	certv1.AddToScheme(scheme.Scheme)
-	v1alpha1.AddToScheme(scheme.Scheme)
-	v1beta1.AddToScheme(scheme.Scheme)
+func newMock(cluster *v1beta1.KafkaCluster) (*certManager, error) {
+	err := certv1.AddToScheme(scheme.Scheme)
+	if err != nil {
+		return nil, err
+	}
+	err = v1alpha1.AddToScheme(scheme.Scheme)
+	if err != nil {
+		return nil, err
+	}
+	err = v1beta1.AddToScheme(scheme.Scheme)
+	if err != nil {
+		return nil, err
+	}
 	return &certManager{
 		cluster: cluster,
 		client:  fake.NewFakeClientWithScheme(scheme.Scheme),
-	}
+	}, nil
 }
 
 func TestNew(t *testing.T) {

--- a/pkg/pki/certmanagerpki/certmanager_tls_config_test.go
+++ b/pkg/pki/certmanagerpki/certmanager_tls_config_test.go
@@ -44,7 +44,7 @@ func newMockControllerSecret(valid bool) *corev1.Secret {
 func TestGetControllerTLSConfig(t *testing.T) {
 	manager, err := newMock(newMockCluster())
 	if err != nil {
-		t.Error("Expected no error on during initialization, got:", err)
+		t.Error("Expected no error during initialization, got:", err)
 	}
 	// Test good controller secret
 	if err := manager.client.Create(context.TODO(), newMockControllerSecret(true)); err != nil {
@@ -56,7 +56,7 @@ func TestGetControllerTLSConfig(t *testing.T) {
 
 	manager, err = newMock(newMockCluster())
 	if err != nil {
-		t.Error("Expected no error on during initialization, got:", err)
+		t.Error("Expected no error during initialization, got:", err)
 	}
 	// Test non-existent controller secret
 	if _, err := manager.GetControllerTLSConfig(); err == nil {

--- a/pkg/pki/certmanagerpki/certmanager_tls_config_test.go
+++ b/pkg/pki/certmanagerpki/certmanager_tls_config_test.go
@@ -42,16 +42,22 @@ func newMockControllerSecret(valid bool) *corev1.Secret {
 }
 
 func TestGetControllerTLSConfig(t *testing.T) {
-	manager := newMock(newMockCluster())
-
+	manager, err := newMock(newMockCluster())
+	if err != nil {
+		t.Error("Expected no error on during initialization, got:", err)
+	}
 	// Test good controller secret
-	manager.client.Create(context.TODO(), newMockControllerSecret(true))
+	if err := manager.client.Create(context.TODO(), newMockControllerSecret(true)); err != nil {
+		t.Error("Expected no error, got:", err)
+	}
 	if _, err := manager.GetControllerTLSConfig(); err != nil {
 		t.Error("Expected no error, got:", err)
 	}
 
-	manager = newMock(newMockCluster())
-
+	manager, err = newMock(newMockCluster())
+	if err != nil {
+		t.Error("Expected no error on during initialization, got:", err)
+	}
 	// Test non-existent controller secret
 	if _, err := manager.GetControllerTLSConfig(); err == nil {
 		t.Error("Expected error got nil")
@@ -60,7 +66,9 @@ func TestGetControllerTLSConfig(t *testing.T) {
 	}
 
 	// Test invalid controller secret
-	manager.client.Create(context.TODO(), newMockControllerSecret(false))
+	if err := manager.client.Create(context.TODO(), newMockControllerSecret(false)); err != nil {
+		t.Error("Expected no error, got:", err)
+	}
 	if _, err := manager.GetControllerTLSConfig(); err == nil {
 		t.Error("Expected error got nil")
 	} else if reflect.TypeOf(err) != reflect.TypeOf(errorfactory.InternalError{}) {

--- a/pkg/pki/certmanagerpki/certmanager_user_test.go
+++ b/pkg/pki/certmanagerpki/certmanager_user_test.go
@@ -54,7 +54,7 @@ func newMockUserSecret() *corev1.Secret {
 func TestFinalizeUserCertificate(t *testing.T) {
 	manager, err := newMock(newMockCluster())
 	if err != nil {
-		t.Error("Expected no error on during initialization, got:", err)
+		t.Error("Expected no error during initialization, got:", err)
 	}
 	if err := manager.FinalizeUserCertificate(context.Background(), &v1alpha1.KafkaUser{}); err != nil {
 		t.Error("Expected no error, got:", err)
@@ -65,7 +65,7 @@ func TestReconcileUserCertificate(t *testing.T) {
 	clusterDomain := "cluster.local"
 	manager, err := newMock(newMockCluster())
 	if err != nil {
-		t.Error("Expected no error on during initialization, got:", err)
+		t.Error("Expected no error during initialization, got:", err)
 	}
 	ctx := context.Background()
 
@@ -90,7 +90,7 @@ func TestReconcileUserCertificate(t *testing.T) {
 	// Test error conditions
 	manager, err = newMock(newMockCluster())
 	if err != nil {
-		t.Error("Expected no error on during initialization, got:", err)
+		t.Error("Expected no error during initialization, got:", err)
 	}
 	if err := manager.client.Create(context.TODO(), newMockUser()); err != nil {
 		t.Error("Expected no error, got:", err)

--- a/pkg/pki/vaultpki/vault_pki.go
+++ b/pkg/pki/vaultpki/vault_pki.go
@@ -25,7 +25,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/banzaicloud/kafka-operator/api/v1alpha1"
 	"github.com/banzaicloud/kafka-operator/api/v1beta1"
@@ -78,11 +77,11 @@ func (v *vaultPKI) ReconcilePKI(ctx context.Context, logger logr.Logger, scheme 
 		return
 	}
 
-	return v.reconcileBootstrapSecrets(ctx, scheme, brokerCert, controllerCert)
+	return v.reconcileBootstrapSecrets(ctx, brokerCert, controllerCert)
 }
 
 // reconcileBootstrapSecrets creates the secret mounts for cruise control and the kafka brokers
-func (v *vaultPKI) reconcileBootstrapSecrets(ctx context.Context, scheme *runtime.Scheme, brokerCert, controllerCert *pkicommon.UserCertificate) (err error) {
+func (v *vaultPKI) reconcileBootstrapSecrets(ctx context.Context, brokerCert, controllerCert *pkicommon.UserCertificate) (err error) {
 	serverSecret := &corev1.Secret{}
 	clientSecret := &corev1.Secret{}
 
@@ -109,7 +108,6 @@ func (v *vaultPKI) reconcileBootstrapSecrets(ctx context.Context, scheme *runtim
 					v1alpha1.PasswordKey:    brokerCert.Password,
 				},
 			}
-			controllerutil.SetControllerReference(v.cluster, serverCert, scheme)
 			toCreate = append(toCreate, serverCert)
 		} else {
 			return errorfactory.New(errorfactory.APIFailure{}, err, "failed to check existence of server secret")
@@ -137,7 +135,6 @@ func (v *vaultPKI) reconcileBootstrapSecrets(ctx context.Context, scheme *runtim
 					v1alpha1.PasswordKey:    controllerCert.Password,
 				},
 			}
-			controllerutil.SetControllerReference(v.cluster, clientCert, scheme)
 			toCreate = append(toCreate, clientCert)
 		} else {
 			return errorfactory.New(errorfactory.APIFailure{}, err, "failed to check existence of client secret")

--- a/pkg/resources/templates/templates.go
+++ b/pkg/resources/templates/templates.go
@@ -40,6 +40,24 @@ func ObjectMeta(name string, labels map[string]string, cluster *v1beta1.KafkaClu
 	}
 }
 
+// ObjectMetaWithCustomNamespaceAndWithoutLabels returns a metav1.ObjectMeta object with custom namespace, ownerReference and name
+func ObjectMetaWithCustomNamespaceAndWithoutLabels(name, namespace string, cluster *v1beta1.KafkaCluster) metav1.ObjectMeta {
+	return metav1.ObjectMeta{
+		Name:      name,
+		Namespace: namespace,
+		OwnerReferences: []metav1.OwnerReference{
+			{
+				APIVersion:         cluster.APIVersion,
+				Kind:               cluster.Kind,
+				Name:               cluster.Name,
+				UID:                cluster.UID,
+				Controller:         util.BoolPointer(true),
+				BlockOwnerDeletion: util.BoolPointer(true),
+			},
+		},
+	}
+}
+
 // ObjectMetaWithoutOwnerRef returns a metav1.ObjectMeta object with labels, and name
 func ObjectMetaWithoutOwnerRef(name string, labels map[string]string, cluster *v1beta1.KafkaCluster) metav1.ObjectMeta {
 	return metav1.ObjectMeta{

--- a/pkg/webhook/request_test.go
+++ b/pkg/webhook/request_test.go
@@ -65,7 +65,10 @@ func newRequest(data []byte) *http.Request {
 }
 
 func TestValidate(t *testing.T) {
-	server := newMockServer()
+	server, err := newMockServer()
+	if err != nil {
+		t.Error("Expected no error got:", err)
+	}
 
 	req := newAdmissionReview()
 
@@ -97,7 +100,10 @@ func TestValidate(t *testing.T) {
 }
 
 func TestServe(t *testing.T) {
-	server := newMockServer()
+	server, err := newMockServer()
+	if err != nil {
+		t.Error("Expected no error got:", err)
+	}
 
 	// Test bad body
 	reader, writer := io.Pipe()
@@ -165,7 +171,9 @@ func TestServe(t *testing.T) {
 			t.Error("Expected admission review response, got error")
 		}
 		admissionReview := admissionv1beta1.AdmissionReview{}
-		json.Unmarshal(body, &admissionReview)
+		if err := json.Unmarshal(body, &admissionReview); err != nil {
+			t.Error("Expected no error got:", err)
+		}
 		if admissionReview.Response.Result.Reason != metav1.StatusReasonBadRequest {
 			t.Error("Expected metav1 bad request, got:", admissionReview.Response.Result.Reason)
 		}
@@ -189,7 +197,9 @@ func TestServe(t *testing.T) {
 			t.Error("Expected admission review response, got error")
 		}
 		admissionReview := admissionv1beta1.AdmissionReview{}
-		json.Unmarshal(body, &admissionReview)
+		if err := json.Unmarshal(body, &admissionReview); err != nil {
+			t.Error("Expected no error got:", err)
+		}
 		if admissionReview.Response.Result.Reason != metav1.StatusReasonNotFound {
 			t.Error("Expected not found for no cluster, got:", admissionReview.Response.Result.Reason)
 		}

--- a/pkg/webhook/server_test.go
+++ b/pkg/webhook/server_test.go
@@ -33,20 +33,27 @@ import (
 	"github.com/banzaicloud/kafka-operator/pkg/kafkaclient"
 )
 
-func newMockServer() *webhookServer {
+func newMockServer() (*webhookServer, error) {
 	return newMockServerWithClients(fake.NewFakeClientWithScheme(scheme.Scheme), kafkaclient.NewMockFromCluster)
 }
 
-func newMockServerWithClients(c client.Client, kafkaClientProvider func(client client.Client, cluster *v1beta1.KafkaCluster) (kafkaclient.KafkaClient, error)) *webhookServer {
-	certv1.AddToScheme(scheme.Scheme)
-	v1alpha1.AddToScheme(scheme.Scheme)
-	v1beta1.AddToScheme(scheme.Scheme)
+func newMockServerWithClients(c client.Client, kafkaClientProvider func(client client.Client,
+	cluster *v1beta1.KafkaCluster) (kafkaclient.KafkaClient, error)) (*webhookServer, error) {
+	if err := certv1.AddToScheme(scheme.Scheme); err != nil {
+		return nil, err
+	}
+	if err := v1alpha1.AddToScheme(scheme.Scheme); err != nil {
+		return nil, err
+	}
+	if err := v1beta1.AddToScheme(scheme.Scheme); err != nil {
+		return nil, err
+	}
 	return &webhookServer{
 		client:              c,
 		scheme:              scheme.Scheme,
 		deserializer:        serializer.NewCodecFactory(scheme.Scheme).UniversalDeserializer(),
 		newKafkaFromCluster: kafkaClientProvider,
-	}
+	}, nil
 }
 
 func TestNewServer(t *testing.T) {


### PR DESCRIPTION
This PR enables a new linter called errcheck it contains all the necessary refactors to make that linter a green lamp