### PR TITLE
Fix istio gateway configuration when using other than default

### DIFF
--- a/controllers/tests/kafkacluster_controller_istioingress_test.go
+++ b/controllers/tests/kafkacluster_controller_istioingress_test.go
@@ -443,6 +443,10 @@ var _ = Describe("KafkaClusterIstioIngressControllerWithBrokerIdBindings", func(
 						},
 						"az2": {IstioIngressConfig: &v1beta1.IstioIngressConfig{
 							Annotations: map[string]string{"zone": "az2"},
+							TLSOptions: &v1alpha3.TLSOptions{
+								Mode:           v1alpha3.TLSModeSimple,
+								CredentialName: util.StringPointer("foobar"),
+							},
 						},
 						},
 					},
@@ -624,16 +628,24 @@ var _ = Describe("KafkaClusterIstioIngressControllerWithBrokerIdBindings", func(
 			ExpectIstioIngressLabels(gateway.Spec.Selector, "external-az2", kafkaClusterCRName)
 			Expect(gateway.Spec.Servers).To(ConsistOf(
 				v1alpha3.Server{
+					TLS: &v1alpha3.TLSOptions{
+						Mode:           v1alpha3.TLSModeSimple,
+						CredentialName: util.StringPointer("foobar"),
+					},
 					Port: &v1alpha3.Port{
 						Number:   19091,
-						Protocol: "TCP",
+						Protocol: "TLS",
 						Name:     "tcp-broker-1"},
 					Hosts: []string{"*"},
 				},
 				v1alpha3.Server{
+					TLS: &v1alpha3.TLSOptions{
+						Mode:           v1alpha3.TLSModeSimple,
+						CredentialName: util.StringPointer("foobar"),
+					},
 					Port: &v1alpha3.Port{
 						Number:   29092,
-						Protocol: "TCP",
+						Protocol: "TLS",
 						Name:     "tcp-all-broker",
 					},
 					Hosts: []string{"*"},

--- a/pkg/resources/istioingress/gateway.go
+++ b/pkg/resources/istioingress/gateway.go
@@ -29,7 +29,7 @@ import (
 )
 
 func (r *Reconciler) gateway(log logr.Logger, externalListenerConfig v1beta1.ExternalListenerConfig,
-	_ v1beta1.IngressConfig, ingressConfigName, defaultIngressConfigName string) runtime.Object {
+	ingressConf v1beta1.IngressConfig, ingressConfigName, defaultIngressConfigName string) runtime.Object {
 	eListenerLabelName := util.ConstructEListenerLabelName(ingressConfigName, externalListenerConfig.Name)
 
 	var gatewayName string
@@ -43,18 +43,19 @@ func (r *Reconciler) gateway(log logr.Logger, externalListenerConfig v1beta1.Ext
 			labelsForIstioIngress(r.KafkaCluster.Name, eListenerLabelName), r.KafkaCluster),
 		Spec: v1alpha3.GatewaySpec{
 			Selector: labelsForIstioIngress(r.KafkaCluster.Name, eListenerLabelName),
-			Servers:  generateServers(r.KafkaCluster, externalListenerConfig, log, ingressConfigName, defaultIngressConfigName),
+			Servers: generateServers(r.KafkaCluster, externalListenerConfig, log, ingressConf,
+				ingressConfigName, defaultIngressConfigName),
 		},
 	}
 }
 
 func generateServers(kc *v1beta1.KafkaCluster, externalListenerConfig v1beta1.ExternalListenerConfig, log logr.Logger,
-	ingressConfigName, defaultIngressConfigName string) []v1alpha3.Server {
+	ingressConf v1beta1.IngressConfig, ingressConfigName, defaultIngressConfigName string) []v1alpha3.Server {
 	servers := make([]v1alpha3.Server, 0)
 	protocol := v1alpha3.ProtocolTCP
 	var tlsConfig *v1alpha3.TLSOptions
-	if kc.Spec.IstioIngressConfig.TLSOptions != nil {
-		tlsConfig = kc.Spec.IstioIngressConfig.TLSOptions
+	if ingressConf.IstioIngressConfig.TLSOptions != nil {
+		tlsConfig = ingressConf.IstioIngressConfig.TLSOptions
 		protocol = v1alpha3.ProtocolTLS
 	}
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes|
| New feature?    | no|
| API breaks?     | no|
| Deprecations?   | no|
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
This PR fixes the istio ingress gateway config generation when it is overwritten through the external listener configuration.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested
- [X] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [X] Logging code meets the guideline
- [X] User guide and development docs updated (if needed)