### PR TITLE
Move away from deprecated k8s apis

### DIFF
--- a/charts/kafka-operator/templates/operator-deployment-with-webhook.yaml
+++ b/charts/kafka-operator/templates/operator-deployment-with-webhook.yaml
@@ -18,7 +18,7 @@
 {{- end }}
 
 {{- if .Values.webhook.enabled }}
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   labels:
@@ -30,7 +30,9 @@ metadata:
     app.kubernetes.io/component: webhook
   name: {{ include "kafka-operator.name" . }}-validating-webhook
 webhooks:
-- clientConfig:
+- admissionReviewVersions:
+  - v1alpha1
+  clientConfig:
     caBundle: {{ $caCrt }}
     service:
       name: "{{ include "kafka-operator.fullname" . }}-operator"
@@ -48,6 +50,7 @@ webhooks:
     - UPDATE
     resources:
     - kafkatopics
+  sideEffects: None
 ---
 apiVersion: v1
 kind: Secret

--- a/config/overlays/certmanager-enabled/webhookcainjection_patch.yaml
+++ b/config/overlays/certmanager-enabled/webhookcainjection_patch.yaml
@@ -1,6 +1,6 @@
 # This patch add annotation to admission webhook config and
 # the variables $(CERTIFICATE_NAMESPACE) and $(CERTIFICATE_NAME) will be substituted by kustomize.
-# apiVersion: admissionregistration.k8s.io/v1beta1
+# apiVersion: admissionregistration.k8s.io/v1
 # kind: MutatingWebhookConfiguration
 # metadata:
 #   name: mutating-webhook-configuration

--- a/config/overlays/certmanager-with-auth-proxy/certmanager/webhookcainjection_patch.yaml
+++ b/config/overlays/certmanager-with-auth-proxy/certmanager/webhookcainjection_patch.yaml
@@ -1,6 +1,6 @@
 # This patch add annotation to admission webhook config and
 # the variables $(CERTIFICATE_NAMESPACE) and $(CERTIFICATE_NAME) will be substituted by kustomize.
-# apiVersion: admissionregistration.k8s.io/v1beta1
+# apiVersion: admissionregistration.k8s.io/v1
 # kind: MutatingWebhookConfiguration
 # metadata:
 #   name: mutating-webhook-configuration

--- a/config/samples/kafkacluster-prometheus.yaml
+++ b/config/samples/kafkacluster-prometheus.yaml
@@ -148,7 +148,7 @@ kind: ServiceAccount
 metadata:
   name: prometheus
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: prometheus
@@ -167,7 +167,7 @@ rules:
 - nonResourceURLs: ["/metrics"]
   verbs: ["get"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: prometheus

--- a/config/test/crd/cert-manager/acme.cert-manager.io_challanges.yaml
+++ b/config/test/crd/cert-manager/acme.cert-manager.io_challanges.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: challenges.acme.cert-manager.io
@@ -25,24 +25,6 @@ metadata:
     app.kubernetes.io/managed-by: 'Helm'
     helm.sh/chart: 'cert-manager-v0.15.1'
 spec:
-  additionalPrinterColumns:
-    - JSONPath: .status.state
-      name: State
-      type: string
-    - JSONPath: .spec.dnsName
-      name: Domain
-      type: string
-    - JSONPath: .status.reason
-      name: Reason
-      priority: 1
-      type: string
-    - JSONPath: .metadata.creationTimestamp
-      description: CreationTimestamp is a timestamp representing the server time when
-        this object was created. It is not guaranteed to be set in happens-before order
-        across separate operations. Clients may not set this value. It is represented
-        in RFC3339 form and is in UTC.
-      name: Age
-      type: date
   group: acme.cert-manager.io
   preserveUnknownFields: false
   names:
@@ -51,803 +33,924 @@ spec:
     plural: challenges
     singular: challenge
   scope: Namespaced
-  subresources:
-    status: {}
   versions:
     - name: v1alpha2
-      served: true
-      storage: true
-    - name: v1alpha3
-      served: true
-      storage: false
-  "validation":
-    "openAPIV3Schema":
-      description: Challenge is a type to represent a Challenge request with an ACME
-        server
-      type: object
-      required:
-        - metadata
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
+      schema:
+        openAPIV3Schema:
+          description: Challenge is a type to represent a Challenge request with an ACME
+            server
           type: object
           required:
-            - authzURL
-            - dnsName
-            - issuerRef
-            - key
-            - solver
-            - token
-            - type
-            - url
+            - metadata
           properties:
-            authzURL:
-              description: AuthzURL is the URL to the ACME Authorization resource
-                that this challenge is a part of.
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+                    of an object. Servers should convert recognized schemas to the latest
+                    internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
               type: string
-            dnsName:
-              description: DNSName is the identifier that this challenge is for, e.g.
-                example.com. If the requested DNSName is a 'wildcard', this field
-                MUST be set to the non-wildcard domain, e.g. for `*.example.com`,
-                it must be `example.com`.
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+                    object represents. Servers may infer this from the endpoint the client
+                    submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
               type: string
-            issuerRef:
-              description: IssuerRef references a properly configured ACME-type Issuer
-                which should be used to create this Challenge. If the Issuer does
-                not exist, processing will be retried. If the Issuer is not an 'ACME'
-                Issuer, an error will be returned and the Challenge will be marked
-                as failed.
+            metadata:
+              type: object
+            spec:
               type: object
               required:
-                - name
+                - authzURL
+                - dnsName
+                - issuerRef
+                - key
+                - solver
+                - token
+                - type
+                - url
               properties:
-                group:
+                authzURL:
+                  description: AuthzURL is the URL to the ACME Authorization resource
+                    that this challenge is a part of.
                   type: string
-                kind:
+                dnsName:
+                  description: DNSName is the identifier that this challenge is for, e.g.
+                    example.com. If the requested DNSName is a 'wildcard', this field
+                    MUST be set to the non-wildcard domain, e.g. for `*.example.com`,
+                    it must be `example.com`.
                   type: string
-                name:
+                issuerRef:
+                  description: IssuerRef references a properly configured ACME-type Issuer
+                    which should be used to create this Challenge. If the Issuer does
+                    not exist, processing will be retried. If the Issuer is not an 'ACME'
+                    Issuer, an error will be returned and the Challenge will be marked
+                    as failed.
+                  type: object
+                  required:
+                    - name
+                  properties:
+                    group:
+                      type: string
+                    kind:
+                      type: string
+                    name:
+                      type: string
+                key:
+                  description: 'Key is the ACME challenge key for this challenge For HTTP01
+                        challenges, this is the value that must be responded with to complete
+                        the HTTP01 challenge in the format: `<private key JWK thumbprint>.<key
+                        from acme server for challenge>`. For DNS01 challenges, this is the
+                        base64 encoded SHA256 sum of the `<private key JWK thumbprint>.<key
+                        from acme server for challenge>` text that must be set as the TXT
+                        record content.'
                   type: string
-            key:
-              description: 'Key is the ACME challenge key for this challenge For HTTP01
-                challenges, this is the value that must be responded with to complete
-                the HTTP01 challenge in the format: `<private key JWK thumbprint>.<key
-                from acme server for challenge>`. For DNS01 challenges, this is the
-                base64 encoded SHA256 sum of the `<private key JWK thumbprint>.<key
-                from acme server for challenge>` text that must be set as the TXT
-                record content.'
-              type: string
-            solver:
-              description: Solver contains the domain solving configuration that should
-                be used to solve this challenge resource.
-              type: object
-              properties:
-                dns01:
+                solver:
+                  description: Solver contains the domain solving configuration that should
+                    be used to solve this challenge resource.
                   type: object
                   properties:
-                    acmedns:
-                      description: ACMEIssuerDNS01ProviderAcmeDNS is a structure containing
-                        the configuration for ACME-DNS servers
+                    dns01:
                       type: object
-                      required:
-                        - accountSecretRef
-                        - host
                       properties:
-                        accountSecretRef:
+                        acmedns:
+                          description: ACMEIssuerDNS01ProviderAcmeDNS is a structure containing
+                            the configuration for ACME-DNS servers
                           type: object
                           required:
-                            - name
+                            - accountSecretRef
+                            - host
                           properties:
-                            key:
-                              description: The key of the secret to select from. Must
-                                be a valid secret key.
+                            accountSecretRef:
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the secret to select from. Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                                  type: string
+                            host:
                               type: string
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                        host:
-                          type: string
-                    akamai:
-                      description: ACMEIssuerDNS01ProviderAkamai is a structure containing
-                        the DNS configuration for Akamai DNS—Zone Record Management
-                        API
-                      type: object
-                      required:
-                        - accessTokenSecretRef
-                        - clientSecretSecretRef
-                        - clientTokenSecretRef
-                        - serviceConsumerDomain
-                      properties:
-                        accessTokenSecretRef:
+                        akamai:
+                          description: ACMEIssuerDNS01ProviderAkamai is a structure containing
+                            the DNS configuration for Akamai DNS—Zone Record Management
+                            API
                           type: object
                           required:
-                            - name
+                            - accessTokenSecretRef
+                            - clientSecretSecretRef
+                            - clientTokenSecretRef
+                            - serviceConsumerDomain
                           properties:
-                            key:
-                              description: The key of the secret to select from. Must
-                                be a valid secret key.
+                            accessTokenSecretRef:
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the secret to select from. Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                                  type: string
+                            clientSecretSecretRef:
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the secret to select from. Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                                  type: string
+                            clientTokenSecretRef:
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the secret to select from. Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                                  type: string
+                            serviceConsumerDomain:
                               type: string
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                        clientSecretSecretRef:
+                        azuredns:
+                          description: ACMEIssuerDNS01ProviderAzureDNS is a structure
+                            containing the configuration for Azure DNS
                           type: object
                           required:
-                            - name
+                            - resourceGroupName
+                            - subscriptionID
                           properties:
-                            key:
-                              description: The key of the secret to select from. Must
-                                be a valid secret key.
+                            clientID:
+                              description: if both this and ClientSecret are left unset
+                                MSI will be used
                               type: string
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                            clientSecretSecretRef:
+                              description: if both this and ClientID are left unset MSI
+                                will be used
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the secret to select from. Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                                  type: string
+                            environment:
                               type: string
-                        clientTokenSecretRef:
+                              enum:
+                                - AzurePublicCloud
+                                - AzureChinaCloud
+                                - AzureGermanCloud
+                                - AzureUSGovernmentCloud
+                            hostedZoneName:
+                              type: string
+                            resourceGroupName:
+                              type: string
+                            subscriptionID:
+                              type: string
+                            tenantID:
+                              description: when specifying ClientID and ClientSecret then
+                                this field is also needed
+                              type: string
+                        clouddns:
+                          description: ACMEIssuerDNS01ProviderCloudDNS is a structure
+                            containing the DNS configuration for Google Cloud DNS
                           type: object
                           required:
-                            - name
+                            - project
                           properties:
-                            key:
-                              description: The key of the secret to select from. Must
-                                be a valid secret key.
+                            project:
                               type: string
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                        serviceConsumerDomain:
-                          type: string
-                    azuredns:
-                      description: ACMEIssuerDNS01ProviderAzureDNS is a structure
-                        containing the configuration for Azure DNS
-                      type: object
-                      required:
-                        - resourceGroupName
-                        - subscriptionID
-                      properties:
-                        clientID:
-                          description: if both this and ClientSecret are left unset
-                            MSI will be used
-                          type: string
-                        clientSecretSecretRef:
-                          description: if both this and ClientID are left unset MSI
-                            will be used
+                            serviceAccountSecretRef:
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the secret to select from. Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                                  type: string
+                        cloudflare:
+                          description: ACMEIssuerDNS01ProviderCloudflare is a structure
+                            containing the DNS configuration for Cloudflare
                           type: object
                           required:
-                            - name
+                            - email
                           properties:
-                            key:
-                              description: The key of the secret to select from. Must
-                                be a valid secret key.
+                            apiKeySecretRef:
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the secret to select from. Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                                  type: string
+                            apiTokenSecretRef:
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the secret to select from. Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                                  type: string
+                            email:
                               type: string
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                        environment:
+                        cnameStrategy:
+                          description: CNAMEStrategy configures how the DNS01 provider
+                            should handle CNAME records when found in DNS zones.
                           type: string
                           enum:
-                            - AzurePublicCloud
-                            - AzureChinaCloud
-                            - AzureGermanCloud
-                            - AzureUSGovernmentCloud
-                        hostedZoneName:
-                          type: string
-                        resourceGroupName:
-                          type: string
-                        subscriptionID:
-                          type: string
-                        tenantID:
-                          description: when specifying ClientID and ClientSecret then
-                            this field is also needed
-                          type: string
-                    clouddns:
-                      description: ACMEIssuerDNS01ProviderCloudDNS is a structure
-                        containing the DNS configuration for Google Cloud DNS
-                      type: object
-                      required:
-                        - project
-                      properties:
-                        project:
-                          type: string
-                        serviceAccountSecretRef:
+                            - None
+                            - Follow
+                        digitalocean:
+                          description: ACMEIssuerDNS01ProviderDigitalOcean is a structure
+                            containing the DNS configuration for DigitalOcean Domains
                           type: object
                           required:
-                            - name
+                            - tokenSecretRef
                           properties:
-                            key:
-                              description: The key of the secret to select from. Must
-                                be a valid secret key.
-                              type: string
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                    cloudflare:
-                      description: ACMEIssuerDNS01ProviderCloudflare is a structure
-                        containing the DNS configuration for Cloudflare
-                      type: object
-                      required:
-                        - email
-                      properties:
-                        apiKeySecretRef:
+                            tokenSecretRef:
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the secret to select from. Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                                  type: string
+                        rfc2136:
+                          description: ACMEIssuerDNS01ProviderRFC2136 is a structure containing
+                            the configuration for RFC2136 DNS
                           type: object
                           required:
-                            - name
+                            - nameserver
                           properties:
-                            key:
-                              description: The key of the secret to select from. Must
-                                be a valid secret key.
+                            nameserver:
+                              description: The IP address or hostname of an authoritative
+                                DNS server supporting RFC2136 in the form host:port. If
+                                the host is an IPv6 address it must be enclosed in square
+                                brackets (e.g [2001:db8::1]) ; port is optional. This
+                                field is required.
                               type: string
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                            tsigAlgorithm:
+                              description: 'The TSIG Algorithm configured in the DNS supporting
+                                    RFC2136. Used only when ``tsigSecretSecretRef`` and ``tsigKeyName``
+                                    are defined. Supported values are (case-insensitive):
+                                    ``HMACMD5`` (default), ``HMACSHA1``, ``HMACSHA256`` or
+                                    ``HMACSHA512``.'
                               type: string
-                        apiTokenSecretRef:
+                            tsigKeyName:
+                              description: The TSIG Key name configured in the DNS. If
+                                ``tsigSecretSecretRef`` is defined, this field is required.
+                              type: string
+                            tsigSecretSecretRef:
+                              description: The name of the secret containing the TSIG
+                                value. If ``tsigKeyName`` is defined, this field is required.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the secret to select from. Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                                  type: string
+                        route53:
+                          description: ACMEIssuerDNS01ProviderRoute53 is a structure containing
+                            the Route 53 configuration for AWS
                           type: object
                           required:
-                            - name
+                            - region
                           properties:
-                            key:
-                              description: The key of the secret to select from. Must
-                                be a valid secret key.
+                            accessKeyID:
+                              description: 'The AccessKeyID is used for authentication.
+                                    If not set we fall-back to using env vars, shared credentials
+                                    file or AWS Instance metadata see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
                               type: string
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                            hostedZoneID:
+                              description: If set, the provider will manage only this
+                                zone in Route53 and will not do an lookup using the route53:ListHostedZonesByName
+                                api call.
                               type: string
-                        email:
-                          type: string
-                    cnameStrategy:
-                      description: CNAMEStrategy configures how the DNS01 provider
-                        should handle CNAME records when found in DNS zones.
-                      type: string
-                      enum:
-                        - None
-                        - Follow
-                    digitalocean:
-                      description: ACMEIssuerDNS01ProviderDigitalOcean is a structure
-                        containing the DNS configuration for DigitalOcean Domains
-                      type: object
-                      required:
-                        - tokenSecretRef
-                      properties:
-                        tokenSecretRef:
+                            region:
+                              description: Always set the region when using AccessKeyID
+                                and SecretAccessKey
+                              type: string
+                            role:
+                              description: Role is a Role ARN which the Route53 provider
+                                will assume using either the explicit credentials AccessKeyID/SecretAccessKey
+                                or the inferred credentials from environment variables,
+                                shared credentials file or AWS Instance metadata
+                              type: string
+                            secretAccessKeySecretRef:
+                              description: The SecretAccessKey is used for authentication.
+                                If not set we fall-back to using env vars, shared credentials
+                                file or AWS Instance metadata https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the secret to select from. Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                                  type: string
+                        webhook:
+                          description: ACMEIssuerDNS01ProviderWebhook specifies configuration
+                            for a webhook DNS01 provider, including where to POST ChallengePayload
+                            resources.
                           type: object
                           required:
-                            - name
+                            - groupName
+                            - solverName
                           properties:
-                            key:
-                              description: The key of the secret to select from. Must
-                                be a valid secret key.
+                            config:
+                              description: Additional configuration that should be passed
+                                to the webhook apiserver when challenges are processed.
+                                This can contain arbitrary JSON data. Secret values should
+                                not be specified in this stanza. If secret values are
+                                needed (e.g. credentials for a DNS service), you should
+                                use a SecretKeySelector to reference a Secret resource.
+                                For details on the schema of this field, consult the webhook
+                                provider implementation's documentation.
+                              x-kubernetes-preserve-unknown-fields: true
+                            groupName:
+                              description: The API group name that should be used when
+                                POSTing ChallengePayload resources to the webhook apiserver.
+                                This should be the same as the GroupName specified in
+                                the webhook provider implementation.
                               type: string
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                            solverName:
+                              description: The name of the solver to use, as defined in
+                                the webhook provider implementation. This will typically
+                                be the name of the provider, e.g. 'cloudflare'.
                               type: string
-                    rfc2136:
-                      description: ACMEIssuerDNS01ProviderRFC2136 is a structure containing
-                        the configuration for RFC2136 DNS
-                      type: object
-                      required:
-                        - nameserver
-                      properties:
-                        nameserver:
-                          description: The IP address or hostname of an authoritative
-                            DNS server supporting RFC2136 in the form host:port. If
-                            the host is an IPv6 address it must be enclosed in square
-                            brackets (e.g [2001:db8::1]) ; port is optional. This
-                            field is required.
-                          type: string
-                        tsigAlgorithm:
-                          description: 'The TSIG Algorithm configured in the DNS supporting
-                            RFC2136. Used only when ``tsigSecretSecretRef`` and ``tsigKeyName``
-                            are defined. Supported values are (case-insensitive):
-                            ``HMACMD5`` (default), ``HMACSHA1``, ``HMACSHA256`` or
-                            ``HMACSHA512``.'
-                          type: string
-                        tsigKeyName:
-                          description: The TSIG Key name configured in the DNS. If
-                            ``tsigSecretSecretRef`` is defined, this field is required.
-                          type: string
-                        tsigSecretSecretRef:
-                          description: The name of the secret containing the TSIG
-                            value. If ``tsigKeyName`` is defined, this field is required.
-                          type: object
-                          required:
-                            - name
-                          properties:
-                            key:
-                              description: The key of the secret to select from. Must
-                                be a valid secret key.
-                              type: string
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                    route53:
-                      description: ACMEIssuerDNS01ProviderRoute53 is a structure containing
-                        the Route 53 configuration for AWS
-                      type: object
-                      required:
-                        - region
-                      properties:
-                        accessKeyID:
-                          description: 'The AccessKeyID is used for authentication.
-                            If not set we fall-back to using env vars, shared credentials
-                            file or AWS Instance metadata see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
-                          type: string
-                        hostedZoneID:
-                          description: If set, the provider will manage only this
-                            zone in Route53 and will not do an lookup using the route53:ListHostedZonesByName
-                            api call.
-                          type: string
-                        region:
-                          description: Always set the region when using AccessKeyID
-                            and SecretAccessKey
-                          type: string
-                        role:
-                          description: Role is a Role ARN which the Route53 provider
-                            will assume using either the explicit credentials AccessKeyID/SecretAccessKey
-                            or the inferred credentials from environment variables,
-                            shared credentials file or AWS Instance metadata
-                          type: string
-                        secretAccessKeySecretRef:
-                          description: The SecretAccessKey is used for authentication.
-                            If not set we fall-back to using env vars, shared credentials
-                            file or AWS Instance metadata https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
-                          type: object
-                          required:
-                            - name
-                          properties:
-                            key:
-                              description: The key of the secret to select from. Must
-                                be a valid secret key.
-                              type: string
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                    webhook:
-                      description: ACMEIssuerDNS01ProviderWebhook specifies configuration
-                        for a webhook DNS01 provider, including where to POST ChallengePayload
-                        resources.
-                      type: object
-                      required:
-                        - groupName
-                        - solverName
-                      properties:
-                        config:
-                          description: Additional configuration that should be passed
-                            to the webhook apiserver when challenges are processed.
-                            This can contain arbitrary JSON data. Secret values should
-                            not be specified in this stanza. If secret values are
-                            needed (e.g. credentials for a DNS service), you should
-                            use a SecretKeySelector to reference a Secret resource.
-                            For details on the schema of this field, consult the webhook
-                            provider implementation's documentation.
-                          x-kubernetes-preserve-unknown-fields: true
-                        groupName:
-                          description: The API group name that should be used when
-                            POSTing ChallengePayload resources to the webhook apiserver.
-                            This should be the same as the GroupName specified in
-                            the webhook provider implementation.
-                          type: string
-                        solverName:
-                          description: The name of the solver to use, as defined in
-                            the webhook provider implementation. This will typically
-                            be the name of the provider, e.g. 'cloudflare'.
-                          type: string
-                http01:
-                  description: ACMEChallengeSolverHTTP01 contains configuration detailing
-                    how to solve HTTP01 challenges within a Kubernetes cluster. Typically
-                    this is accomplished through creating 'routes' of some description
-                    that configure ingress controllers to direct traffic to 'solver
-                    pods', which are responsible for responding to the ACME server's
-                    HTTP requests.
-                  type: object
-                  properties:
-                    ingress:
-                      description: The ingress based HTTP01 challenge solver will
-                        solve challenges by creating or modifying Ingress resources
-                        in order to route requests for '/.well-known/acme-challenge/XYZ'
-                        to 'challenge solver' pods that are provisioned by cert-manager
-                        for each Challenge to be completed.
+                    http01:
+                      description: ACMEChallengeSolverHTTP01 contains configuration detailing
+                        how to solve HTTP01 challenges within a Kubernetes cluster. Typically
+                        this is accomplished through creating 'routes' of some description
+                        that configure ingress controllers to direct traffic to 'solver
+                        pods', which are responsible for responding to the ACME server's
+                        HTTP requests.
                       type: object
                       properties:
-                        class:
-                          description: The ingress class to use when creating Ingress
-                            resources to solve ACME challenges that use this challenge
-                            solver. Only one of 'class' or 'name' may be specified.
-                          type: string
-                        ingressTemplate:
-                          description: Optional ingress template used to configure
-                            the ACME challenge solver ingress used for HTTP01 challenges
+                        ingress:
+                          description: The ingress based HTTP01 challenge solver will
+                            solve challenges by creating or modifying Ingress resources
+                            in order to route requests for '/.well-known/acme-challenge/XYZ'
+                            to 'challenge solver' pods that are provisioned by cert-manager
+                            for each Challenge to be completed.
                           type: object
                           properties:
-                            metadata:
-                              description: ObjectMeta overrides for the ingress used
-                                to solve HTTP01 challenges. Only the 'labels' and
-                                'annotations' fields may be set. If labels or annotations
-                                overlap with in-built values, the values here will
-                                override the in-built values.
+                            class:
+                              description: The ingress class to use when creating Ingress
+                                resources to solve ACME challenges that use this challenge
+                                solver. Only one of 'class' or 'name' may be specified.
+                              type: string
+                            ingressTemplate:
+                              description: Optional ingress template used to configure
+                                the ACME challenge solver ingress used for HTTP01 challenges
                               type: object
                               properties:
-                                annotations:
-                                  description: Annotations that should be added to
-                                    the created ACME HTTP01 solver ingress.
-                                  type: object
-                                  additionalProperties:
-                                    type: string
-                                labels:
-                                  description: Labels that should be added to the
-                                    created ACME HTTP01 solver ingress.
-                                  type: object
-                                  additionalProperties:
-                                    type: string
-                        name:
-                          description: The name of the ingress resource that should
-                            have ACME challenge solving routes inserted into it in
-                            order to solve HTTP01 challenges. This is typically used
-                            in conjunction with ingress controllers like ingress-gce,
-                            which maintains a 1:1 mapping between external IPs and
-                            ingress resources.
-                          type: string
-                        podTemplate:
-                          description: Optional pod template used to configure the
-                            ACME challenge solver pods used for HTTP01 challenges
-                          type: object
-                          properties:
-                            metadata:
-                              description: ObjectMeta overrides for the pod used to
-                                solve HTTP01 challenges. Only the 'labels' and 'annotations'
-                                fields may be set. If labels or annotations overlap
-                                with in-built values, the values here will override
-                                the in-built values.
-                              type: object
-                              properties:
-                                annotations:
-                                  description: Annotations that should be added to
-                                    the create ACME HTTP01 solver pods.
-                                  type: object
-                                  additionalProperties:
-                                    type: string
-                                labels:
-                                  description: Labels that should be added to the
-                                    created ACME HTTP01 solver pods.
-                                  type: object
-                                  additionalProperties:
-                                    type: string
-                            spec:
-                              description: PodSpec defines overrides for the HTTP01
-                                challenge solver pod. Only the 'nodeSelector', 'affinity'
-                                and 'tolerations' fields are supported currently.
-                                All other fields will be ignored.
-                              type: object
-                              properties:
-                                affinity:
-                                  description: If specified, the pod's scheduling
-                                    constraints
+                                metadata:
+                                  description: ObjectMeta overrides for the ingress used
+                                    to solve HTTP01 challenges. Only the 'labels' and
+                                    'annotations' fields may be set. If labels or annotations
+                                    overlap with in-built values, the values here will
+                                    override the in-built values.
                                   type: object
                                   properties:
-                                    nodeAffinity:
-                                      description: Describes node affinity scheduling
-                                        rules for the pod.
+                                    annotations:
+                                      description: Annotations that should be added to
+                                        the created ACME HTTP01 solver ingress.
+                                      type: object
+                                      additionalProperties:
+                                        type: string
+                                    labels:
+                                      description: Labels that should be added to the
+                                        created ACME HTTP01 solver ingress.
+                                      type: object
+                                      additionalProperties:
+                                        type: string
+                            name:
+                              description: The name of the ingress resource that should
+                                have ACME challenge solving routes inserted into it in
+                                order to solve HTTP01 challenges. This is typically used
+                                in conjunction with ingress controllers like ingress-gce,
+                                which maintains a 1:1 mapping between external IPs and
+                                ingress resources.
+                              type: string
+                            podTemplate:
+                              description: Optional pod template used to configure the
+                                ACME challenge solver pods used for HTTP01 challenges
+                              type: object
+                              properties:
+                                metadata:
+                                  description: ObjectMeta overrides for the pod used to
+                                    solve HTTP01 challenges. Only the 'labels' and 'annotations'
+                                    fields may be set. If labels or annotations overlap
+                                    with in-built values, the values here will override
+                                    the in-built values.
+                                  type: object
+                                  properties:
+                                    annotations:
+                                      description: Annotations that should be added to
+                                        the create ACME HTTP01 solver pods.
+                                      type: object
+                                      additionalProperties:
+                                        type: string
+                                    labels:
+                                      description: Labels that should be added to the
+                                        created ACME HTTP01 solver pods.
+                                      type: object
+                                      additionalProperties:
+                                        type: string
+                                spec:
+                                  description: PodSpec defines overrides for the HTTP01
+                                    challenge solver pod. Only the 'nodeSelector', 'affinity'
+                                    and 'tolerations' fields are supported currently.
+                                    All other fields will be ignored.
+                                  type: object
+                                  properties:
+                                    affinity:
+                                      description: If specified, the pod's scheduling
+                                        constraints
                                       type: object
                                       properties:
-                                        preferredDuringSchedulingIgnoredDuringExecution:
-                                          description: The scheduler will prefer to
-                                            schedule pods to nodes that satisfy the
-                                            affinity expressions specified by this
-                                            field, but it may choose a node that violates
-                                            one or more of the expressions. The node
-                                            that is most preferred is the one with
-                                            the greatest sum of weights, i.e. for
-                                            each node that meets all of the scheduling
-                                            requirements (resource request, requiredDuringScheduling
-                                            affinity expressions, etc.), compute a
-                                            sum by iterating through the elements
-                                            of this field and adding "weight" to the
-                                            sum if the node matches the corresponding
-                                            matchExpressions; the node(s) with the
-                                            highest sum are the most preferred.
-                                          type: array
-                                          items:
-                                            description: An empty preferred scheduling
-                                              term matches all objects with implicit
-                                              weight 0 (i.e. it's a no-op). A null
-                                              preferred scheduling term matches no
-                                              objects (i.e. is also a no-op).
-                                            type: object
-                                            required:
-                                              - preference
-                                              - weight
-                                            properties:
-                                              preference:
-                                                description: A node selector term,
-                                                  associated with the corresponding
-                                                  weight.
-                                                type: object
-                                                properties:
-                                                  matchExpressions:
-                                                    description: A list of node selector
-                                                      requirements by node's labels.
-                                                    type: array
-                                                    items:
-                                                      description: A node selector
-                                                        requirement is a selector
-                                                        that contains values, a key,
-                                                        and an operator that relates
-                                                        the key and values.
-                                                      type: object
-                                                      required:
-                                                        - key
-                                                        - operator
-                                                      properties:
-                                                        key:
-                                                          description: The label key
-                                                            that the selector applies
-                                                            to.
-                                                          type: string
-                                                        operator:
-                                                          description: Represents
-                                                            a key's relationship to
-                                                            a set of values. Valid
-                                                            operators are In, NotIn,
-                                                            Exists, DoesNotExist.
-                                                            Gt, and Lt.
-                                                          type: string
-                                                        values:
-                                                          description: An array of
-                                                            string values. If the
-                                                            operator is In or NotIn,
-                                                            the values array must
-                                                            be non-empty. If the operator
-                                                            is Exists or DoesNotExist,
-                                                            the values array must
-                                                            be empty. If the operator
-                                                            is Gt or Lt, the values
-                                                            array must have a single
-                                                            element, which will be
-                                                            interpreted as an integer.
-                                                            This array is replaced
-                                                            during a strategic merge
-                                                            patch.
-                                                          type: array
-                                                          items:
-                                                            type: string
-                                                  matchFields:
-                                                    description: A list of node selector
-                                                      requirements by node's fields.
-                                                    type: array
-                                                    items:
-                                                      description: A node selector
-                                                        requirement is a selector
-                                                        that contains values, a key,
-                                                        and an operator that relates
-                                                        the key and values.
-                                                      type: object
-                                                      required:
-                                                        - key
-                                                        - operator
-                                                      properties:
-                                                        key:
-                                                          description: The label key
-                                                            that the selector applies
-                                                            to.
-                                                          type: string
-                                                        operator:
-                                                          description: Represents
-                                                            a key's relationship to
-                                                            a set of values. Valid
-                                                            operators are In, NotIn,
-                                                            Exists, DoesNotExist.
-                                                            Gt, and Lt.
-                                                          type: string
-                                                        values:
-                                                          description: An array of
-                                                            string values. If the
-                                                            operator is In or NotIn,
-                                                            the values array must
-                                                            be non-empty. If the operator
-                                                            is Exists or DoesNotExist,
-                                                            the values array must
-                                                            be empty. If the operator
-                                                            is Gt or Lt, the values
-                                                            array must have a single
-                                                            element, which will be
-                                                            interpreted as an integer.
-                                                            This array is replaced
-                                                            during a strategic merge
-                                                            patch.
-                                                          type: array
-                                                          items:
-                                                            type: string
-                                              weight:
-                                                description: Weight associated with
-                                                  matching the corresponding nodeSelectorTerm,
-                                                  in the range 1-100.
-                                                type: integer
-                                                format: int32
-                                        requiredDuringSchedulingIgnoredDuringExecution:
-                                          description: If the affinity requirements
-                                            specified by this field are not met at
-                                            scheduling time, the pod will not be scheduled
-                                            onto the node. If the affinity requirements
-                                            specified by this field cease to be met
-                                            at some point during pod execution (e.g.
-                                            due to an update), the system may or may
-                                            not try to eventually evict the pod from
-                                            its node.
+                                        nodeAffinity:
+                                          description: Describes node affinity scheduling
+                                            rules for the pod.
                                           type: object
-                                          required:
-                                            - nodeSelectorTerms
                                           properties:
-                                            nodeSelectorTerms:
-                                              description: Required. A list of node
-                                                selector terms. The terms are ORed.
+                                            preferredDuringSchedulingIgnoredDuringExecution:
+                                              description: The scheduler will prefer to
+                                                schedule pods to nodes that satisfy the
+                                                affinity expressions specified by this
+                                                field, but it may choose a node that violates
+                                                one or more of the expressions. The node
+                                                that is most preferred is the one with
+                                                the greatest sum of weights, i.e. for
+                                                each node that meets all of the scheduling
+                                                requirements (resource request, requiredDuringScheduling
+                                                affinity expressions, etc.), compute a
+                                                sum by iterating through the elements
+                                                of this field and adding "weight" to the
+                                                sum if the node matches the corresponding
+                                                matchExpressions; the node(s) with the
+                                                highest sum are the most preferred.
                                               type: array
                                               items:
-                                                description: A null or empty node
-                                                  selector term matches no objects.
-                                                  The requirements of them are ANDed.
-                                                  The TopologySelectorTerm type implements
-                                                  a subset of the NodeSelectorTerm.
+                                                description: An empty preferred scheduling
+                                                  term matches all objects with implicit
+                                                  weight 0 (i.e. it's a no-op). A null
+                                                  preferred scheduling term matches no
+                                                  objects (i.e. is also a no-op).
                                                 type: object
+                                                required:
+                                                  - preference
+                                                  - weight
                                                 properties:
-                                                  matchExpressions:
-                                                    description: A list of node selector
-                                                      requirements by node's labels.
-                                                    type: array
-                                                    items:
-                                                      description: A node selector
-                                                        requirement is a selector
-                                                        that contains values, a key,
-                                                        and an operator that relates
-                                                        the key and values.
-                                                      type: object
-                                                      required:
-                                                        - key
-                                                        - operator
-                                                      properties:
-                                                        key:
-                                                          description: The label key
-                                                            that the selector applies
-                                                            to.
+                                                  preference:
+                                                    description: A node selector term,
+                                                      associated with the corresponding
+                                                      weight.
+                                                    type: object
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: A list of node selector
+                                                          requirements by node's labels.
+                                                        type: array
+                                                        items:
+                                                          description: A node selector
+                                                            requirement is a selector
+                                                            that contains values, a key,
+                                                            and an operator that relates
+                                                            the key and values.
+                                                          type: object
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          properties:
+                                                            key:
+                                                              description: The label key
+                                                                that the selector applies
+                                                                to.
+                                                              type: string
+                                                            operator:
+                                                              description: Represents
+                                                                a key's relationship to
+                                                                a set of values. Valid
+                                                                operators are In, NotIn,
+                                                                Exists, DoesNotExist.
+                                                                Gt, and Lt.
+                                                              type: string
+                                                            values:
+                                                              description: An array of
+                                                                string values. If the
+                                                                operator is In or NotIn,
+                                                                the values array must
+                                                                be non-empty. If the operator
+                                                                is Exists or DoesNotExist,
+                                                                the values array must
+                                                                be empty. If the operator
+                                                                is Gt or Lt, the values
+                                                                array must have a single
+                                                                element, which will be
+                                                                interpreted as an integer.
+                                                                This array is replaced
+                                                                during a strategic merge
+                                                                patch.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                      matchFields:
+                                                        description: A list of node selector
+                                                          requirements by node's fields.
+                                                        type: array
+                                                        items:
+                                                          description: A node selector
+                                                            requirement is a selector
+                                                            that contains values, a key,
+                                                            and an operator that relates
+                                                            the key and values.
+                                                          type: object
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          properties:
+                                                            key:
+                                                              description: The label key
+                                                                that the selector applies
+                                                                to.
+                                                              type: string
+                                                            operator:
+                                                              description: Represents
+                                                                a key's relationship to
+                                                                a set of values. Valid
+                                                                operators are In, NotIn,
+                                                                Exists, DoesNotExist.
+                                                                Gt, and Lt.
+                                                              type: string
+                                                            values:
+                                                              description: An array of
+                                                                string values. If the
+                                                                operator is In or NotIn,
+                                                                the values array must
+                                                                be non-empty. If the operator
+                                                                is Exists or DoesNotExist,
+                                                                the values array must
+                                                                be empty. If the operator
+                                                                is Gt or Lt, the values
+                                                                array must have a single
+                                                                element, which will be
+                                                                interpreted as an integer.
+                                                                This array is replaced
+                                                                during a strategic merge
+                                                                patch.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                  weight:
+                                                    description: Weight associated with
+                                                      matching the corresponding nodeSelectorTerm,
+                                                      in the range 1-100.
+                                                    type: integer
+                                                    format: int32
+                                            requiredDuringSchedulingIgnoredDuringExecution:
+                                              description: If the affinity requirements
+                                                specified by this field are not met at
+                                                scheduling time, the pod will not be scheduled
+                                                onto the node. If the affinity requirements
+                                                specified by this field cease to be met
+                                                at some point during pod execution (e.g.
+                                                due to an update), the system may or may
+                                                not try to eventually evict the pod from
+                                                its node.
+                                              type: object
+                                              required:
+                                                - nodeSelectorTerms
+                                              properties:
+                                                nodeSelectorTerms:
+                                                  description: Required. A list of node
+                                                    selector terms. The terms are ORed.
+                                                  type: array
+                                                  items:
+                                                    description: A null or empty node
+                                                      selector term matches no objects.
+                                                      The requirements of them are ANDed.
+                                                      The TopologySelectorTerm type implements
+                                                      a subset of the NodeSelectorTerm.
+                                                    type: object
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: A list of node selector
+                                                          requirements by node's labels.
+                                                        type: array
+                                                        items:
+                                                          description: A node selector
+                                                            requirement is a selector
+                                                            that contains values, a key,
+                                                            and an operator that relates
+                                                            the key and values.
+                                                          type: object
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          properties:
+                                                            key:
+                                                              description: The label key
+                                                                that the selector applies
+                                                                to.
+                                                              type: string
+                                                            operator:
+                                                              description: Represents
+                                                                a key's relationship to
+                                                                a set of values. Valid
+                                                                operators are In, NotIn,
+                                                                Exists, DoesNotExist.
+                                                                Gt, and Lt.
+                                                              type: string
+                                                            values:
+                                                              description: An array of
+                                                                string values. If the
+                                                                operator is In or NotIn,
+                                                                the values array must
+                                                                be non-empty. If the operator
+                                                                is Exists or DoesNotExist,
+                                                                the values array must
+                                                                be empty. If the operator
+                                                                is Gt or Lt, the values
+                                                                array must have a single
+                                                                element, which will be
+                                                                interpreted as an integer.
+                                                                This array is replaced
+                                                                during a strategic merge
+                                                                patch.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                      matchFields:
+                                                        description: A list of node selector
+                                                          requirements by node's fields.
+                                                        type: array
+                                                        items:
+                                                          description: A node selector
+                                                            requirement is a selector
+                                                            that contains values, a key,
+                                                            and an operator that relates
+                                                            the key and values.
+                                                          type: object
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          properties:
+                                                            key:
+                                                              description: The label key
+                                                                that the selector applies
+                                                                to.
+                                                              type: string
+                                                            operator:
+                                                              description: Represents
+                                                                a key's relationship to
+                                                                a set of values. Valid
+                                                                operators are In, NotIn,
+                                                                Exists, DoesNotExist.
+                                                                Gt, and Lt.
+                                                              type: string
+                                                            values:
+                                                              description: An array of
+                                                                string values. If the
+                                                                operator is In or NotIn,
+                                                                the values array must
+                                                                be non-empty. If the operator
+                                                                is Exists or DoesNotExist,
+                                                                the values array must
+                                                                be empty. If the operator
+                                                                is Gt or Lt, the values
+                                                                array must have a single
+                                                                element, which will be
+                                                                interpreted as an integer.
+                                                                This array is replaced
+                                                                during a strategic merge
+                                                                patch.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                        podAffinity:
+                                          description: Describes pod affinity scheduling
+                                            rules (e.g. co-locate this pod in the same
+                                            node, zone, etc. as some other pod(s)).
+                                          type: object
+                                          properties:
+                                            preferredDuringSchedulingIgnoredDuringExecution:
+                                              description: The scheduler will prefer to
+                                                schedule pods to nodes that satisfy the
+                                                affinity expressions specified by this
+                                                field, but it may choose a node that violates
+                                                one or more of the expressions. The node
+                                                that is most preferred is the one with
+                                                the greatest sum of weights, i.e. for
+                                                each node that meets all of the scheduling
+                                                requirements (resource request, requiredDuringScheduling
+                                                affinity expressions, etc.), compute a
+                                                sum by iterating through the elements
+                                                of this field and adding "weight" to the
+                                                sum if the node has pods which matches
+                                                the corresponding podAffinityTerm; the
+                                                node(s) with the highest sum are the most
+                                                preferred.
+                                              type: array
+                                              items:
+                                                description: The weights of all of the
+                                                  matched WeightedPodAffinityTerm fields
+                                                  are added per-node to find the most
+                                                  preferred node(s)
+                                                type: object
+                                                required:
+                                                  - podAffinityTerm
+                                                  - weight
+                                                properties:
+                                                  podAffinityTerm:
+                                                    description: Required. A pod affinity
+                                                      term, associated with the corresponding
+                                                      weight.
+                                                    type: object
+                                                    required:
+                                                      - topologyKey
+                                                    properties:
+                                                      labelSelector:
+                                                        description: A label query over
+                                                          a set of resources, in this
+                                                          case pods.
+                                                        type: object
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: matchExpressions
+                                                              is a list of label selector
+                                                              requirements. The requirements
+                                                              are ANDed.
+                                                            type: array
+                                                            items:
+                                                              description: A label selector
+                                                                requirement is a selector
+                                                                that contains values,
+                                                                a key, and an operator
+                                                                that relates the key and
+                                                                values.
+                                                              type: object
+                                                              required:
+                                                                - key
+                                                                - operator
+                                                              properties:
+                                                                key:
+                                                                  description: key is
+                                                                    the label key that
+                                                                    the selector applies
+                                                                    to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: operator
+                                                                    represents a key's
+                                                                    relationship to a
+                                                                    set of values. Valid
+                                                                    operators are In,
+                                                                    NotIn, Exists and
+                                                                    DoesNotExist.
+                                                                  type: string
+                                                                values:
+                                                                  description: values
+                                                                    is an array of string
+                                                                    values. If the operator
+                                                                    is In or NotIn, the
+                                                                    values array must
+                                                                    be non-empty. If the
+                                                                    operator is Exists
+                                                                    or DoesNotExist, the
+                                                                    values array must
+                                                                    be empty. This array
+                                                                    is replaced during
+                                                                    a strategic merge
+                                                                    patch.
+                                                                  type: array
+                                                                  items:
+                                                                    type: string
+                                                          matchLabels:
+                                                            description: matchLabels is
+                                                              a map of {key,value} pairs.
+                                                              A single {key,value} in
+                                                              the matchLabels map is equivalent
+                                                              to an element of matchExpressions,
+                                                              whose key field is "key",
+                                                              the operator is "In", and
+                                                              the values array contains
+                                                              only "value". The requirements
+                                                              are ANDed.
+                                                            type: object
+                                                            additionalProperties:
+                                                              type: string
+                                                      namespaces:
+                                                        description: namespaces specifies
+                                                          which namespaces the labelSelector
+                                                          applies to (matches against);
+                                                          null or empty list means "this
+                                                          pod's namespace"
+                                                        type: array
+                                                        items:
                                                           type: string
-                                                        operator:
-                                                          description: Represents
-                                                            a key's relationship to
-                                                            a set of values. Valid
-                                                            operators are In, NotIn,
-                                                            Exists, DoesNotExist.
-                                                            Gt, and Lt.
-                                                          type: string
-                                                        values:
-                                                          description: An array of
-                                                            string values. If the
-                                                            operator is In or NotIn,
-                                                            the values array must
-                                                            be non-empty. If the operator
-                                                            is Exists or DoesNotExist,
-                                                            the values array must
-                                                            be empty. If the operator
-                                                            is Gt or Lt, the values
-                                                            array must have a single
-                                                            element, which will be
-                                                            interpreted as an integer.
-                                                            This array is replaced
-                                                            during a strategic merge
-                                                            patch.
-                                                          type: array
-                                                          items:
-                                                            type: string
-                                                  matchFields:
-                                                    description: A list of node selector
-                                                      requirements by node's fields.
-                                                    type: array
-                                                    items:
-                                                      description: A node selector
-                                                        requirement is a selector
-                                                        that contains values, a key,
-                                                        and an operator that relates
-                                                        the key and values.
-                                                      type: object
-                                                      required:
-                                                        - key
-                                                        - operator
-                                                      properties:
-                                                        key:
-                                                          description: The label key
-                                                            that the selector applies
-                                                            to.
-                                                          type: string
-                                                        operator:
-                                                          description: Represents
-                                                            a key's relationship to
-                                                            a set of values. Valid
-                                                            operators are In, NotIn,
-                                                            Exists, DoesNotExist.
-                                                            Gt, and Lt.
-                                                          type: string
-                                                        values:
-                                                          description: An array of
-                                                            string values. If the
-                                                            operator is In or NotIn,
-                                                            the values array must
-                                                            be non-empty. If the operator
-                                                            is Exists or DoesNotExist,
-                                                            the values array must
-                                                            be empty. If the operator
-                                                            is Gt or Lt, the values
-                                                            array must have a single
-                                                            element, which will be
-                                                            interpreted as an integer.
-                                                            This array is replaced
-                                                            during a strategic merge
-                                                            patch.
-                                                          type: array
-                                                          items:
-                                                            type: string
-                                    podAffinity:
-                                      description: Describes pod affinity scheduling
-                                        rules (e.g. co-locate this pod in the same
-                                        node, zone, etc. as some other pod(s)).
-                                      type: object
-                                      properties:
-                                        preferredDuringSchedulingIgnoredDuringExecution:
-                                          description: The scheduler will prefer to
-                                            schedule pods to nodes that satisfy the
-                                            affinity expressions specified by this
-                                            field, but it may choose a node that violates
-                                            one or more of the expressions. The node
-                                            that is most preferred is the one with
-                                            the greatest sum of weights, i.e. for
-                                            each node that meets all of the scheduling
-                                            requirements (resource request, requiredDuringScheduling
-                                            affinity expressions, etc.), compute a
-                                            sum by iterating through the elements
-                                            of this field and adding "weight" to the
-                                            sum if the node has pods which matches
-                                            the corresponding podAffinityTerm; the
-                                            node(s) with the highest sum are the most
-                                            preferred.
-                                          type: array
-                                          items:
-                                            description: The weights of all of the
-                                              matched WeightedPodAffinityTerm fields
-                                              are added per-node to find the most
-                                              preferred node(s)
-                                            type: object
-                                            required:
-                                              - podAffinityTerm
-                                              - weight
-                                            properties:
-                                              podAffinityTerm:
-                                                description: Required. A pod affinity
-                                                  term, associated with the corresponding
-                                                  weight.
+                                                      topologyKey:
+                                                        description: This pod should be
+                                                          co-located (affinity) or not
+                                                          co-located (anti-affinity) with
+                                                          the pods matching the labelSelector
+                                                          in the specified namespaces,
+                                                          where co-located is defined
+                                                          as running on a node whose value
+                                                          of the label with key topologyKey
+                                                          matches that of any node on
+                                                          which any of the selected pods
+                                                          is running. Empty topologyKey
+                                                          is not allowed.
+                                                        type: string
+                                                  weight:
+                                                    description: weight associated with
+                                                      matching the corresponding podAffinityTerm,
+                                                      in the range 1-100.
+                                                    type: integer
+                                                    format: int32
+                                            requiredDuringSchedulingIgnoredDuringExecution:
+                                              description: If the affinity requirements
+                                                specified by this field are not met at
+                                                scheduling time, the pod will not be scheduled
+                                                onto the node. If the affinity requirements
+                                                specified by this field cease to be met
+                                                at some point during pod execution (e.g.
+                                                due to a pod label update), the system
+                                                may or may not try to eventually evict
+                                                the pod from its node. When there are
+                                                multiple elements, the lists of nodes
+                                                corresponding to each podAffinityTerm
+                                                are intersected, i.e. all terms must be
+                                                satisfied.
+                                              type: array
+                                              items:
+                                                description: Defines a set of pods (namely
+                                                  those matching the labelSelector relative
+                                                  to the given namespace(s)) that this
+                                                  pod should be co-located (affinity)
+                                                  or not co-located (anti-affinity) with,
+                                                  where co-located is defined as running
+                                                  on a node whose value of the label with
+                                                  key <topologyKey> matches that of any
+                                                  node on which a pod of the set of pods
+                                                  is running
                                                 type: object
                                                 required:
                                                   - topologyKey
                                                 properties:
                                                   labelSelector:
-                                                    description: A label query over
-                                                      a set of resources, in this
-                                                      case pods.
+                                                    description: A label query over a
+                                                      set of resources, in this case pods.
                                                     type: object
                                                     properties:
                                                       matchExpressions:
@@ -859,57 +962,49 @@ spec:
                                                         items:
                                                           description: A label selector
                                                             requirement is a selector
-                                                            that contains values,
-                                                            a key, and an operator
-                                                            that relates the key and
-                                                            values.
+                                                            that contains values, a key,
+                                                            and an operator that relates
+                                                            the key and values.
                                                           type: object
                                                           required:
                                                             - key
                                                             - operator
                                                           properties:
                                                             key:
-                                                              description: key is
-                                                                the label key that
-                                                                the selector applies
-                                                                to.
+                                                              description: key is the
+                                                                label key that the selector
+                                                                applies to.
                                                               type: string
                                                             operator:
-                                                              description: operator
-                                                                represents a key's
-                                                                relationship to a
-                                                                set of values. Valid
-                                                                operators are In,
-                                                                NotIn, Exists and
-                                                                DoesNotExist.
+                                                              description: operator represents
+                                                                a key's relationship to
+                                                                a set of values. Valid
+                                                                operators are In, NotIn,
+                                                                Exists and DoesNotExist.
                                                               type: string
                                                             values:
-                                                              description: values
-                                                                is an array of string
-                                                                values. If the operator
-                                                                is In or NotIn, the
-                                                                values array must
-                                                                be non-empty. If the
-                                                                operator is Exists
-                                                                or DoesNotExist, the
-                                                                values array must
-                                                                be empty. This array
-                                                                is replaced during
-                                                                a strategic merge
-                                                                patch.
+                                                              description: values is an
+                                                                array of string values.
+                                                                If the operator is In
+                                                                or NotIn, the values array
+                                                                must be non-empty. If
+                                                                the operator is Exists
+                                                                or DoesNotExist, the values
+                                                                array must be empty. This
+                                                                array is replaced during
+                                                                a strategic merge patch.
                                                               type: array
                                                               items:
                                                                 type: string
                                                       matchLabels:
-                                                        description: matchLabels is
-                                                          a map of {key,value} pairs.
-                                                          A single {key,value} in
-                                                          the matchLabels map is equivalent
-                                                          to an element of matchExpressions,
-                                                          whose key field is "key",
-                                                          the operator is "In", and
-                                                          the values array contains
-                                                          only "value". The requirements
+                                                        description: matchLabels is a
+                                                          map of {key,value} pairs. A
+                                                          single {key,value} in the matchLabels
+                                                          map is equivalent to an element
+                                                          of matchExpressions, whose key
+                                                          field is "key", the operator
+                                                          is "In", and the values array
+                                                          contains only "value". The requirements
                                                           are ANDed.
                                                         type: object
                                                         additionalProperties:
@@ -917,190 +1012,198 @@ spec:
                                                   namespaces:
                                                     description: namespaces specifies
                                                       which namespaces the labelSelector
-                                                      applies to (matches against);
-                                                      null or empty list means "this
-                                                      pod's namespace"
+                                                      applies to (matches against); null
+                                                      or empty list means "this pod's
+                                                      namespace"
                                                     type: array
                                                     items:
                                                       type: string
                                                   topologyKey:
-                                                    description: This pod should be
-                                                      co-located (affinity) or not
-                                                      co-located (anti-affinity) with
-                                                      the pods matching the labelSelector
-                                                      in the specified namespaces,
-                                                      where co-located is defined
-                                                      as running on a node whose value
-                                                      of the label with key topologyKey
-                                                      matches that of any node on
-                                                      which any of the selected pods
-                                                      is running. Empty topologyKey
-                                                      is not allowed.
+                                                    description: This pod should be co-located
+                                                      (affinity) or not co-located (anti-affinity)
+                                                      with the pods matching the labelSelector
+                                                      in the specified namespaces, where
+                                                      co-located is defined as running
+                                                      on a node whose value of the label
+                                                      with key topologyKey matches that
+                                                      of any node on which any of the
+                                                      selected pods is running. Empty
+                                                      topologyKey is not allowed.
                                                     type: string
-                                              weight:
-                                                description: weight associated with
-                                                  matching the corresponding podAffinityTerm,
-                                                  in the range 1-100.
-                                                type: integer
-                                                format: int32
-                                        requiredDuringSchedulingIgnoredDuringExecution:
-                                          description: If the affinity requirements
-                                            specified by this field are not met at
-                                            scheduling time, the pod will not be scheduled
-                                            onto the node. If the affinity requirements
-                                            specified by this field cease to be met
-                                            at some point during pod execution (e.g.
-                                            due to a pod label update), the system
-                                            may or may not try to eventually evict
-                                            the pod from its node. When there are
-                                            multiple elements, the lists of nodes
-                                            corresponding to each podAffinityTerm
-                                            are intersected, i.e. all terms must be
-                                            satisfied.
-                                          type: array
-                                          items:
-                                            description: Defines a set of pods (namely
-                                              those matching the labelSelector relative
-                                              to the given namespace(s)) that this
-                                              pod should be co-located (affinity)
-                                              or not co-located (anti-affinity) with,
-                                              where co-located is defined as running
-                                              on a node whose value of the label with
-                                              key <topologyKey> matches that of any
-                                              node on which a pod of the set of pods
-                                              is running
-                                            type: object
-                                            required:
-                                              - topologyKey
-                                            properties:
-                                              labelSelector:
-                                                description: A label query over a
-                                                  set of resources, in this case pods.
+                                        podAntiAffinity:
+                                          description: Describes pod anti-affinity scheduling
+                                            rules (e.g. avoid putting this pod in the
+                                            same node, zone, etc. as some other pod(s)).
+                                          type: object
+                                          properties:
+                                            preferredDuringSchedulingIgnoredDuringExecution:
+                                              description: The scheduler will prefer to
+                                                schedule pods to nodes that satisfy the
+                                                anti-affinity expressions specified by
+                                                this field, but it may choose a node that
+                                                violates one or more of the expressions.
+                                                The node that is most preferred is the
+                                                one with the greatest sum of weights,
+                                                i.e. for each node that meets all of the
+                                                scheduling requirements (resource request,
+                                                requiredDuringScheduling anti-affinity
+                                                expressions, etc.), compute a sum by iterating
+                                                through the elements of this field and
+                                                adding "weight" to the sum if the node
+                                                has pods which matches the corresponding
+                                                podAffinityTerm; the node(s) with the
+                                                highest sum are the most preferred.
+                                              type: array
+                                              items:
+                                                description: The weights of all of the
+                                                  matched WeightedPodAffinityTerm fields
+                                                  are added per-node to find the most
+                                                  preferred node(s)
                                                 type: object
+                                                required:
+                                                  - podAffinityTerm
+                                                  - weight
                                                 properties:
-                                                  matchExpressions:
-                                                    description: matchExpressions
-                                                      is a list of label selector
-                                                      requirements. The requirements
-                                                      are ANDed.
-                                                    type: array
-                                                    items:
-                                                      description: A label selector
-                                                        requirement is a selector
-                                                        that contains values, a key,
-                                                        and an operator that relates
-                                                        the key and values.
-                                                      type: object
-                                                      required:
-                                                        - key
-                                                        - operator
-                                                      properties:
-                                                        key:
-                                                          description: key is the
-                                                            label key that the selector
-                                                            applies to.
-                                                          type: string
-                                                        operator:
-                                                          description: operator represents
-                                                            a key's relationship to
-                                                            a set of values. Valid
-                                                            operators are In, NotIn,
-                                                            Exists and DoesNotExist.
-                                                          type: string
-                                                        values:
-                                                          description: values is an
-                                                            array of string values.
-                                                            If the operator is In
-                                                            or NotIn, the values array
-                                                            must be non-empty. If
-                                                            the operator is Exists
-                                                            or DoesNotExist, the values
-                                                            array must be empty. This
-                                                            array is replaced during
-                                                            a strategic merge patch.
-                                                          type: array
-                                                          items:
-                                                            type: string
-                                                  matchLabels:
-                                                    description: matchLabels is a
-                                                      map of {key,value} pairs. A
-                                                      single {key,value} in the matchLabels
-                                                      map is equivalent to an element
-                                                      of matchExpressions, whose key
-                                                      field is "key", the operator
-                                                      is "In", and the values array
-                                                      contains only "value". The requirements
-                                                      are ANDed.
+                                                  podAffinityTerm:
+                                                    description: Required. A pod affinity
+                                                      term, associated with the corresponding
+                                                      weight.
                                                     type: object
-                                                    additionalProperties:
-                                                      type: string
-                                              namespaces:
-                                                description: namespaces specifies
-                                                  which namespaces the labelSelector
-                                                  applies to (matches against); null
-                                                  or empty list means "this pod's
-                                                  namespace"
-                                                type: array
-                                                items:
-                                                  type: string
-                                              topologyKey:
-                                                description: This pod should be co-located
-                                                  (affinity) or not co-located (anti-affinity)
-                                                  with the pods matching the labelSelector
-                                                  in the specified namespaces, where
-                                                  co-located is defined as running
-                                                  on a node whose value of the label
-                                                  with key topologyKey matches that
-                                                  of any node on which any of the
-                                                  selected pods is running. Empty
-                                                  topologyKey is not allowed.
-                                                type: string
-                                    podAntiAffinity:
-                                      description: Describes pod anti-affinity scheduling
-                                        rules (e.g. avoid putting this pod in the
-                                        same node, zone, etc. as some other pod(s)).
-                                      type: object
-                                      properties:
-                                        preferredDuringSchedulingIgnoredDuringExecution:
-                                          description: The scheduler will prefer to
-                                            schedule pods to nodes that satisfy the
-                                            anti-affinity expressions specified by
-                                            this field, but it may choose a node that
-                                            violates one or more of the expressions.
-                                            The node that is most preferred is the
-                                            one with the greatest sum of weights,
-                                            i.e. for each node that meets all of the
-                                            scheduling requirements (resource request,
-                                            requiredDuringScheduling anti-affinity
-                                            expressions, etc.), compute a sum by iterating
-                                            through the elements of this field and
-                                            adding "weight" to the sum if the node
-                                            has pods which matches the corresponding
-                                            podAffinityTerm; the node(s) with the
-                                            highest sum are the most preferred.
-                                          type: array
-                                          items:
-                                            description: The weights of all of the
-                                              matched WeightedPodAffinityTerm fields
-                                              are added per-node to find the most
-                                              preferred node(s)
-                                            type: object
-                                            required:
-                                              - podAffinityTerm
-                                              - weight
-                                            properties:
-                                              podAffinityTerm:
-                                                description: Required. A pod affinity
-                                                  term, associated with the corresponding
-                                                  weight.
+                                                    required:
+                                                      - topologyKey
+                                                    properties:
+                                                      labelSelector:
+                                                        description: A label query over
+                                                          a set of resources, in this
+                                                          case pods.
+                                                        type: object
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: matchExpressions
+                                                              is a list of label selector
+                                                              requirements. The requirements
+                                                              are ANDed.
+                                                            type: array
+                                                            items:
+                                                              description: A label selector
+                                                                requirement is a selector
+                                                                that contains values,
+                                                                a key, and an operator
+                                                                that relates the key and
+                                                                values.
+                                                              type: object
+                                                              required:
+                                                                - key
+                                                                - operator
+                                                              properties:
+                                                                key:
+                                                                  description: key is
+                                                                    the label key that
+                                                                    the selector applies
+                                                                    to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: operator
+                                                                    represents a key's
+                                                                    relationship to a
+                                                                    set of values. Valid
+                                                                    operators are In,
+                                                                    NotIn, Exists and
+                                                                    DoesNotExist.
+                                                                  type: string
+                                                                values:
+                                                                  description: values
+                                                                    is an array of string
+                                                                    values. If the operator
+                                                                    is In or NotIn, the
+                                                                    values array must
+                                                                    be non-empty. If the
+                                                                    operator is Exists
+                                                                    or DoesNotExist, the
+                                                                    values array must
+                                                                    be empty. This array
+                                                                    is replaced during
+                                                                    a strategic merge
+                                                                    patch.
+                                                                  type: array
+                                                                  items:
+                                                                    type: string
+                                                          matchLabels:
+                                                            description: matchLabels is
+                                                              a map of {key,value} pairs.
+                                                              A single {key,value} in
+                                                              the matchLabels map is equivalent
+                                                              to an element of matchExpressions,
+                                                              whose key field is "key",
+                                                              the operator is "In", and
+                                                              the values array contains
+                                                              only "value". The requirements
+                                                              are ANDed.
+                                                            type: object
+                                                            additionalProperties:
+                                                              type: string
+                                                      namespaces:
+                                                        description: namespaces specifies
+                                                          which namespaces the labelSelector
+                                                          applies to (matches against);
+                                                          null or empty list means "this
+                                                          pod's namespace"
+                                                        type: array
+                                                        items:
+                                                          type: string
+                                                      topologyKey:
+                                                        description: This pod should be
+                                                          co-located (affinity) or not
+                                                          co-located (anti-affinity) with
+                                                          the pods matching the labelSelector
+                                                          in the specified namespaces,
+                                                          where co-located is defined
+                                                          as running on a node whose value
+                                                          of the label with key topologyKey
+                                                          matches that of any node on
+                                                          which any of the selected pods
+                                                          is running. Empty topologyKey
+                                                          is not allowed.
+                                                        type: string
+                                                  weight:
+                                                    description: weight associated with
+                                                      matching the corresponding podAffinityTerm,
+                                                      in the range 1-100.
+                                                    type: integer
+                                                    format: int32
+                                            requiredDuringSchedulingIgnoredDuringExecution:
+                                              description: If the anti-affinity requirements
+                                                specified by this field are not met at
+                                                scheduling time, the pod will not be scheduled
+                                                onto the node. If the anti-affinity requirements
+                                                specified by this field cease to be met
+                                                at some point during pod execution (e.g.
+                                                due to a pod label update), the system
+                                                may or may not try to eventually evict
+                                                the pod from its node. When there are
+                                                multiple elements, the lists of nodes
+                                                corresponding to each podAffinityTerm
+                                                are intersected, i.e. all terms must be
+                                                satisfied.
+                                              type: array
+                                              items:
+                                                description: Defines a set of pods (namely
+                                                  those matching the labelSelector relative
+                                                  to the given namespace(s)) that this
+                                                  pod should be co-located (affinity)
+                                                  or not co-located (anti-affinity) with,
+                                                  where co-located is defined as running
+                                                  on a node whose value of the label with
+                                                  key <topologyKey> matches that of any
+                                                  node on which a pod of the set of pods
+                                                  is running
                                                 type: object
                                                 required:
                                                   - topologyKey
                                                 properties:
                                                   labelSelector:
-                                                    description: A label query over
-                                                      a set of resources, in this
-                                                      case pods.
+                                                    description: A label query over a
+                                                      set of resources, in this case pods.
                                                     type: object
                                                     properties:
                                                       matchExpressions:
@@ -1112,57 +1215,49 @@ spec:
                                                         items:
                                                           description: A label selector
                                                             requirement is a selector
-                                                            that contains values,
-                                                            a key, and an operator
-                                                            that relates the key and
-                                                            values.
+                                                            that contains values, a key,
+                                                            and an operator that relates
+                                                            the key and values.
                                                           type: object
                                                           required:
                                                             - key
                                                             - operator
                                                           properties:
                                                             key:
-                                                              description: key is
-                                                                the label key that
-                                                                the selector applies
-                                                                to.
+                                                              description: key is the
+                                                                label key that the selector
+                                                                applies to.
                                                               type: string
                                                             operator:
-                                                              description: operator
-                                                                represents a key's
-                                                                relationship to a
-                                                                set of values. Valid
-                                                                operators are In,
-                                                                NotIn, Exists and
-                                                                DoesNotExist.
+                                                              description: operator represents
+                                                                a key's relationship to
+                                                                a set of values. Valid
+                                                                operators are In, NotIn,
+                                                                Exists and DoesNotExist.
                                                               type: string
                                                             values:
-                                                              description: values
-                                                                is an array of string
-                                                                values. If the operator
-                                                                is In or NotIn, the
-                                                                values array must
-                                                                be non-empty. If the
-                                                                operator is Exists
-                                                                or DoesNotExist, the
-                                                                values array must
-                                                                be empty. This array
-                                                                is replaced during
-                                                                a strategic merge
-                                                                patch.
+                                                              description: values is an
+                                                                array of string values.
+                                                                If the operator is In
+                                                                or NotIn, the values array
+                                                                must be non-empty. If
+                                                                the operator is Exists
+                                                                or DoesNotExist, the values
+                                                                array must be empty. This
+                                                                array is replaced during
+                                                                a strategic merge patch.
                                                               type: array
                                                               items:
                                                                 type: string
                                                       matchLabels:
-                                                        description: matchLabels is
-                                                          a map of {key,value} pairs.
-                                                          A single {key,value} in
-                                                          the matchLabels map is equivalent
-                                                          to an element of matchExpressions,
-                                                          whose key field is "key",
-                                                          the operator is "In", and
-                                                          the values array contains
-                                                          only "value". The requirements
+                                                        description: matchLabels is a
+                                                          map of {key,value} pairs. A
+                                                          single {key,value} in the matchLabels
+                                                          map is equivalent to an element
+                                                          of matchExpressions, whose key
+                                                          field is "key", the operator
+                                                          is "In", and the values array
+                                                          contains only "value". The requirements
                                                           are ANDed.
                                                         type: object
                                                         additionalProperties:
@@ -1170,287 +1265,1606 @@ spec:
                                                   namespaces:
                                                     description: namespaces specifies
                                                       which namespaces the labelSelector
-                                                      applies to (matches against);
-                                                      null or empty list means "this
-                                                      pod's namespace"
+                                                      applies to (matches against); null
+                                                      or empty list means "this pod's
+                                                      namespace"
                                                     type: array
                                                     items:
                                                       type: string
                                                   topologyKey:
-                                                    description: This pod should be
-                                                      co-located (affinity) or not
-                                                      co-located (anti-affinity) with
-                                                      the pods matching the labelSelector
-                                                      in the specified namespaces,
-                                                      where co-located is defined
-                                                      as running on a node whose value
-                                                      of the label with key topologyKey
-                                                      matches that of any node on
-                                                      which any of the selected pods
-                                                      is running. Empty topologyKey
-                                                      is not allowed.
+                                                    description: This pod should be co-located
+                                                      (affinity) or not co-located (anti-affinity)
+                                                      with the pods matching the labelSelector
+                                                      in the specified namespaces, where
+                                                      co-located is defined as running
+                                                      on a node whose value of the label
+                                                      with key topologyKey matches that
+                                                      of any node on which any of the
+                                                      selected pods is running. Empty
+                                                      topologyKey is not allowed.
                                                     type: string
-                                              weight:
-                                                description: weight associated with
-                                                  matching the corresponding podAffinityTerm,
-                                                  in the range 1-100.
-                                                type: integer
-                                                format: int32
-                                        requiredDuringSchedulingIgnoredDuringExecution:
-                                          description: If the anti-affinity requirements
-                                            specified by this field are not met at
-                                            scheduling time, the pod will not be scheduled
-                                            onto the node. If the anti-affinity requirements
-                                            specified by this field cease to be met
-                                            at some point during pod execution (e.g.
-                                            due to a pod label update), the system
-                                            may or may not try to eventually evict
-                                            the pod from its node. When there are
-                                            multiple elements, the lists of nodes
-                                            corresponding to each podAffinityTerm
-                                            are intersected, i.e. all terms must be
-                                            satisfied.
-                                          type: array
-                                          items:
-                                            description: Defines a set of pods (namely
-                                              those matching the labelSelector relative
-                                              to the given namespace(s)) that this
-                                              pod should be co-located (affinity)
-                                              or not co-located (anti-affinity) with,
-                                              where co-located is defined as running
-                                              on a node whose value of the label with
-                                              key <topologyKey> matches that of any
-                                              node on which a pod of the set of pods
-                                              is running
-                                            type: object
-                                            required:
-                                              - topologyKey
-                                            properties:
-                                              labelSelector:
-                                                description: A label query over a
-                                                  set of resources, in this case pods.
-                                                type: object
-                                                properties:
-                                                  matchExpressions:
-                                                    description: matchExpressions
-                                                      is a list of label selector
-                                                      requirements. The requirements
-                                                      are ANDed.
-                                                    type: array
-                                                    items:
-                                                      description: A label selector
-                                                        requirement is a selector
-                                                        that contains values, a key,
-                                                        and an operator that relates
-                                                        the key and values.
-                                                      type: object
-                                                      required:
-                                                        - key
-                                                        - operator
-                                                      properties:
-                                                        key:
-                                                          description: key is the
-                                                            label key that the selector
-                                                            applies to.
-                                                          type: string
-                                                        operator:
-                                                          description: operator represents
-                                                            a key's relationship to
-                                                            a set of values. Valid
-                                                            operators are In, NotIn,
-                                                            Exists and DoesNotExist.
-                                                          type: string
-                                                        values:
-                                                          description: values is an
-                                                            array of string values.
-                                                            If the operator is In
-                                                            or NotIn, the values array
-                                                            must be non-empty. If
-                                                            the operator is Exists
-                                                            or DoesNotExist, the values
-                                                            array must be empty. This
-                                                            array is replaced during
-                                                            a strategic merge patch.
-                                                          type: array
-                                                          items:
-                                                            type: string
-                                                  matchLabels:
-                                                    description: matchLabels is a
-                                                      map of {key,value} pairs. A
-                                                      single {key,value} in the matchLabels
-                                                      map is equivalent to an element
-                                                      of matchExpressions, whose key
-                                                      field is "key", the operator
-                                                      is "In", and the values array
-                                                      contains only "value". The requirements
-                                                      are ANDed.
-                                                    type: object
-                                                    additionalProperties:
-                                                      type: string
-                                              namespaces:
-                                                description: namespaces specifies
-                                                  which namespaces the labelSelector
-                                                  applies to (matches against); null
-                                                  or empty list means "this pod's
-                                                  namespace"
-                                                type: array
-                                                items:
-                                                  type: string
-                                              topologyKey:
-                                                description: This pod should be co-located
-                                                  (affinity) or not co-located (anti-affinity)
-                                                  with the pods matching the labelSelector
-                                                  in the specified namespaces, where
-                                                  co-located is defined as running
-                                                  on a node whose value of the label
-                                                  with key topologyKey matches that
-                                                  of any node on which any of the
-                                                  selected pods is running. Empty
-                                                  topologyKey is not allowed.
-                                                type: string
-                                nodeSelector:
-                                  description: 'NodeSelector is a selector which must
-                                    be true for the pod to fit on a node. Selector
-                                    which must match a node''s labels for the pod
-                                    to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
-                                  type: object
-                                  additionalProperties:
-                                    type: string
-                                tolerations:
-                                  description: If specified, the pod's tolerations.
-                                  type: array
-                                  items:
-                                    description: The pod this Toleration is attached
-                                      to tolerates any taint that matches the triple
-                                      <key,value,effect> using the matching operator
-                                      <operator>.
-                                    type: object
-                                    properties:
-                                      effect:
-                                        description: Effect indicates the taint effect
-                                          to match. Empty means match all taint effects.
-                                          When specified, allowed values are NoSchedule,
-                                          PreferNoSchedule and NoExecute.
+                                    nodeSelector:
+                                      description: 'NodeSelector is a selector which must
+                                            be true for the pod to fit on a node. Selector
+                                            which must match a node''s labels for the pod
+                                            to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                                      type: object
+                                      additionalProperties:
                                         type: string
-                                      key:
-                                        description: Key is the taint key that the
-                                          toleration applies to. Empty means match
-                                          all taint keys. If the key is empty, operator
-                                          must be Exists; this combination means to
-                                          match all values and all keys.
-                                        type: string
-                                      operator:
-                                        description: Operator represents a key's relationship
-                                          to the value. Valid operators are Exists
-                                          and Equal. Defaults to Equal. Exists is
-                                          equivalent to wildcard for value, so that
-                                          a pod can tolerate all taints of a particular
-                                          category.
-                                        type: string
-                                      tolerationSeconds:
-                                        description: TolerationSeconds represents
-                                          the period of time the toleration (which
-                                          must be of effect NoExecute, otherwise this
-                                          field is ignored) tolerates the taint. By
-                                          default, it is not set, which means tolerate
-                                          the taint forever (do not evict). Zero and
-                                          negative values will be treated as 0 (evict
-                                          immediately) by the system.
-                                        type: integer
-                                        format: int64
-                                      value:
-                                        description: Value is the taint value the
-                                          toleration matches to. If the operator is
-                                          Exists, the value should be empty, otherwise
-                                          just a regular string.
-                                        type: string
-                        serviceType:
-                          description: Optional service type for Kubernetes solver
-                            service
-                          type: string
-                selector:
-                  description: Selector selects a set of DNSNames on the Certificate
-                    resource that should be solved using this challenge solver.
+                                    tolerations:
+                                      description: If specified, the pod's tolerations.
+                                      type: array
+                                      items:
+                                        description: The pod this Toleration is attached
+                                          to tolerates any taint that matches the triple
+                                          <key,value,effect> using the matching operator
+                                          <operator>.
+                                        type: object
+                                        properties:
+                                          effect:
+                                            description: Effect indicates the taint effect
+                                              to match. Empty means match all taint effects.
+                                              When specified, allowed values are NoSchedule,
+                                              PreferNoSchedule and NoExecute.
+                                            type: string
+                                          key:
+                                            description: Key is the taint key that the
+                                              toleration applies to. Empty means match
+                                              all taint keys. If the key is empty, operator
+                                              must be Exists; this combination means to
+                                              match all values and all keys.
+                                            type: string
+                                          operator:
+                                            description: Operator represents a key's relationship
+                                              to the value. Valid operators are Exists
+                                              and Equal. Defaults to Equal. Exists is
+                                              equivalent to wildcard for value, so that
+                                              a pod can tolerate all taints of a particular
+                                              category.
+                                            type: string
+                                          tolerationSeconds:
+                                            description: TolerationSeconds represents
+                                              the period of time the toleration (which
+                                              must be of effect NoExecute, otherwise this
+                                              field is ignored) tolerates the taint. By
+                                              default, it is not set, which means tolerate
+                                              the taint forever (do not evict). Zero and
+                                              negative values will be treated as 0 (evict
+                                              immediately) by the system.
+                                            type: integer
+                                            format: int64
+                                          value:
+                                            description: Value is the taint value the
+                                              toleration matches to. If the operator is
+                                              Exists, the value should be empty, otherwise
+                                              just a regular string.
+                                            type: string
+                            serviceType:
+                              description: Optional service type for Kubernetes solver
+                                service
+                              type: string
+                    selector:
+                      description: Selector selects a set of DNSNames on the Certificate
+                        resource that should be solved using this challenge solver.
+                      type: object
+                      properties:
+                        dnsNames:
+                          description: List of DNSNames that this solver will be used
+                            to solve. If specified and a match is found, a dnsNames selector
+                            will take precedence over a dnsZones selector. If multiple
+                            solvers match with the same dnsNames value, the solver with
+                            the most matching labels in matchLabels will be selected.
+                            If neither has more matches, the solver defined earlier in
+                            the list will be selected.
+                          type: array
+                          items:
+                            type: string
+                        dnsZones:
+                          description: List of DNSZones that this solver will be used
+                            to solve. The most specific DNS zone match specified here
+                            will take precedence over other DNS zone matches, so a solver
+                            specifying sys.example.com will be selected over one specifying
+                            example.com for the domain www.sys.example.com. If multiple
+                            solvers match with the same dnsZones value, the solver with
+                            the most matching labels in matchLabels will be selected.
+                            If neither has more matches, the solver defined earlier in
+                            the list will be selected.
+                          type: array
+                          items:
+                            type: string
+                        matchLabels:
+                          description: A label selector that is used to refine the set
+                            of certificate's that this challenge solver will apply to.
+                          type: object
+                          additionalProperties:
+                            type: string
+                token:
+                  description: Token is the ACME challenge token for this challenge. This
+                    is the raw value returned from the ACME server.
+                  type: string
+                type:
+                  description: Type is the type of ACME challenge this resource represents,
+                    e.g. "dns01" or "http01".
+                  type: string
+                url:
+                  description: URL is the URL of the ACME Challenge resource for this
+                    challenge. This can be used to lookup details about the status of
+                    this challenge.
+                  type: string
+                wildcard:
+                  description: Wildcard will be true if this challenge is for a wildcard
+                    identifier, for example '*.example.com'.
+                  type: boolean
+            status:
+              type: object
+              properties:
+                presented:
+                  description: Presented will be set to true if the challenge values for
+                    this challenge are currently 'presented'. This *does not* imply the
+                    self check is passing. Only that the values have been 'submitted'
+                    for the appropriate challenge mechanism (i.e. the DNS01 TXT record
+                    has been presented, or the HTTP01 configuration has been configured).
+                  type: boolean
+                processing:
+                  description: Processing is used to denote whether this challenge should
+                    be processed or not. This field will only be set to true by the 'scheduling'
+                    component. It will only be set to false by the 'challenges' controller,
+                    after the challenge has reached a final state or timed out. If this
+                    field is set to false, the challenge controller will not take any
+                    more action.
+                  type: boolean
+                reason:
+                  description: Reason contains human readable information on why the Challenge
+                    is in the current state.
+                  type: string
+                state:
+                  description: State contains the current 'state' of the challenge. If
+                    not set, the state of the challenge is unknown.
+                  type: string
+                  enum:
+                    - valid
+                    - ready
+                    - pending
+                    - processing
+                    - invalid
+                    - expired
+                    - errored
+      served: true
+      storage: true
+      additionalPrinterColumns:
+        - jsonPath: .status.state
+          name: State
+          type: string
+        - jsonPath: .spec.dnsName
+          name: Domain
+          type: string
+        - jsonPath: .status.reason
+          name: Reason
+          priority: 1
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          description: CreationTimestamp is a timestamp representing the server time when
+            this object was created. It is not guaranteed to be set in happens-before order
+            across separate operations. Clients may not set this value. It is represented
+            in RFC3339 form and is in UTC.
+          name: Age
+          type: date
+      subresources:
+        status: { }
+    - name: v1alpha3
+      schema:
+        openAPIV3Schema:
+          description: Challenge is a type to represent a Challenge request with an ACME
+            server
+          type: object
+          required:
+            - metadata
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+                    of an object. Servers should convert recognized schemas to the latest
+                    internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+                    object represents. Servers may infer this from the endpoint the client
+                    submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              required:
+                - authzURL
+                - dnsName
+                - issuerRef
+                - key
+                - solver
+                - token
+                - type
+                - url
+              properties:
+                authzURL:
+                  description: AuthzURL is the URL to the ACME Authorization resource
+                    that this challenge is a part of.
+                  type: string
+                dnsName:
+                  description: DNSName is the identifier that this challenge is for, e.g.
+                    example.com. If the requested DNSName is a 'wildcard', this field
+                    MUST be set to the non-wildcard domain, e.g. for `*.example.com`,
+                    it must be `example.com`.
+                  type: string
+                issuerRef:
+                  description: IssuerRef references a properly configured ACME-type Issuer
+                    which should be used to create this Challenge. If the Issuer does
+                    not exist, processing will be retried. If the Issuer is not an 'ACME'
+                    Issuer, an error will be returned and the Challenge will be marked
+                    as failed.
+                  type: object
+                  required:
+                    - name
+                  properties:
+                    group:
+                      type: string
+                    kind:
+                      type: string
+                    name:
+                      type: string
+                key:
+                  description: 'Key is the ACME challenge key for this challenge For HTTP01
+                        challenges, this is the value that must be responded with to complete
+                        the HTTP01 challenge in the format: `<private key JWK thumbprint>.<key
+                        from acme server for challenge>`. For DNS01 challenges, this is the
+                        base64 encoded SHA256 sum of the `<private key JWK thumbprint>.<key
+                        from acme server for challenge>` text that must be set as the TXT
+                        record content.'
+                  type: string
+                solver:
+                  description: Solver contains the domain solving configuration that should
+                    be used to solve this challenge resource.
                   type: object
                   properties:
-                    dnsNames:
-                      description: List of DNSNames that this solver will be used
-                        to solve. If specified and a match is found, a dnsNames selector
-                        will take precedence over a dnsZones selector. If multiple
-                        solvers match with the same dnsNames value, the solver with
-                        the most matching labels in matchLabels will be selected.
-                        If neither has more matches, the solver defined earlier in
-                        the list will be selected.
-                      type: array
-                      items:
-                        type: string
-                    dnsZones:
-                      description: List of DNSZones that this solver will be used
-                        to solve. The most specific DNS zone match specified here
-                        will take precedence over other DNS zone matches, so a solver
-                        specifying sys.example.com will be selected over one specifying
-                        example.com for the domain www.sys.example.com. If multiple
-                        solvers match with the same dnsZones value, the solver with
-                        the most matching labels in matchLabels will be selected.
-                        If neither has more matches, the solver defined earlier in
-                        the list will be selected.
-                      type: array
-                      items:
-                        type: string
-                    matchLabels:
-                      description: A label selector that is used to refine the set
-                        of certificate's that this challenge solver will apply to.
+                    dns01:
                       type: object
-                      additionalProperties:
-                        type: string
-            token:
-              description: Token is the ACME challenge token for this challenge. This
-                is the raw value returned from the ACME server.
-              type: string
-            type:
-              description: Type is the type of ACME challenge this resource represents,
-                e.g. "dns01" or "http01".
-              type: string
-            url:
-              description: URL is the URL of the ACME Challenge resource for this
-                challenge. This can be used to lookup details about the status of
-                this challenge.
-              type: string
-            wildcard:
-              description: Wildcard will be true if this challenge is for a wildcard
-                identifier, for example '*.example.com'.
-              type: boolean
-        status:
-          type: object
-          properties:
-            presented:
-              description: Presented will be set to true if the challenge values for
-                this challenge are currently 'presented'. This *does not* imply the
-                self check is passing. Only that the values have been 'submitted'
-                for the appropriate challenge mechanism (i.e. the DNS01 TXT record
-                has been presented, or the HTTP01 configuration has been configured).
-              type: boolean
-            processing:
-              description: Processing is used to denote whether this challenge should
-                be processed or not. This field will only be set to true by the 'scheduling'
-                component. It will only be set to false by the 'challenges' controller,
-                after the challenge has reached a final state or timed out. If this
-                field is set to false, the challenge controller will not take any
-                more action.
-              type: boolean
-            reason:
-              description: Reason contains human readable information on why the Challenge
-                is in the current state.
-              type: string
-            state:
-              description: State contains the current 'state' of the challenge. If
-                not set, the state of the challenge is unknown.
-              type: string
-              enum:
-                - valid
-                - ready
-                - pending
-                - processing
-                - invalid
-                - expired
-                - errored
+                      properties:
+                        acmedns:
+                          description: ACMEIssuerDNS01ProviderAcmeDNS is a structure containing
+                            the configuration for ACME-DNS servers
+                          type: object
+                          required:
+                            - accountSecretRef
+                            - host
+                          properties:
+                            accountSecretRef:
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the secret to select from. Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                                  type: string
+                            host:
+                              type: string
+                        akamai:
+                          description: ACMEIssuerDNS01ProviderAkamai is a structure containing
+                            the DNS configuration for Akamai DNS—Zone Record Management
+                            API
+                          type: object
+                          required:
+                            - accessTokenSecretRef
+                            - clientSecretSecretRef
+                            - clientTokenSecretRef
+                            - serviceConsumerDomain
+                          properties:
+                            accessTokenSecretRef:
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the secret to select from. Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                                  type: string
+                            clientSecretSecretRef:
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the secret to select from. Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                                  type: string
+                            clientTokenSecretRef:
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the secret to select from. Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                                  type: string
+                            serviceConsumerDomain:
+                              type: string
+                        azuredns:
+                          description: ACMEIssuerDNS01ProviderAzureDNS is a structure
+                            containing the configuration for Azure DNS
+                          type: object
+                          required:
+                            - resourceGroupName
+                            - subscriptionID
+                          properties:
+                            clientID:
+                              description: if both this and ClientSecret are left unset
+                                MSI will be used
+                              type: string
+                            clientSecretSecretRef:
+                              description: if both this and ClientID are left unset MSI
+                                will be used
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the secret to select from. Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                                  type: string
+                            environment:
+                              type: string
+                              enum:
+                                - AzurePublicCloud
+                                - AzureChinaCloud
+                                - AzureGermanCloud
+                                - AzureUSGovernmentCloud
+                            hostedZoneName:
+                              type: string
+                            resourceGroupName:
+                              type: string
+                            subscriptionID:
+                              type: string
+                            tenantID:
+                              description: when specifying ClientID and ClientSecret then
+                                this field is also needed
+                              type: string
+                        clouddns:
+                          description: ACMEIssuerDNS01ProviderCloudDNS is a structure
+                            containing the DNS configuration for Google Cloud DNS
+                          type: object
+                          required:
+                            - project
+                          properties:
+                            project:
+                              type: string
+                            serviceAccountSecretRef:
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the secret to select from. Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                                  type: string
+                        cloudflare:
+                          description: ACMEIssuerDNS01ProviderCloudflare is a structure
+                            containing the DNS configuration for Cloudflare
+                          type: object
+                          required:
+                            - email
+                          properties:
+                            apiKeySecretRef:
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the secret to select from. Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                                  type: string
+                            apiTokenSecretRef:
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the secret to select from. Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                                  type: string
+                            email:
+                              type: string
+                        cnameStrategy:
+                          description: CNAMEStrategy configures how the DNS01 provider
+                            should handle CNAME records when found in DNS zones.
+                          type: string
+                          enum:
+                            - None
+                            - Follow
+                        digitalocean:
+                          description: ACMEIssuerDNS01ProviderDigitalOcean is a structure
+                            containing the DNS configuration for DigitalOcean Domains
+                          type: object
+                          required:
+                            - tokenSecretRef
+                          properties:
+                            tokenSecretRef:
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the secret to select from. Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                                  type: string
+                        rfc2136:
+                          description: ACMEIssuerDNS01ProviderRFC2136 is a structure containing
+                            the configuration for RFC2136 DNS
+                          type: object
+                          required:
+                            - nameserver
+                          properties:
+                            nameserver:
+                              description: The IP address or hostname of an authoritative
+                                DNS server supporting RFC2136 in the form host:port. If
+                                the host is an IPv6 address it must be enclosed in square
+                                brackets (e.g [2001:db8::1]) ; port is optional. This
+                                field is required.
+                              type: string
+                            tsigAlgorithm:
+                              description: 'The TSIG Algorithm configured in the DNS supporting
+                                    RFC2136. Used only when ``tsigSecretSecretRef`` and ``tsigKeyName``
+                                    are defined. Supported values are (case-insensitive):
+                                    ``HMACMD5`` (default), ``HMACSHA1``, ``HMACSHA256`` or
+                                    ``HMACSHA512``.'
+                              type: string
+                            tsigKeyName:
+                              description: The TSIG Key name configured in the DNS. If
+                                ``tsigSecretSecretRef`` is defined, this field is required.
+                              type: string
+                            tsigSecretSecretRef:
+                              description: The name of the secret containing the TSIG
+                                value. If ``tsigKeyName`` is defined, this field is required.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the secret to select from. Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                                  type: string
+                        route53:
+                          description: ACMEIssuerDNS01ProviderRoute53 is a structure containing
+                            the Route 53 configuration for AWS
+                          type: object
+                          required:
+                            - region
+                          properties:
+                            accessKeyID:
+                              description: 'The AccessKeyID is used for authentication.
+                                    If not set we fall-back to using env vars, shared credentials
+                                    file or AWS Instance metadata see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
+                              type: string
+                            hostedZoneID:
+                              description: If set, the provider will manage only this
+                                zone in Route53 and will not do an lookup using the route53:ListHostedZonesByName
+                                api call.
+                              type: string
+                            region:
+                              description: Always set the region when using AccessKeyID
+                                and SecretAccessKey
+                              type: string
+                            role:
+                              description: Role is a Role ARN which the Route53 provider
+                                will assume using either the explicit credentials AccessKeyID/SecretAccessKey
+                                or the inferred credentials from environment variables,
+                                shared credentials file or AWS Instance metadata
+                              type: string
+                            secretAccessKeySecretRef:
+                              description: The SecretAccessKey is used for authentication.
+                                If not set we fall-back to using env vars, shared credentials
+                                file or AWS Instance metadata https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the secret to select from. Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                                  type: string
+                        webhook:
+                          description: ACMEIssuerDNS01ProviderWebhook specifies configuration
+                            for a webhook DNS01 provider, including where to POST ChallengePayload
+                            resources.
+                          type: object
+                          required:
+                            - groupName
+                            - solverName
+                          properties:
+                            config:
+                              description: Additional configuration that should be passed
+                                to the webhook apiserver when challenges are processed.
+                                This can contain arbitrary JSON data. Secret values should
+                                not be specified in this stanza. If secret values are
+                                needed (e.g. credentials for a DNS service), you should
+                                use a SecretKeySelector to reference a Secret resource.
+                                For details on the schema of this field, consult the webhook
+                                provider implementation's documentation.
+                              x-kubernetes-preserve-unknown-fields: true
+                            groupName:
+                              description: The API group name that should be used when
+                                POSTing ChallengePayload resources to the webhook apiserver.
+                                This should be the same as the GroupName specified in
+                                the webhook provider implementation.
+                              type: string
+                            solverName:
+                              description: The name of the solver to use, as defined in
+                                the webhook provider implementation. This will typically
+                                be the name of the provider, e.g. 'cloudflare'.
+                              type: string
+                    http01:
+                      description: ACMEChallengeSolverHTTP01 contains configuration detailing
+                        how to solve HTTP01 challenges within a Kubernetes cluster. Typically
+                        this is accomplished through creating 'routes' of some description
+                        that configure ingress controllers to direct traffic to 'solver
+                        pods', which are responsible for responding to the ACME server's
+                        HTTP requests.
+                      type: object
+                      properties:
+                        ingress:
+                          description: The ingress based HTTP01 challenge solver will
+                            solve challenges by creating or modifying Ingress resources
+                            in order to route requests for '/.well-known/acme-challenge/XYZ'
+                            to 'challenge solver' pods that are provisioned by cert-manager
+                            for each Challenge to be completed.
+                          type: object
+                          properties:
+                            class:
+                              description: The ingress class to use when creating Ingress
+                                resources to solve ACME challenges that use this challenge
+                                solver. Only one of 'class' or 'name' may be specified.
+                              type: string
+                            ingressTemplate:
+                              description: Optional ingress template used to configure
+                                the ACME challenge solver ingress used for HTTP01 challenges
+                              type: object
+                              properties:
+                                metadata:
+                                  description: ObjectMeta overrides for the ingress used
+                                    to solve HTTP01 challenges. Only the 'labels' and
+                                    'annotations' fields may be set. If labels or annotations
+                                    overlap with in-built values, the values here will
+                                    override the in-built values.
+                                  type: object
+                                  properties:
+                                    annotations:
+                                      description: Annotations that should be added to
+                                        the created ACME HTTP01 solver ingress.
+                                      type: object
+                                      additionalProperties:
+                                        type: string
+                                    labels:
+                                      description: Labels that should be added to the
+                                        created ACME HTTP01 solver ingress.
+                                      type: object
+                                      additionalProperties:
+                                        type: string
+                            name:
+                              description: The name of the ingress resource that should
+                                have ACME challenge solving routes inserted into it in
+                                order to solve HTTP01 challenges. This is typically used
+                                in conjunction with ingress controllers like ingress-gce,
+                                which maintains a 1:1 mapping between external IPs and
+                                ingress resources.
+                              type: string
+                            podTemplate:
+                              description: Optional pod template used to configure the
+                                ACME challenge solver pods used for HTTP01 challenges
+                              type: object
+                              properties:
+                                metadata:
+                                  description: ObjectMeta overrides for the pod used to
+                                    solve HTTP01 challenges. Only the 'labels' and 'annotations'
+                                    fields may be set. If labels or annotations overlap
+                                    with in-built values, the values here will override
+                                    the in-built values.
+                                  type: object
+                                  properties:
+                                    annotations:
+                                      description: Annotations that should be added to
+                                        the create ACME HTTP01 solver pods.
+                                      type: object
+                                      additionalProperties:
+                                        type: string
+                                    labels:
+                                      description: Labels that should be added to the
+                                        created ACME HTTP01 solver pods.
+                                      type: object
+                                      additionalProperties:
+                                        type: string
+                                spec:
+                                  description: PodSpec defines overrides for the HTTP01
+                                    challenge solver pod. Only the 'nodeSelector', 'affinity'
+                                    and 'tolerations' fields are supported currently.
+                                    All other fields will be ignored.
+                                  type: object
+                                  properties:
+                                    affinity:
+                                      description: If specified, the pod's scheduling
+                                        constraints
+                                      type: object
+                                      properties:
+                                        nodeAffinity:
+                                          description: Describes node affinity scheduling
+                                            rules for the pod.
+                                          type: object
+                                          properties:
+                                            preferredDuringSchedulingIgnoredDuringExecution:
+                                              description: The scheduler will prefer to
+                                                schedule pods to nodes that satisfy the
+                                                affinity expressions specified by this
+                                                field, but it may choose a node that violates
+                                                one or more of the expressions. The node
+                                                that is most preferred is the one with
+                                                the greatest sum of weights, i.e. for
+                                                each node that meets all of the scheduling
+                                                requirements (resource request, requiredDuringScheduling
+                                                affinity expressions, etc.), compute a
+                                                sum by iterating through the elements
+                                                of this field and adding "weight" to the
+                                                sum if the node matches the corresponding
+                                                matchExpressions; the node(s) with the
+                                                highest sum are the most preferred.
+                                              type: array
+                                              items:
+                                                description: An empty preferred scheduling
+                                                  term matches all objects with implicit
+                                                  weight 0 (i.e. it's a no-op). A null
+                                                  preferred scheduling term matches no
+                                                  objects (i.e. is also a no-op).
+                                                type: object
+                                                required:
+                                                  - preference
+                                                  - weight
+                                                properties:
+                                                  preference:
+                                                    description: A node selector term,
+                                                      associated with the corresponding
+                                                      weight.
+                                                    type: object
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: A list of node selector
+                                                          requirements by node's labels.
+                                                        type: array
+                                                        items:
+                                                          description: A node selector
+                                                            requirement is a selector
+                                                            that contains values, a key,
+                                                            and an operator that relates
+                                                            the key and values.
+                                                          type: object
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          properties:
+                                                            key:
+                                                              description: The label key
+                                                                that the selector applies
+                                                                to.
+                                                              type: string
+                                                            operator:
+                                                              description: Represents
+                                                                a key's relationship to
+                                                                a set of values. Valid
+                                                                operators are In, NotIn,
+                                                                Exists, DoesNotExist.
+                                                                Gt, and Lt.
+                                                              type: string
+                                                            values:
+                                                              description: An array of
+                                                                string values. If the
+                                                                operator is In or NotIn,
+                                                                the values array must
+                                                                be non-empty. If the operator
+                                                                is Exists or DoesNotExist,
+                                                                the values array must
+                                                                be empty. If the operator
+                                                                is Gt or Lt, the values
+                                                                array must have a single
+                                                                element, which will be
+                                                                interpreted as an integer.
+                                                                This array is replaced
+                                                                during a strategic merge
+                                                                patch.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                      matchFields:
+                                                        description: A list of node selector
+                                                          requirements by node's fields.
+                                                        type: array
+                                                        items:
+                                                          description: A node selector
+                                                            requirement is a selector
+                                                            that contains values, a key,
+                                                            and an operator that relates
+                                                            the key and values.
+                                                          type: object
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          properties:
+                                                            key:
+                                                              description: The label key
+                                                                that the selector applies
+                                                                to.
+                                                              type: string
+                                                            operator:
+                                                              description: Represents
+                                                                a key's relationship to
+                                                                a set of values. Valid
+                                                                operators are In, NotIn,
+                                                                Exists, DoesNotExist.
+                                                                Gt, and Lt.
+                                                              type: string
+                                                            values:
+                                                              description: An array of
+                                                                string values. If the
+                                                                operator is In or NotIn,
+                                                                the values array must
+                                                                be non-empty. If the operator
+                                                                is Exists or DoesNotExist,
+                                                                the values array must
+                                                                be empty. If the operator
+                                                                is Gt or Lt, the values
+                                                                array must have a single
+                                                                element, which will be
+                                                                interpreted as an integer.
+                                                                This array is replaced
+                                                                during a strategic merge
+                                                                patch.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                  weight:
+                                                    description: Weight associated with
+                                                      matching the corresponding nodeSelectorTerm,
+                                                      in the range 1-100.
+                                                    type: integer
+                                                    format: int32
+                                            requiredDuringSchedulingIgnoredDuringExecution:
+                                              description: If the affinity requirements
+                                                specified by this field are not met at
+                                                scheduling time, the pod will not be scheduled
+                                                onto the node. If the affinity requirements
+                                                specified by this field cease to be met
+                                                at some point during pod execution (e.g.
+                                                due to an update), the system may or may
+                                                not try to eventually evict the pod from
+                                                its node.
+                                              type: object
+                                              required:
+                                                - nodeSelectorTerms
+                                              properties:
+                                                nodeSelectorTerms:
+                                                  description: Required. A list of node
+                                                    selector terms. The terms are ORed.
+                                                  type: array
+                                                  items:
+                                                    description: A null or empty node
+                                                      selector term matches no objects.
+                                                      The requirements of them are ANDed.
+                                                      The TopologySelectorTerm type implements
+                                                      a subset of the NodeSelectorTerm.
+                                                    type: object
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: A list of node selector
+                                                          requirements by node's labels.
+                                                        type: array
+                                                        items:
+                                                          description: A node selector
+                                                            requirement is a selector
+                                                            that contains values, a key,
+                                                            and an operator that relates
+                                                            the key and values.
+                                                          type: object
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          properties:
+                                                            key:
+                                                              description: The label key
+                                                                that the selector applies
+                                                                to.
+                                                              type: string
+                                                            operator:
+                                                              description: Represents
+                                                                a key's relationship to
+                                                                a set of values. Valid
+                                                                operators are In, NotIn,
+                                                                Exists, DoesNotExist.
+                                                                Gt, and Lt.
+                                                              type: string
+                                                            values:
+                                                              description: An array of
+                                                                string values. If the
+                                                                operator is In or NotIn,
+                                                                the values array must
+                                                                be non-empty. If the operator
+                                                                is Exists or DoesNotExist,
+                                                                the values array must
+                                                                be empty. If the operator
+                                                                is Gt or Lt, the values
+                                                                array must have a single
+                                                                element, which will be
+                                                                interpreted as an integer.
+                                                                This array is replaced
+                                                                during a strategic merge
+                                                                patch.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                      matchFields:
+                                                        description: A list of node selector
+                                                          requirements by node's fields.
+                                                        type: array
+                                                        items:
+                                                          description: A node selector
+                                                            requirement is a selector
+                                                            that contains values, a key,
+                                                            and an operator that relates
+                                                            the key and values.
+                                                          type: object
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          properties:
+                                                            key:
+                                                              description: The label key
+                                                                that the selector applies
+                                                                to.
+                                                              type: string
+                                                            operator:
+                                                              description: Represents
+                                                                a key's relationship to
+                                                                a set of values. Valid
+                                                                operators are In, NotIn,
+                                                                Exists, DoesNotExist.
+                                                                Gt, and Lt.
+                                                              type: string
+                                                            values:
+                                                              description: An array of
+                                                                string values. If the
+                                                                operator is In or NotIn,
+                                                                the values array must
+                                                                be non-empty. If the operator
+                                                                is Exists or DoesNotExist,
+                                                                the values array must
+                                                                be empty. If the operator
+                                                                is Gt or Lt, the values
+                                                                array must have a single
+                                                                element, which will be
+                                                                interpreted as an integer.
+                                                                This array is replaced
+                                                                during a strategic merge
+                                                                patch.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                        podAffinity:
+                                          description: Describes pod affinity scheduling
+                                            rules (e.g. co-locate this pod in the same
+                                            node, zone, etc. as some other pod(s)).
+                                          type: object
+                                          properties:
+                                            preferredDuringSchedulingIgnoredDuringExecution:
+                                              description: The scheduler will prefer to
+                                                schedule pods to nodes that satisfy the
+                                                affinity expressions specified by this
+                                                field, but it may choose a node that violates
+                                                one or more of the expressions. The node
+                                                that is most preferred is the one with
+                                                the greatest sum of weights, i.e. for
+                                                each node that meets all of the scheduling
+                                                requirements (resource request, requiredDuringScheduling
+                                                affinity expressions, etc.), compute a
+                                                sum by iterating through the elements
+                                                of this field and adding "weight" to the
+                                                sum if the node has pods which matches
+                                                the corresponding podAffinityTerm; the
+                                                node(s) with the highest sum are the most
+                                                preferred.
+                                              type: array
+                                              items:
+                                                description: The weights of all of the
+                                                  matched WeightedPodAffinityTerm fields
+                                                  are added per-node to find the most
+                                                  preferred node(s)
+                                                type: object
+                                                required:
+                                                  - podAffinityTerm
+                                                  - weight
+                                                properties:
+                                                  podAffinityTerm:
+                                                    description: Required. A pod affinity
+                                                      term, associated with the corresponding
+                                                      weight.
+                                                    type: object
+                                                    required:
+                                                      - topologyKey
+                                                    properties:
+                                                      labelSelector:
+                                                        description: A label query over
+                                                          a set of resources, in this
+                                                          case pods.
+                                                        type: object
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: matchExpressions
+                                                              is a list of label selector
+                                                              requirements. The requirements
+                                                              are ANDed.
+                                                            type: array
+                                                            items:
+                                                              description: A label selector
+                                                                requirement is a selector
+                                                                that contains values,
+                                                                a key, and an operator
+                                                                that relates the key and
+                                                                values.
+                                                              type: object
+                                                              required:
+                                                                - key
+                                                                - operator
+                                                              properties:
+                                                                key:
+                                                                  description: key is
+                                                                    the label key that
+                                                                    the selector applies
+                                                                    to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: operator
+                                                                    represents a key's
+                                                                    relationship to a
+                                                                    set of values. Valid
+                                                                    operators are In,
+                                                                    NotIn, Exists and
+                                                                    DoesNotExist.
+                                                                  type: string
+                                                                values:
+                                                                  description: values
+                                                                    is an array of string
+                                                                    values. If the operator
+                                                                    is In or NotIn, the
+                                                                    values array must
+                                                                    be non-empty. If the
+                                                                    operator is Exists
+                                                                    or DoesNotExist, the
+                                                                    values array must
+                                                                    be empty. This array
+                                                                    is replaced during
+                                                                    a strategic merge
+                                                                    patch.
+                                                                  type: array
+                                                                  items:
+                                                                    type: string
+                                                          matchLabels:
+                                                            description: matchLabels is
+                                                              a map of {key,value} pairs.
+                                                              A single {key,value} in
+                                                              the matchLabels map is equivalent
+                                                              to an element of matchExpressions,
+                                                              whose key field is "key",
+                                                              the operator is "In", and
+                                                              the values array contains
+                                                              only "value". The requirements
+                                                              are ANDed.
+                                                            type: object
+                                                            additionalProperties:
+                                                              type: string
+                                                      namespaces:
+                                                        description: namespaces specifies
+                                                          which namespaces the labelSelector
+                                                          applies to (matches against);
+                                                          null or empty list means "this
+                                                          pod's namespace"
+                                                        type: array
+                                                        items:
+                                                          type: string
+                                                      topologyKey:
+                                                        description: This pod should be
+                                                          co-located (affinity) or not
+                                                          co-located (anti-affinity) with
+                                                          the pods matching the labelSelector
+                                                          in the specified namespaces,
+                                                          where co-located is defined
+                                                          as running on a node whose value
+                                                          of the label with key topologyKey
+                                                          matches that of any node on
+                                                          which any of the selected pods
+                                                          is running. Empty topologyKey
+                                                          is not allowed.
+                                                        type: string
+                                                  weight:
+                                                    description: weight associated with
+                                                      matching the corresponding podAffinityTerm,
+                                                      in the range 1-100.
+                                                    type: integer
+                                                    format: int32
+                                            requiredDuringSchedulingIgnoredDuringExecution:
+                                              description: If the affinity requirements
+                                                specified by this field are not met at
+                                                scheduling time, the pod will not be scheduled
+                                                onto the node. If the affinity requirements
+                                                specified by this field cease to be met
+                                                at some point during pod execution (e.g.
+                                                due to a pod label update), the system
+                                                may or may not try to eventually evict
+                                                the pod from its node. When there are
+                                                multiple elements, the lists of nodes
+                                                corresponding to each podAffinityTerm
+                                                are intersected, i.e. all terms must be
+                                                satisfied.
+                                              type: array
+                                              items:
+                                                description: Defines a set of pods (namely
+                                                  those matching the labelSelector relative
+                                                  to the given namespace(s)) that this
+                                                  pod should be co-located (affinity)
+                                                  or not co-located (anti-affinity) with,
+                                                  where co-located is defined as running
+                                                  on a node whose value of the label with
+                                                  key <topologyKey> matches that of any
+                                                  node on which a pod of the set of pods
+                                                  is running
+                                                type: object
+                                                required:
+                                                  - topologyKey
+                                                properties:
+                                                  labelSelector:
+                                                    description: A label query over a
+                                                      set of resources, in this case pods.
+                                                    type: object
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions
+                                                          is a list of label selector
+                                                          requirements. The requirements
+                                                          are ANDed.
+                                                        type: array
+                                                        items:
+                                                          description: A label selector
+                                                            requirement is a selector
+                                                            that contains values, a key,
+                                                            and an operator that relates
+                                                            the key and values.
+                                                          type: object
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          properties:
+                                                            key:
+                                                              description: key is the
+                                                                label key that the selector
+                                                                applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: operator represents
+                                                                a key's relationship to
+                                                                a set of values. Valid
+                                                                operators are In, NotIn,
+                                                                Exists and DoesNotExist.
+                                                              type: string
+                                                            values:
+                                                              description: values is an
+                                                                array of string values.
+                                                                If the operator is In
+                                                                or NotIn, the values array
+                                                                must be non-empty. If
+                                                                the operator is Exists
+                                                                or DoesNotExist, the values
+                                                                array must be empty. This
+                                                                array is replaced during
+                                                                a strategic merge patch.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                      matchLabels:
+                                                        description: matchLabels is a
+                                                          map of {key,value} pairs. A
+                                                          single {key,value} in the matchLabels
+                                                          map is equivalent to an element
+                                                          of matchExpressions, whose key
+                                                          field is "key", the operator
+                                                          is "In", and the values array
+                                                          contains only "value". The requirements
+                                                          are ANDed.
+                                                        type: object
+                                                        additionalProperties:
+                                                          type: string
+                                                  namespaces:
+                                                    description: namespaces specifies
+                                                      which namespaces the labelSelector
+                                                      applies to (matches against); null
+                                                      or empty list means "this pod's
+                                                      namespace"
+                                                    type: array
+                                                    items:
+                                                      type: string
+                                                  topologyKey:
+                                                    description: This pod should be co-located
+                                                      (affinity) or not co-located (anti-affinity)
+                                                      with the pods matching the labelSelector
+                                                      in the specified namespaces, where
+                                                      co-located is defined as running
+                                                      on a node whose value of the label
+                                                      with key topologyKey matches that
+                                                      of any node on which any of the
+                                                      selected pods is running. Empty
+                                                      topologyKey is not allowed.
+                                                    type: string
+                                        podAntiAffinity:
+                                          description: Describes pod anti-affinity scheduling
+                                            rules (e.g. avoid putting this pod in the
+                                            same node, zone, etc. as some other pod(s)).
+                                          type: object
+                                          properties:
+                                            preferredDuringSchedulingIgnoredDuringExecution:
+                                              description: The scheduler will prefer to
+                                                schedule pods to nodes that satisfy the
+                                                anti-affinity expressions specified by
+                                                this field, but it may choose a node that
+                                                violates one or more of the expressions.
+                                                The node that is most preferred is the
+                                                one with the greatest sum of weights,
+                                                i.e. for each node that meets all of the
+                                                scheduling requirements (resource request,
+                                                requiredDuringScheduling anti-affinity
+                                                expressions, etc.), compute a sum by iterating
+                                                through the elements of this field and
+                                                adding "weight" to the sum if the node
+                                                has pods which matches the corresponding
+                                                podAffinityTerm; the node(s) with the
+                                                highest sum are the most preferred.
+                                              type: array
+                                              items:
+                                                description: The weights of all of the
+                                                  matched WeightedPodAffinityTerm fields
+                                                  are added per-node to find the most
+                                                  preferred node(s)
+                                                type: object
+                                                required:
+                                                  - podAffinityTerm
+                                                  - weight
+                                                properties:
+                                                  podAffinityTerm:
+                                                    description: Required. A pod affinity
+                                                      term, associated with the corresponding
+                                                      weight.
+                                                    type: object
+                                                    required:
+                                                      - topologyKey
+                                                    properties:
+                                                      labelSelector:
+                                                        description: A label query over
+                                                          a set of resources, in this
+                                                          case pods.
+                                                        type: object
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: matchExpressions
+                                                              is a list of label selector
+                                                              requirements. The requirements
+                                                              are ANDed.
+                                                            type: array
+                                                            items:
+                                                              description: A label selector
+                                                                requirement is a selector
+                                                                that contains values,
+                                                                a key, and an operator
+                                                                that relates the key and
+                                                                values.
+                                                              type: object
+                                                              required:
+                                                                - key
+                                                                - operator
+                                                              properties:
+                                                                key:
+                                                                  description: key is
+                                                                    the label key that
+                                                                    the selector applies
+                                                                    to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: operator
+                                                                    represents a key's
+                                                                    relationship to a
+                                                                    set of values. Valid
+                                                                    operators are In,
+                                                                    NotIn, Exists and
+                                                                    DoesNotExist.
+                                                                  type: string
+                                                                values:
+                                                                  description: values
+                                                                    is an array of string
+                                                                    values. If the operator
+                                                                    is In or NotIn, the
+                                                                    values array must
+                                                                    be non-empty. If the
+                                                                    operator is Exists
+                                                                    or DoesNotExist, the
+                                                                    values array must
+                                                                    be empty. This array
+                                                                    is replaced during
+                                                                    a strategic merge
+                                                                    patch.
+                                                                  type: array
+                                                                  items:
+                                                                    type: string
+                                                          matchLabels:
+                                                            description: matchLabels is
+                                                              a map of {key,value} pairs.
+                                                              A single {key,value} in
+                                                              the matchLabels map is equivalent
+                                                              to an element of matchExpressions,
+                                                              whose key field is "key",
+                                                              the operator is "In", and
+                                                              the values array contains
+                                                              only "value". The requirements
+                                                              are ANDed.
+                                                            type: object
+                                                            additionalProperties:
+                                                              type: string
+                                                      namespaces:
+                                                        description: namespaces specifies
+                                                          which namespaces the labelSelector
+                                                          applies to (matches against);
+                                                          null or empty list means "this
+                                                          pod's namespace"
+                                                        type: array
+                                                        items:
+                                                          type: string
+                                                      topologyKey:
+                                                        description: This pod should be
+                                                          co-located (affinity) or not
+                                                          co-located (anti-affinity) with
+                                                          the pods matching the labelSelector
+                                                          in the specified namespaces,
+                                                          where co-located is defined
+                                                          as running on a node whose value
+                                                          of the label with key topologyKey
+                                                          matches that of any node on
+                                                          which any of the selected pods
+                                                          is running. Empty topologyKey
+                                                          is not allowed.
+                                                        type: string
+                                                  weight:
+                                                    description: weight associated with
+                                                      matching the corresponding podAffinityTerm,
+                                                      in the range 1-100.
+                                                    type: integer
+                                                    format: int32
+                                            requiredDuringSchedulingIgnoredDuringExecution:
+                                              description: If the anti-affinity requirements
+                                                specified by this field are not met at
+                                                scheduling time, the pod will not be scheduled
+                                                onto the node. If the anti-affinity requirements
+                                                specified by this field cease to be met
+                                                at some point during pod execution (e.g.
+                                                due to a pod label update), the system
+                                                may or may not try to eventually evict
+                                                the pod from its node. When there are
+                                                multiple elements, the lists of nodes
+                                                corresponding to each podAffinityTerm
+                                                are intersected, i.e. all terms must be
+                                                satisfied.
+                                              type: array
+                                              items:
+                                                description: Defines a set of pods (namely
+                                                  those matching the labelSelector relative
+                                                  to the given namespace(s)) that this
+                                                  pod should be co-located (affinity)
+                                                  or not co-located (anti-affinity) with,
+                                                  where co-located is defined as running
+                                                  on a node whose value of the label with
+                                                  key <topologyKey> matches that of any
+                                                  node on which a pod of the set of pods
+                                                  is running
+                                                type: object
+                                                required:
+                                                  - topologyKey
+                                                properties:
+                                                  labelSelector:
+                                                    description: A label query over a
+                                                      set of resources, in this case pods.
+                                                    type: object
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions
+                                                          is a list of label selector
+                                                          requirements. The requirements
+                                                          are ANDed.
+                                                        type: array
+                                                        items:
+                                                          description: A label selector
+                                                            requirement is a selector
+                                                            that contains values, a key,
+                                                            and an operator that relates
+                                                            the key and values.
+                                                          type: object
+                                                          required:
+                                                            - key
+                                                            - operator
+                                                          properties:
+                                                            key:
+                                                              description: key is the
+                                                                label key that the selector
+                                                                applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: operator represents
+                                                                a key's relationship to
+                                                                a set of values. Valid
+                                                                operators are In, NotIn,
+                                                                Exists and DoesNotExist.
+                                                              type: string
+                                                            values:
+                                                              description: values is an
+                                                                array of string values.
+                                                                If the operator is In
+                                                                or NotIn, the values array
+                                                                must be non-empty. If
+                                                                the operator is Exists
+                                                                or DoesNotExist, the values
+                                                                array must be empty. This
+                                                                array is replaced during
+                                                                a strategic merge patch.
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                      matchLabels:
+                                                        description: matchLabels is a
+                                                          map of {key,value} pairs. A
+                                                          single {key,value} in the matchLabels
+                                                          map is equivalent to an element
+                                                          of matchExpressions, whose key
+                                                          field is "key", the operator
+                                                          is "In", and the values array
+                                                          contains only "value". The requirements
+                                                          are ANDed.
+                                                        type: object
+                                                        additionalProperties:
+                                                          type: string
+                                                  namespaces:
+                                                    description: namespaces specifies
+                                                      which namespaces the labelSelector
+                                                      applies to (matches against); null
+                                                      or empty list means "this pod's
+                                                      namespace"
+                                                    type: array
+                                                    items:
+                                                      type: string
+                                                  topologyKey:
+                                                    description: This pod should be co-located
+                                                      (affinity) or not co-located (anti-affinity)
+                                                      with the pods matching the labelSelector
+                                                      in the specified namespaces, where
+                                                      co-located is defined as running
+                                                      on a node whose value of the label
+                                                      with key topologyKey matches that
+                                                      of any node on which any of the
+                                                      selected pods is running. Empty
+                                                      topologyKey is not allowed.
+                                                    type: string
+                                    nodeSelector:
+                                      description: 'NodeSelector is a selector which must
+                                            be true for the pod to fit on a node. Selector
+                                            which must match a node''s labels for the pod
+                                            to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                                      type: object
+                                      additionalProperties:
+                                        type: string
+                                    tolerations:
+                                      description: If specified, the pod's tolerations.
+                                      type: array
+                                      items:
+                                        description: The pod this Toleration is attached
+                                          to tolerates any taint that matches the triple
+                                          <key,value,effect> using the matching operator
+                                          <operator>.
+                                        type: object
+                                        properties:
+                                          effect:
+                                            description: Effect indicates the taint effect
+                                              to match. Empty means match all taint effects.
+                                              When specified, allowed values are NoSchedule,
+                                              PreferNoSchedule and NoExecute.
+                                            type: string
+                                          key:
+                                            description: Key is the taint key that the
+                                              toleration applies to. Empty means match
+                                              all taint keys. If the key is empty, operator
+                                              must be Exists; this combination means to
+                                              match all values and all keys.
+                                            type: string
+                                          operator:
+                                            description: Operator represents a key's relationship
+                                              to the value. Valid operators are Exists
+                                              and Equal. Defaults to Equal. Exists is
+                                              equivalent to wildcard for value, so that
+                                              a pod can tolerate all taints of a particular
+                                              category.
+                                            type: string
+                                          tolerationSeconds:
+                                            description: TolerationSeconds represents
+                                              the period of time the toleration (which
+                                              must be of effect NoExecute, otherwise this
+                                              field is ignored) tolerates the taint. By
+                                              default, it is not set, which means tolerate
+                                              the taint forever (do not evict). Zero and
+                                              negative values will be treated as 0 (evict
+                                              immediately) by the system.
+                                            type: integer
+                                            format: int64
+                                          value:
+                                            description: Value is the taint value the
+                                              toleration matches to. If the operator is
+                                              Exists, the value should be empty, otherwise
+                                              just a regular string.
+                                            type: string
+                            serviceType:
+                              description: Optional service type for Kubernetes solver
+                                service
+                              type: string
+                    selector:
+                      description: Selector selects a set of DNSNames on the Certificate
+                        resource that should be solved using this challenge solver.
+                      type: object
+                      properties:
+                        dnsNames:
+                          description: List of DNSNames that this solver will be used
+                            to solve. If specified and a match is found, a dnsNames selector
+                            will take precedence over a dnsZones selector. If multiple
+                            solvers match with the same dnsNames value, the solver with
+                            the most matching labels in matchLabels will be selected.
+                            If neither has more matches, the solver defined earlier in
+                            the list will be selected.
+                          type: array
+                          items:
+                            type: string
+                        dnsZones:
+                          description: List of DNSZones that this solver will be used
+                            to solve. The most specific DNS zone match specified here
+                            will take precedence over other DNS zone matches, so a solver
+                            specifying sys.example.com will be selected over one specifying
+                            example.com for the domain www.sys.example.com. If multiple
+                            solvers match with the same dnsZones value, the solver with
+                            the most matching labels in matchLabels will be selected.
+                            If neither has more matches, the solver defined earlier in
+                            the list will be selected.
+                          type: array
+                          items:
+                            type: string
+                        matchLabels:
+                          description: A label selector that is used to refine the set
+                            of certificate's that this challenge solver will apply to.
+                          type: object
+                          additionalProperties:
+                            type: string
+                token:
+                  description: Token is the ACME challenge token for this challenge. This
+                    is the raw value returned from the ACME server.
+                  type: string
+                type:
+                  description: Type is the type of ACME challenge this resource represents,
+                    e.g. "dns01" or "http01".
+                  type: string
+                url:
+                  description: URL is the URL of the ACME Challenge resource for this
+                    challenge. This can be used to lookup details about the status of
+                    this challenge.
+                  type: string
+                wildcard:
+                  description: Wildcard will be true if this challenge is for a wildcard
+                    identifier, for example '*.example.com'.
+                  type: boolean
+            status:
+              type: object
+              properties:
+                presented:
+                  description: Presented will be set to true if the challenge values for
+                    this challenge are currently 'presented'. This *does not* imply the
+                    self check is passing. Only that the values have been 'submitted'
+                    for the appropriate challenge mechanism (i.e. the DNS01 TXT record
+                    has been presented, or the HTTP01 configuration has been configured).
+                  type: boolean
+                processing:
+                  description: Processing is used to denote whether this challenge should
+                    be processed or not. This field will only be set to true by the 'scheduling'
+                    component. It will only be set to false by the 'challenges' controller,
+                    after the challenge has reached a final state or timed out. If this
+                    field is set to false, the challenge controller will not take any
+                    more action.
+                  type: boolean
+                reason:
+                  description: Reason contains human readable information on why the Challenge
+                    is in the current state.
+                  type: string
+                state:
+                  description: State contains the current 'state' of the challenge. If
+                    not set, the state of the challenge is unknown.
+                  type: string
+                  enum:
+                    - valid
+                    - ready
+                    - pending
+                    - processing
+                    - invalid
+                    - expired
+                    - errored
+      served: true
+      storage: false
+      additionalPrinterColumns:
+        - jsonPath: .status.state
+          name: State
+          type: string
+        - jsonPath: .spec.dnsName
+          name: Domain
+          type: string
+        - jsonPath: .status.reason
+          name: Reason
+          priority: 1
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          description: CreationTimestamp is a timestamp representing the server time when
+            this object was created. It is not guaranteed to be set in happens-before order
+            across separate operations. Clients may not set this value. It is represented
+            in RFC3339 form and is in UTC.
+          name: Age
+          type: date
+      subresources:
+        status: { }

--- a/config/test/crd/cert-manager/acme.cert-manager.io_orders.yaml
+++ b/config/test/crd/cert-manager/acme.cert-manager.io_orders.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: orders.acme.cert-manager.io
@@ -25,25 +25,6 @@ metadata:
     app.kubernetes.io/managed-by: 'Helm'
     helm.sh/chart: 'cert-manager-v0.15.1'
 spec:
-  additionalPrinterColumns:
-    - JSONPath: .status.state
-      name: State
-      type: string
-    - JSONPath: .spec.issuerRef.name
-      name: Issuer
-      priority: 1
-      type: string
-    - JSONPath: .status.reason
-      name: Reason
-      priority: 1
-      type: string
-    - JSONPath: .metadata.creationTimestamp
-      description: CreationTimestamp is a timestamp representing the server time when
-        this object was created. It is not guaranteed to be set in happens-before order
-        across separate operations. Clients may not set this value. It is represented
-        in RFC3339 form and is in UTC.
-      name: Age
-      type: date
   group: acme.cert-manager.io
   preserveUnknownFields: false
   names:
@@ -52,192 +33,412 @@ spec:
     plural: orders
     singular: order
   scope: Namespaced
-  subresources:
-    status: {}
   versions:
     - name: v1alpha2
-      served: true
-      storage: true
-    - name: v1alpha3
-      served: true
-      storage: false
-  "validation":
-    "openAPIV3Schema":
-      description: Order is a type to represent an Order with an ACME server
-      type: object
-      required:
-        - metadata
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
+      schema:
+        openAPIV3Schema:
+          description: Order is a type to represent an Order with an ACME server
           type: object
           required:
-            - csr
-            - issuerRef
+            - metadata
           properties:
-            commonName:
-              description: CommonName is the common name as specified on the DER encoded
-                CSR. If CommonName is not specified, the first DNSName specified will
-                be used as the CommonName. At least one of CommonName or a DNSNames
-                must be set. This field must match the corresponding field on the
-                DER encoded CSR.
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
               type: string
-            csr:
-              description: Certificate signing request bytes in DER encoding. This
-                will be used when finalizing the order. This field must be set on
-                the order.
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
               type: string
-              format: byte
-            dnsNames:
-              description: DNSNames is a list of DNS names that should be included
-                as part of the Order validation process. If CommonName is not specified,
-                the first DNSName specified will be used as the CommonName. At least
-                one of CommonName or a DNSNames must be set. This field must match
-                the corresponding field on the DER encoded CSR.
-              type: array
-              items:
-                type: string
-            issuerRef:
-              description: IssuerRef references a properly configured ACME-type Issuer
-                which should be used to create this Order. If the Issuer does not
-                exist, processing will be retried. If the Issuer is not an 'ACME'
-                Issuer, an error will be returned and the Order will be marked as
-                failed.
+            metadata:
+              type: object
+            spec:
               type: object
               required:
-                - name
+                - csr
+                - issuerRef
               properties:
-                group:
+                commonName:
+                  description: CommonName is the common name as specified on the DER encoded
+                    CSR. If CommonName is not specified, the first DNSName specified will
+                    be used as the CommonName. At least one of CommonName or a DNSNames
+                    must be set. This field must match the corresponding field on the
+                    DER encoded CSR.
                   type: string
-                kind:
+                csr:
+                  description: Certificate signing request bytes in DER encoding. This
+                    will be used when finalizing the order. This field must be set on
+                    the order.
                   type: string
-                name:
+                  format: byte
+                dnsNames:
+                  description: DNSNames is a list of DNS names that should be included
+                    as part of the Order validation process. If CommonName is not specified,
+                    the first DNSName specified will be used as the CommonName. At least
+                    one of CommonName or a DNSNames must be set. This field must match
+                    the corresponding field on the DER encoded CSR.
+                  type: array
+                  items:
+                    type: string
+                issuerRef:
+                  description: IssuerRef references a properly configured ACME-type Issuer
+                    which should be used to create this Order. If the Issuer does not
+                    exist, processing will be retried. If the Issuer is not an 'ACME'
+                    Issuer, an error will be returned and the Order will be marked as
+                    failed.
+                  type: object
+                  required:
+                    - name
+                  properties:
+                    group:
+                      type: string
+                    kind:
+                      type: string
+                    name:
+                      type: string
+            status:
+              type: object
+              properties:
+                authorizations:
+                  description: Authorizations contains data returned from the ACME server
+                    on what authorizations must be completed in order to validate the
+                    DNS names specified on the Order.
+                  type: array
+                  items:
+                    description: ACMEAuthorization contains data returned from the ACME
+                      server on an authorization that must be completed in order validate
+                      a DNS name on an ACME Order resource.
+                    type: object
+                    required:
+                      - url
+                    properties:
+                      challenges:
+                        description: Challenges specifies the challenge types offered
+                          by the ACME server. One of these challenge types will be selected
+                          when validating the DNS name and an appropriate Challenge resource
+                          will be created to perform the ACME challenge process.
+                        type: array
+                        items:
+                          description: Challenge specifies a challenge offered by the
+                            ACME server for an Order. An appropriate Challenge resource
+                            can be created to perform the ACME challenge process.
+                          type: object
+                          required:
+                            - token
+                            - type
+                            - url
+                          properties:
+                            token:
+                              description: Token is the token that must be presented for
+                                this challenge. This is used to compute the 'key' that
+                                must also be presented.
+                              type: string
+                            type:
+                              description: Type is the type of challenge being offered,
+                                e.g. http-01, dns-01
+                              type: string
+                            url:
+                              description: URL is the URL of this challenge. It can be
+                                used to retrieve additional metadata about the Challenge
+                                from the ACME server.
+                              type: string
+                      identifier:
+                        description: Identifier is the DNS name to be validated as part
+                          of this authorization
+                        type: string
+                      initialState:
+                        description: InitialState is the initial state of the ACME authorization
+                          when first fetched from the ACME server. If an Authorization
+                          is already 'valid', the Order controller will not create a Challenge
+                          resource for the authorization. This will occur when working
+                          with an ACME server that enables 'authz reuse' (such as Let's
+                          Encrypt's production endpoint). If not set and 'identifier'
+                          is set, the state is assumed to be pending and a Challenge will
+                          be created.
+                        type: string
+                        enum:
+                          - valid
+                          - ready
+                          - pending
+                          - processing
+                          - invalid
+                          - expired
+                          - errored
+                      url:
+                        description: URL is the URL of the Authorization that must be
+                          completed
+                        type: string
+                      wildcard:
+                        description: Wildcard will be true if this authorization is for
+                          a wildcard DNS name. If this is true, the identifier will be
+                          the *non-wildcard* version of the DNS name. For example, if
+                          '*.example.com' is the DNS name being validated, this field
+                          will be 'true' and the 'identifier' field will be 'example.com'.
+                        type: boolean
+                certificate:
+                  description: Certificate is a copy of the PEM encoded certificate for
+                    this Order. This field will be populated after the order has been
+                    successfully finalized with the ACME server, and the order has transitioned
+                    to the 'valid' state.
                   type: string
-        status:
+                  format: byte
+                failureTime:
+                  description: FailureTime stores the time that this order failed. This
+                    is used to influence garbage collection and back-off.
+                  type: string
+                  format: date-time
+                finalizeURL:
+                  description: FinalizeURL of the Order. This is used to obtain certificates
+                    for this order once it has been completed.
+                  type: string
+                reason:
+                  description: Reason optionally provides more information about a why
+                    the order is in the current state.
+                  type: string
+                state:
+                  description: State contains the current state of this Order resource.
+                    States 'success' and 'expired' are 'final'
+                  type: string
+                  enum:
+                    - valid
+                    - ready
+                    - pending
+                    - processing
+                    - invalid
+                    - expired
+                    - errored
+                url:
+                  description: URL of the Order. This will initially be empty when the
+                    resource is first created. The Order controller will populate this
+                    field when the Order is first processed. This field will be immutable
+                    after it is initially set.
+                  type: string
+      served: true
+      storage: true
+      additionalPrinterColumns:
+        - jsonPath: .status.state
+          name: State
+          type: string
+        - jsonPath: .spec.issuerRef.name
+          name: Issuer
+          priority: 1
+          type: string
+        - jsonPath: .status.reason
+          name: Reason
+          priority: 1
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          description: CreationTimestamp is a timestamp representing the server time when
+            this object was created. It is not guaranteed to be set in happens-before order
+            across separate operations. Clients may not set this value. It is represented
+            in RFC3339 form and is in UTC.
+          name: Age
+          type: date
+      subresources:
+        status: { }
+    - name: v1alpha3
+      schema:
+        openAPIV3Schema:
+          description: Order is a type to represent an Order with an ACME server
           type: object
+          required:
+            - metadata
           properties:
-            authorizations:
-              description: Authorizations contains data returned from the ACME server
-                on what authorizations must be completed in order to validate the
-                DNS names specified on the Order.
-              type: array
-              items:
-                description: ACMEAuthorization contains data returned from the ACME
-                  server on an authorization that must be completed in order validate
-                  a DNS name on an ACME Order resource.
-                type: object
-                required:
-                  - url
-                properties:
-                  challenges:
-                    description: Challenges specifies the challenge types offered
-                      by the ACME server. One of these challenge types will be selected
-                      when validating the DNS name and an appropriate Challenge resource
-                      will be created to perform the ACME challenge process.
-                    type: array
-                    items:
-                      description: Challenge specifies a challenge offered by the
-                        ACME server for an Order. An appropriate Challenge resource
-                        can be created to perform the ACME challenge process.
-                      type: object
-                      required:
-                        - token
-                        - type
-                        - url
-                      properties:
-                        token:
-                          description: Token is the token that must be presented for
-                            this challenge. This is used to compute the 'key' that
-                            must also be presented.
-                          type: string
-                        type:
-                          description: Type is the type of challenge being offered,
-                            e.g. http-01, dns-01
-                          type: string
-                        url:
-                          description: URL is the URL of this challenge. It can be
-                            used to retrieve additional metadata about the Challenge
-                            from the ACME server.
-                          type: string
-                  identifier:
-                    description: Identifier is the DNS name to be validated as part
-                      of this authorization
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              type: object
+              required:
+                - csr
+                - issuerRef
+              properties:
+                commonName:
+                  description: CommonName is the common name as specified on the DER encoded
+                    CSR. If CommonName is not specified, the first DNSName specified will
+                    be used as the CommonName. At least one of CommonName or a DNSNames
+                    must be set. This field must match the corresponding field on the
+                    DER encoded CSR.
+                  type: string
+                csr:
+                  description: Certificate signing request bytes in DER encoding. This
+                    will be used when finalizing the order. This field must be set on
+                    the order.
+                  type: string
+                  format: byte
+                dnsNames:
+                  description: DNSNames is a list of DNS names that should be included
+                    as part of the Order validation process. If CommonName is not specified,
+                    the first DNSName specified will be used as the CommonName. At least
+                    one of CommonName or a DNSNames must be set. This field must match
+                    the corresponding field on the DER encoded CSR.
+                  type: array
+                  items:
                     type: string
-                  initialState:
-                    description: InitialState is the initial state of the ACME authorization
-                      when first fetched from the ACME server. If an Authorization
-                      is already 'valid', the Order controller will not create a Challenge
-                      resource for the authorization. This will occur when working
-                      with an ACME server that enables 'authz reuse' (such as Let's
-                      Encrypt's production endpoint). If not set and 'identifier'
-                      is set, the state is assumed to be pending and a Challenge will
-                      be created.
-                    type: string
-                    enum:
-                      - valid
-                      - ready
-                      - pending
-                      - processing
-                      - invalid
-                      - expired
-                      - errored
-                  url:
-                    description: URL is the URL of the Authorization that must be
-                      completed
-                    type: string
-                  wildcard:
-                    description: Wildcard will be true if this authorization is for
-                      a wildcard DNS name. If this is true, the identifier will be
-                      the *non-wildcard* version of the DNS name. For example, if
-                      '*.example.com' is the DNS name being validated, this field
-                      will be 'true' and the 'identifier' field will be 'example.com'.
-                    type: boolean
-            certificate:
-              description: Certificate is a copy of the PEM encoded certificate for
-                this Order. This field will be populated after the order has been
-                successfully finalized with the ACME server, and the order has transitioned
-                to the 'valid' state.
-              type: string
-              format: byte
-            failureTime:
-              description: FailureTime stores the time that this order failed. This
-                is used to influence garbage collection and back-off.
-              type: string
-              format: date-time
-            finalizeURL:
-              description: FinalizeURL of the Order. This is used to obtain certificates
-                for this order once it has been completed.
-              type: string
-            reason:
-              description: Reason optionally provides more information about a why
-                the order is in the current state.
-              type: string
-            state:
-              description: State contains the current state of this Order resource.
-                States 'success' and 'expired' are 'final'
-              type: string
-              enum:
-                - valid
-                - ready
-                - pending
-                - processing
-                - invalid
-                - expired
-                - errored
-            url:
-              description: URL of the Order. This will initially be empty when the
-                resource is first created. The Order controller will populate this
-                field when the Order is first processed. This field will be immutable
-                after it is initially set.
-              type: string
+                issuerRef:
+                  description: IssuerRef references a properly configured ACME-type Issuer
+                    which should be used to create this Order. If the Issuer does not
+                    exist, processing will be retried. If the Issuer is not an 'ACME'
+                    Issuer, an error will be returned and the Order will be marked as
+                    failed.
+                  type: object
+                  required:
+                    - name
+                  properties:
+                    group:
+                      type: string
+                    kind:
+                      type: string
+                    name:
+                      type: string
+            status:
+              type: object
+              properties:
+                authorizations:
+                  description: Authorizations contains data returned from the ACME server
+                    on what authorizations must be completed in order to validate the
+                    DNS names specified on the Order.
+                  type: array
+                  items:
+                    description: ACMEAuthorization contains data returned from the ACME
+                      server on an authorization that must be completed in order validate
+                      a DNS name on an ACME Order resource.
+                    type: object
+                    required:
+                      - url
+                    properties:
+                      challenges:
+                        description: Challenges specifies the challenge types offered
+                          by the ACME server. One of these challenge types will be selected
+                          when validating the DNS name and an appropriate Challenge resource
+                          will be created to perform the ACME challenge process.
+                        type: array
+                        items:
+                          description: Challenge specifies a challenge offered by the
+                            ACME server for an Order. An appropriate Challenge resource
+                            can be created to perform the ACME challenge process.
+                          type: object
+                          required:
+                            - token
+                            - type
+                            - url
+                          properties:
+                            token:
+                              description: Token is the token that must be presented for
+                                this challenge. This is used to compute the 'key' that
+                                must also be presented.
+                              type: string
+                            type:
+                              description: Type is the type of challenge being offered,
+                                e.g. http-01, dns-01
+                              type: string
+                            url:
+                              description: URL is the URL of this challenge. It can be
+                                used to retrieve additional metadata about the Challenge
+                                from the ACME server.
+                              type: string
+                      identifier:
+                        description: Identifier is the DNS name to be validated as part
+                          of this authorization
+                        type: string
+                      initialState:
+                        description: InitialState is the initial state of the ACME authorization
+                          when first fetched from the ACME server. If an Authorization
+                          is already 'valid', the Order controller will not create a Challenge
+                          resource for the authorization. This will occur when working
+                          with an ACME server that enables 'authz reuse' (such as Let's
+                          Encrypt's production endpoint). If not set and 'identifier'
+                          is set, the state is assumed to be pending and a Challenge will
+                          be created.
+                        type: string
+                        enum:
+                          - valid
+                          - ready
+                          - pending
+                          - processing
+                          - invalid
+                          - expired
+                          - errored
+                      url:
+                        description: URL is the URL of the Authorization that must be
+                          completed
+                        type: string
+                      wildcard:
+                        description: Wildcard will be true if this authorization is for
+                          a wildcard DNS name. If this is true, the identifier will be
+                          the *non-wildcard* version of the DNS name. For example, if
+                          '*.example.com' is the DNS name being validated, this field
+                          will be 'true' and the 'identifier' field will be 'example.com'.
+                        type: boolean
+                certificate:
+                  description: Certificate is a copy of the PEM encoded certificate for
+                    this Order. This field will be populated after the order has been
+                    successfully finalized with the ACME server, and the order has transitioned
+                    to the 'valid' state.
+                  type: string
+                  format: byte
+                failureTime:
+                  description: FailureTime stores the time that this order failed. This
+                    is used to influence garbage collection and back-off.
+                  type: string
+                  format: date-time
+                finalizeURL:
+                  description: FinalizeURL of the Order. This is used to obtain certificates
+                    for this order once it has been completed.
+                  type: string
+                reason:
+                  description: Reason optionally provides more information about a why
+                    the order is in the current state.
+                  type: string
+                state:
+                  description: State contains the current state of this Order resource.
+                    States 'success' and 'expired' are 'final'
+                  type: string
+                  enum:
+                    - valid
+                    - ready
+                    - pending
+                    - processing
+                    - invalid
+                    - expired
+                    - errored
+                url:
+                  description: URL of the Order. This will initially be empty when the
+                    resource is first created. The Order controller will populate this
+                    field when the Order is first processed. This field will be immutable
+                    after it is initially set.
+                  type: string
+      served: true
+      storage: false
+      additionalPrinterColumns:
+        - jsonPath: .status.state
+          name: State
+          type: string
+        - jsonPath: .spec.issuerRef.name
+          name: Issuer
+          priority: 1
+          type: string
+        - jsonPath: .status.reason
+          name: Reason
+          priority: 1
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          description: CreationTimestamp is a timestamp representing the server time when
+            this object was created. It is not guaranteed to be set in happens-before order
+            across separate operations. Clients may not set this value. It is represented
+            in RFC3339 form and is in UTC.
+          name: Age
+          type: date
+      subresources:
+        status: { }

--- a/config/test/crd/cert-manager/cert-manager.io_certificaterequests.yaml
+++ b/config/test/crd/cert-manager/cert-manager.io_certificaterequests.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: certificaterequests.cert-manager.io
@@ -25,25 +25,6 @@ metadata:
     app.kubernetes.io/managed-by: 'Helm'
     helm.sh/chart: 'cert-manager-v0.15.1'
 spec:
-  additionalPrinterColumns:
-    - JSONPath: .status.conditions[?(@.type=="Ready")].status
-      name: Ready
-      type: string
-    - JSONPath: .spec.issuerRef.name
-      name: Issuer
-      priority: 1
-      type: string
-    - JSONPath: .status.conditions[?(@.type=="Ready")].message
-      name: Status
-      priority: 1
-      type: string
-    - JSONPath: .metadata.creationTimestamp
-      description: CreationTimestamp is a timestamp representing the server time when
-        this object was created. It is not guaranteed to be set in happens-before order
-        across separate operations. Clients may not set this value. It is represented
-        in RFC3339 form and is in UTC.
-      name: Age
-      type: date
   group: cert-manager.io
   preserveUnknownFields: false
   names:
@@ -55,160 +36,348 @@ spec:
       - crs
     singular: certificaterequest
   scope: Namespaced
-  subresources:
-    status: {}
   versions:
     - name: v1alpha2
-      served: true
-      storage: true
-    - name: v1alpha3
-      served: true
-      storage: false
-  "validation":
-    "openAPIV3Schema":
-      description: CertificateRequest is a type to represent a Certificate Signing
-        Request
-      type: object
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
+      schema:
+        openAPIV3Schema:
+          description: CertificateRequest is a type to represent a Certificate Signing
+            Request
           type: object
-        spec:
-          description: CertificateRequestSpec defines the desired state of CertificateRequest
-          type: object
-          required:
-            - csr
-            - issuerRef
           properties:
-            csr:
-              description: Byte slice containing the PEM encoded CertificateSigningRequest
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
               type: string
-              format: byte
-            duration:
-              description: Requested certificate default Duration
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
               type: string
-            isCA:
-              description: IsCA will mark the resulting certificate as valid for signing.
-                This implies that the 'cert sign' usage is set
-              type: boolean
-            issuerRef:
-              description: IssuerRef is a reference to the issuer for this CertificateRequest.  If
-                the 'kind' field is not set, or set to 'Issuer', an Issuer resource
-                with the given name in the same namespace as the CertificateRequest
-                will be used.  If the 'kind' field is set to 'ClusterIssuer', a ClusterIssuer
-                with the provided name will be used. The 'name' field in this stanza
-                is required at all times. The group field refers to the API group
-                of the issuer which defaults to 'cert-manager.io' if empty.
+            metadata:
+              type: object
+            spec:
+              description: CertificateRequestSpec defines the desired state of CertificateRequest
               type: object
               required:
-                - name
+                - csr
+                - issuerRef
               properties:
-                group:
+                csr:
+                  description: Byte slice containing the PEM encoded CertificateSigningRequest
                   type: string
-                kind:
+                  format: byte
+                duration:
+                  description: Requested certificate default Duration
                   type: string
-                name:
-                  type: string
-            usages:
-              description: Usages is the set of x509 actions that are enabled for
-                a given key. Defaults are ('digital signature', 'key encipherment')
-                if empty
-              type: array
-              items:
-                description: 'KeyUsage specifies valid usage contexts for keys. See:
-                  https://tools.ietf.org/html/rfc5280#section-4.2.1.3      https://tools.ietf.org/html/rfc5280#section-4.2.1.12
-                  Valid KeyUsage values are as follows: "signing", "digital signature",
-                  "content commitment", "key encipherment", "key agreement", "data
-                  encipherment", "cert sign", "crl sign", "encipher only", "decipher
-                  only", "any", "server auth", "client auth", "code signing", "email
-                  protection", "s/mime", "ipsec end system", "ipsec tunnel", "ipsec
-                  user", "timestamping", "ocsp signing", "microsoft sgc", "netscape
-                  sgc"'
-                type: string
-                enum:
-                  - signing
-                  - digital signature
-                  - content commitment
-                  - key encipherment
-                  - key agreement
-                  - data encipherment
-                  - cert sign
-                  - crl sign
-                  - encipher only
-                  - decipher only
-                  - any
-                  - server auth
-                  - client auth
-                  - code signing
-                  - email protection
-                  - s/mime
-                  - ipsec end system
-                  - ipsec tunnel
-                  - ipsec user
-                  - timestamping
-                  - ocsp signing
-                  - microsoft sgc
-                  - netscape sgc
-        status:
-          description: CertificateStatus defines the observed state of CertificateRequest
-            and resulting signed certificate.
-          type: object
-          properties:
-            ca:
-              description: Byte slice containing the PEM encoded certificate authority
-                of the signed certificate.
-              type: string
-              format: byte
-            certificate:
-              description: Byte slice containing a PEM encoded signed certificate
-                resulting from the given certificate signing request.
-              type: string
-              format: byte
-            conditions:
-              type: array
-              items:
-                description: CertificateRequestCondition contains condition information
-                  for a CertificateRequest.
-                type: object
-                required:
-                  - status
-                  - type
-                properties:
-                  lastTransitionTime:
-                    description: LastTransitionTime is the timestamp corresponding
-                      to the last status change of this condition.
-                    type: string
-                    format: date-time
-                  message:
-                    description: Message is a human readable description of the details
-                      of the last transition, complementing reason.
-                    type: string
-                  reason:
-                    description: Reason is a brief machine readable explanation for
-                      the condition's last transition.
-                    type: string
-                  status:
-                    description: Status of the condition, one of ('True', 'False',
-                      'Unknown').
+                isCA:
+                  description: IsCA will mark the resulting certificate as valid for signing.
+                    This implies that the 'cert sign' usage is set
+                  type: boolean
+                issuerRef:
+                  description: IssuerRef is a reference to the issuer for this CertificateRequest.  If
+                    the 'kind' field is not set, or set to 'Issuer', an Issuer resource
+                    with the given name in the same namespace as the CertificateRequest
+                    will be used.  If the 'kind' field is set to 'ClusterIssuer', a ClusterIssuer
+                    with the provided name will be used. The 'name' field in this stanza
+                    is required at all times. The group field refers to the API group
+                    of the issuer which defaults to 'cert-manager.io' if empty.
+                  type: object
+                  required:
+                    - name
+                  properties:
+                    group:
+                      type: string
+                    kind:
+                      type: string
+                    name:
+                      type: string
+                usages:
+                  description: Usages is the set of x509 actions that are enabled for
+                    a given key. Defaults are ('digital signature', 'key encipherment')
+                    if empty
+                  type: array
+                  items:
+                    description: 'KeyUsage specifies valid usage contexts for keys. See:
+                      https://tools.ietf.org/html/rfc5280#section-4.2.1.3      https://tools.ietf.org/html/rfc5280#section-4.2.1.12
+                      Valid KeyUsage values are as follows: "signing", "digital signature",
+                      "content commitment", "key encipherment", "key agreement", "data
+                      encipherment", "cert sign", "crl sign", "encipher only", "decipher
+                      only", "any", "server auth", "client auth", "code signing", "email
+                      protection", "s/mime", "ipsec end system", "ipsec tunnel", "ipsec
+                      user", "timestamping", "ocsp signing", "microsoft sgc", "netscape
+                      sgc"'
                     type: string
                     enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                  type:
-                    description: Type of the condition, currently ('Ready', 'InvalidRequest').
-                    type: string
-            failureTime:
-              description: FailureTime stores the time that this CertificateRequest
-                failed. This is used to influence garbage collection and back-off.
+                      - signing
+                      - digital signature
+                      - content commitment
+                      - key encipherment
+                      - key agreement
+                      - data encipherment
+                      - cert sign
+                      - crl sign
+                      - encipher only
+                      - decipher only
+                      - any
+                      - server auth
+                      - client auth
+                      - code signing
+                      - email protection
+                      - s/mime
+                      - ipsec end system
+                      - ipsec tunnel
+                      - ipsec user
+                      - timestamping
+                      - ocsp signing
+                      - microsoft sgc
+                      - netscape sgc
+            status:
+              description: CertificateStatus defines the observed state of CertificateRequest
+                and resulting signed certificate.
+              type: object
+              properties:
+                ca:
+                  description: Byte slice containing the PEM encoded certificate authority
+                    of the signed certificate.
+                  type: string
+                  format: byte
+                certificate:
+                  description: Byte slice containing a PEM encoded signed certificate
+                    resulting from the given certificate signing request.
+                  type: string
+                  format: byte
+                conditions:
+                  type: array
+                  items:
+                    description: CertificateRequestCondition contains condition information
+                      for a CertificateRequest.
+                    type: object
+                    required:
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: LastTransitionTime is the timestamp corresponding
+                          to the last status change of this condition.
+                        type: string
+                        format: date-time
+                      message:
+                        description: Message is a human readable description of the details
+                          of the last transition, complementing reason.
+                        type: string
+                      reason:
+                        description: Reason is a brief machine readable explanation for
+                          the condition's last transition.
+                        type: string
+                      status:
+                        description: Status of the condition, one of ('True', 'False',
+                          'Unknown').
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      type:
+                        description: Type of the condition, currently ('Ready', 'InvalidRequest').
+                        type: string
+                failureTime:
+                  description: FailureTime stores the time that this CertificateRequest
+                    failed. This is used to influence garbage collection and back-off.
+                  type: string
+                  format: date-time
+      served: true
+      storage: true
+      additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .spec.issuerRef.name
+          name: Issuer
+          priority: 1
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].message
+          name: Status
+          priority: 1
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          description: CreationTimestamp is a timestamp representing the server time when
+            this object was created. It is not guaranteed to be set in happens-before order
+            across separate operations. Clients may not set this value. It is represented
+            in RFC3339 form and is in UTC.
+          name: Age
+          type: date
+      subresources:
+        status: { }
+    - name: v1alpha3
+      schema:
+        openAPIV3Schema:
+          description: CertificateRequest is a type to represent a Certificate Signing
+            Request
+          type: object
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+                of an object. Servers should convert recognized schemas to the latest
+                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
               type: string
-              format: date-time
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+                object represents. Servers may infer this from the endpoint the client
+                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: CertificateRequestSpec defines the desired state of CertificateRequest
+              type: object
+              required:
+                - csr
+                - issuerRef
+              properties:
+                csr:
+                  description: Byte slice containing the PEM encoded CertificateSigningRequest
+                  type: string
+                  format: byte
+                duration:
+                  description: Requested certificate default Duration
+                  type: string
+                isCA:
+                  description: IsCA will mark the resulting certificate as valid for signing.
+                    This implies that the 'cert sign' usage is set
+                  type: boolean
+                issuerRef:
+                  description: IssuerRef is a reference to the issuer for this CertificateRequest.  If
+                    the 'kind' field is not set, or set to 'Issuer', an Issuer resource
+                    with the given name in the same namespace as the CertificateRequest
+                    will be used.  If the 'kind' field is set to 'ClusterIssuer', a ClusterIssuer
+                    with the provided name will be used. The 'name' field in this stanza
+                    is required at all times. The group field refers to the API group
+                    of the issuer which defaults to 'cert-manager.io' if empty.
+                  type: object
+                  required:
+                    - name
+                  properties:
+                    group:
+                      type: string
+                    kind:
+                      type: string
+                    name:
+                      type: string
+                usages:
+                  description: Usages is the set of x509 actions that are enabled for
+                    a given key. Defaults are ('digital signature', 'key encipherment')
+                    if empty
+                  type: array
+                  items:
+                    description: 'KeyUsage specifies valid usage contexts for keys. See:
+                      https://tools.ietf.org/html/rfc5280#section-4.2.1.3      https://tools.ietf.org/html/rfc5280#section-4.2.1.12
+                      Valid KeyUsage values are as follows: "signing", "digital signature",
+                      "content commitment", "key encipherment", "key agreement", "data
+                      encipherment", "cert sign", "crl sign", "encipher only", "decipher
+                      only", "any", "server auth", "client auth", "code signing", "email
+                      protection", "s/mime", "ipsec end system", "ipsec tunnel", "ipsec
+                      user", "timestamping", "ocsp signing", "microsoft sgc", "netscape
+                      sgc"'
+                    type: string
+                    enum:
+                      - signing
+                      - digital signature
+                      - content commitment
+                      - key encipherment
+                      - key agreement
+                      - data encipherment
+                      - cert sign
+                      - crl sign
+                      - encipher only
+                      - decipher only
+                      - any
+                      - server auth
+                      - client auth
+                      - code signing
+                      - email protection
+                      - s/mime
+                      - ipsec end system
+                      - ipsec tunnel
+                      - ipsec user
+                      - timestamping
+                      - ocsp signing
+                      - microsoft sgc
+                      - netscape sgc
+            status:
+              description: CertificateStatus defines the observed state of CertificateRequest
+                and resulting signed certificate.
+              type: object
+              properties:
+                ca:
+                  description: Byte slice containing the PEM encoded certificate authority
+                    of the signed certificate.
+                  type: string
+                  format: byte
+                certificate:
+                  description: Byte slice containing a PEM encoded signed certificate
+                    resulting from the given certificate signing request.
+                  type: string
+                  format: byte
+                conditions:
+                  type: array
+                  items:
+                    description: CertificateRequestCondition contains condition information
+                      for a CertificateRequest.
+                    type: object
+                    required:
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: LastTransitionTime is the timestamp corresponding
+                          to the last status change of this condition.
+                        type: string
+                        format: date-time
+                      message:
+                        description: Message is a human readable description of the details
+                          of the last transition, complementing reason.
+                        type: string
+                      reason:
+                        description: Reason is a brief machine readable explanation for
+                          the condition's last transition.
+                        type: string
+                      status:
+                        description: Status of the condition, one of ('True', 'False',
+                          'Unknown').
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      type:
+                        description: Type of the condition, currently ('Ready', 'InvalidRequest').
+                        type: string
+                failureTime:
+                  description: FailureTime stores the time that this CertificateRequest
+                    failed. This is used to influence garbage collection and back-off.
+                  type: string
+                  format: date-time
+      served: true
+      storage: false
+      additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .spec.issuerRef.name
+          name: Issuer
+          priority: 1
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].message
+          name: Status
+          priority: 1
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          description: CreationTimestamp is a timestamp representing the server time when
+            this object was created. It is not guaranteed to be set in happens-before order
+            across separate operations. Clients may not set this value. It is represented
+            in RFC3339 form and is in UTC.
+          name: Age
+          type: date
+      subresources:
+        status: { }

--- a/config/test/crd/cert-manager/cert-manager.io_certificates.yaml
+++ b/config/test/crd/cert-manager/cert-manager.io_certificates.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: certificates.cert-manager.io
@@ -25,28 +25,6 @@ metadata:
     app.kubernetes.io/managed-by: 'Helm'
     helm.sh/chart: 'cert-manager-v0.15.1'
 spec:
-  additionalPrinterColumns:
-    - JSONPath: .status.conditions[?(@.type=="Ready")].status
-      name: Ready
-      type: string
-    - JSONPath: .spec.secretName
-      name: Secret
-      type: string
-    - JSONPath: .spec.issuerRef.name
-      name: Issuer
-      priority: 1
-      type: string
-    - JSONPath: .status.conditions[?(@.type=="Ready")].message
-      name: Status
-      priority: 1
-      type: string
-    - JSONPath: .metadata.creationTimestamp
-      description: CreationTimestamp is a timestamp representing the server time when
-        this object was created. It is not guaranteed to be set in happens-before order
-        across separate operations. Clients may not set this value. It is represented
-        in RFC3339 form and is in UTC.
-      name: Age
-      type: date
   group: cert-manager.io
   preserveUnknownFields: false
   names:
@@ -58,14 +36,34 @@ spec:
       - certs
     singular: certificate
   scope: Namespaced
-  subresources:
-    status: {}
   versions:
     - name: v1alpha2
       served: true
       storage: true
-      "schema":
-        "openAPIV3Schema":
+      additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .spec.secretName
+          name: Secret
+          type: string
+        - jsonPath: .spec.issuerRef.name
+          name: Issuer
+          priority: 1
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].message
+          name: Status
+          priority: 1
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          description: CreationTimestamp is a timestamp representing the server time when
+            this object was created. It is not guaranteed to be set in happens-before order
+            across separate operations. Clients may not set this value. It is represented
+            in RFC3339 form and is in UTC.
+          name: Age
+          type: date
+      schema:
+        openAPIV3Schema:
           description: Certificate is a type to represent a Certificate from ACME
           type: object
           properties:
@@ -757,3 +755,5 @@ spec:
                   issuance by checking if the revision value in the annotation is
                   greater than this field."
                   type: integer
+      subresources:
+        status: { }

--- a/config/test/crd/cert-manager/cert-manager.io_clusterissuers.yaml
+++ b/config/test/crd/cert-manager/cert-manager.io_clusterissuers.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clusterissuers.cert-manager.io
@@ -25,21 +25,6 @@ metadata:
     app.kubernetes.io/managed-by: 'Helm'
     helm.sh/chart: 'cert-manager-v0.15.1'
 spec:
-  additionalPrinterColumns:
-    - JSONPath: .status.conditions[?(@.type=="Ready")].status
-      name: Ready
-      type: string
-    - JSONPath: .status.conditions[?(@.type=="Ready")].message
-      name: Status
-      priority: 1
-      type: string
-    - JSONPath: .metadata.creationTimestamp
-      description: CreationTimestamp is a timestamp representing the server time when
-        this object was created. It is not guaranteed to be set in happens-before order
-        across separate operations. Clients may not set this value. It is represented
-        in RFC3339 form and is in UTC.
-      name: Age
-      type: date
   group: cert-manager.io
   preserveUnknownFields: false
   names:
@@ -48,955 +33,1084 @@ spec:
     plural: clusterissuers
     singular: clusterissuer
   scope: Cluster
-  subresources:
-    status: {}
   versions:
     - name: v1alpha2
-      served: true
-      storage: true
-    - name: v1alpha3
-      served: true
-      storage: false
-  "validation":
-    "openAPIV3Schema":
-      type: object
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: IssuerSpec is the specification of an Issuer. This includes
-            any configuration required for the issuer.
+      schema:
+        openAPIV3Schema:
           type: object
           properties:
-            acme:
-              description: ACMEIssuer contains the specification for an ACME issuer
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
               type: object
-              required:
-                - privateKeySecretRef
-                - server
+            spec:
+              description: IssuerSpec is the specification of an Issuer. This includes
+                any configuration required for the issuer.
+              type: object
               properties:
-                email:
-                  description: Email is the email for this account
-                  type: string
-                externalAccountBinding:
-                  description: ExternalAccountBinding is a reference to a CA external
-                    account of the ACME server.
+                acme:
+                  description: ACMEIssuer contains the specification for an ACME issuer
                   type: object
                   required:
-                    - keyAlgorithm
-                    - keyID
-                    - keySecretRef
+                    - privateKeySecretRef
+                    - server
                   properties:
-                    keyAlgorithm:
-                      description: keyAlgorithm is the MAC key algorithm that the
-                        key is used for. Valid values are "HS256", "HS384" and "HS512".
+                    email:
+                      description: Email is the email for this account
                       type: string
-                      enum:
-                        - HS256
-                        - HS384
-                        - HS512
-                    keyID:
-                      description: keyID is the ID of the CA key that the External
-                        Account is bound to.
-                      type: string
-                    keySecretRef:
-                      description: keySecretRef is a Secret Key Selector referencing
-                        a data item in a Kubernetes Secret which holds the symmetric
-                        MAC key of the External Account Binding. The `key` is the
-                        index string that is paired with the key data in the Secret
-                        and should not be confused with the key data itself, or indeed
-                        with the External Account Binding keyID above. The secret
-                        key stored in the Secret **must** be un-padded, base64 URL
-                        encoded data.
+                    externalAccountBinding:
+                      description: ExternalAccountBinding is a reference to a CA external
+                        account of the ACME server.
+                      type: object
+                      required:
+                        - keyAlgorithm
+                        - keyID
+                        - keySecretRef
+                      properties:
+                        keyAlgorithm:
+                          description: keyAlgorithm is the MAC key algorithm that the
+                            key is used for. Valid values are "HS256", "HS384" and "HS512".
+                          type: string
+                          enum:
+                            - HS256
+                            - HS384
+                            - HS512
+                        keyID:
+                          description: keyID is the ID of the CA key that the External
+                            Account is bound to.
+                          type: string
+                        keySecretRef:
+                          description: keySecretRef is a Secret Key Selector referencing
+                            a data item in a Kubernetes Secret which holds the symmetric
+                            MAC key of the External Account Binding. The `key` is the
+                            index string that is paired with the key data in the Secret
+                            and should not be confused with the key data itself, or indeed
+                            with the External Account Binding keyID above. The secret
+                            key stored in the Secret **must** be un-padded, base64 URL
+                            encoded data.
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            key:
+                              description: The key of the secret to select from. Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                    privateKeySecretRef:
+                      description: PrivateKey is the name of a secret containing the private
+                        key for this user account.
                       type: object
                       required:
                         - name
                       properties:
                         key:
-                          description: The key of the secret to select from. Must
-                            be a valid secret key.
+                          description: The key of the secret to select from. Must be a
+                            valid secret key.
                           type: string
                         name:
                           description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
                           type: string
-                privateKeySecretRef:
-                  description: PrivateKey is the name of a secret containing the private
-                    key for this user account.
-                  type: object
-                  required:
-                    - name
-                  properties:
-                    key:
-                      description: The key of the secret to select from. Must be a
-                        valid secret key.
+                    server:
+                      description: Server is the ACME server URL
                       type: string
-                    name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        TODO: Add other useful fields. apiVersion, kind, uid?'
-                      type: string
-                server:
-                  description: Server is the ACME server URL
-                  type: string
-                skipTLSVerify:
-                  description: If true, skip verifying the ACME server TLS certificate
-                  type: boolean
-                solvers:
-                  description: Solvers is a list of challenge solvers that will be
-                    used to solve ACME challenges for the matching domains.
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      dns01:
+                    skipTLSVerify:
+                      description: If true, skip verifying the ACME server TLS certificate
+                      type: boolean
+                    solvers:
+                      description: Solvers is a list of challenge solvers that will be
+                        used to solve ACME challenges for the matching domains.
+                      type: array
+                      items:
                         type: object
                         properties:
-                          acmedns:
-                            description: ACMEIssuerDNS01ProviderAcmeDNS is a structure
-                              containing the configuration for ACME-DNS servers
+                          dns01:
                             type: object
-                            required:
-                              - accountSecretRef
-                              - host
                             properties:
-                              accountSecretRef:
+                              acmedns:
+                                description: ACMEIssuerDNS01ProviderAcmeDNS is a structure
+                                  containing the configuration for ACME-DNS servers
                                 type: object
                                 required:
-                                  - name
+                                  - accountSecretRef
+                                  - host
                                 properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
+                                  accountSecretRef:
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.
+                                          Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion, kind,
+                                            uid?'
+                                        type: string
+                                  host:
                                     type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                              host:
-                                type: string
-                          akamai:
-                            description: ACMEIssuerDNS01ProviderAkamai is a structure
-                              containing the DNS configuration for Akamai DNS—Zone
-                              Record Management API
-                            type: object
-                            required:
-                              - accessTokenSecretRef
-                              - clientSecretSecretRef
-                              - clientTokenSecretRef
-                              - serviceConsumerDomain
-                            properties:
-                              accessTokenSecretRef:
+                              akamai:
+                                description: ACMEIssuerDNS01ProviderAkamai is a structure
+                                  containing the DNS configuration for Akamai DNS—Zone
+                                  Record Management API
                                 type: object
                                 required:
-                                  - name
+                                  - accessTokenSecretRef
+                                  - clientSecretSecretRef
+                                  - clientTokenSecretRef
+                                  - serviceConsumerDomain
                                 properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
+                                  accessTokenSecretRef:
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.
+                                          Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion, kind,
+                                            uid?'
+                                        type: string
+                                  clientSecretSecretRef:
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.
+                                          Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion, kind,
+                                            uid?'
+                                        type: string
+                                  clientTokenSecretRef:
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.
+                                          Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion, kind,
+                                            uid?'
+                                        type: string
+                                  serviceConsumerDomain:
                                     type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                              clientSecretSecretRef:
+                              azuredns:
+                                description: ACMEIssuerDNS01ProviderAzureDNS is a structure
+                                  containing the configuration for Azure DNS
                                 type: object
                                 required:
-                                  - name
+                                  - resourceGroupName
+                                  - subscriptionID
                                 properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
+                                  clientID:
+                                    description: if both this and ClientSecret are left
+                                      unset MSI will be used
                                     type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                  clientSecretSecretRef:
+                                    description: if both this and ClientID are left unset
+                                      MSI will be used
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.
+                                          Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion, kind,
+                                            uid?'
+                                        type: string
+                                  environment:
                                     type: string
-                              clientTokenSecretRef:
+                                    enum:
+                                      - AzurePublicCloud
+                                      - AzureChinaCloud
+                                      - AzureGermanCloud
+                                      - AzureUSGovernmentCloud
+                                  hostedZoneName:
+                                    type: string
+                                  resourceGroupName:
+                                    type: string
+                                  subscriptionID:
+                                    type: string
+                                  tenantID:
+                                    description: when specifying ClientID and ClientSecret
+                                      then this field is also needed
+                                    type: string
+                              clouddns:
+                                description: ACMEIssuerDNS01ProviderCloudDNS is a structure
+                                  containing the DNS configuration for Google Cloud DNS
                                 type: object
                                 required:
-                                  - name
+                                  - project
                                 properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
+                                  project:
                                     type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                              serviceConsumerDomain:
-                                type: string
-                          azuredns:
-                            description: ACMEIssuerDNS01ProviderAzureDNS is a structure
-                              containing the configuration for Azure DNS
-                            type: object
-                            required:
-                              - resourceGroupName
-                              - subscriptionID
-                            properties:
-                              clientID:
-                                description: if both this and ClientSecret are left
-                                  unset MSI will be used
-                                type: string
-                              clientSecretSecretRef:
-                                description: if both this and ClientID are left unset
-                                  MSI will be used
+                                  serviceAccountSecretRef:
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.
+                                          Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion, kind,
+                                            uid?'
+                                        type: string
+                              cloudflare:
+                                description: ACMEIssuerDNS01ProviderCloudflare is a structure
+                                  containing the DNS configuration for Cloudflare
                                 type: object
                                 required:
-                                  - name
+                                  - email
                                 properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
+                                  apiKeySecretRef:
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.
+                                          Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion, kind,
+                                            uid?'
+                                        type: string
+                                  apiTokenSecretRef:
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.
+                                          Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion, kind,
+                                            uid?'
+                                        type: string
+                                  email:
                                     type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                              environment:
+                              cnameStrategy:
+                                description: CNAMEStrategy configures how the DNS01 provider
+                                  should handle CNAME records when found in DNS zones.
                                 type: string
                                 enum:
-                                  - AzurePublicCloud
-                                  - AzureChinaCloud
-                                  - AzureGermanCloud
-                                  - AzureUSGovernmentCloud
-                              hostedZoneName:
-                                type: string
-                              resourceGroupName:
-                                type: string
-                              subscriptionID:
-                                type: string
-                              tenantID:
-                                description: when specifying ClientID and ClientSecret
-                                  then this field is also needed
-                                type: string
-                          clouddns:
-                            description: ACMEIssuerDNS01ProviderCloudDNS is a structure
-                              containing the DNS configuration for Google Cloud DNS
-                            type: object
-                            required:
-                              - project
-                            properties:
-                              project:
-                                type: string
-                              serviceAccountSecretRef:
+                                  - None
+                                  - Follow
+                              digitalocean:
+                                description: ACMEIssuerDNS01ProviderDigitalOcean is a
+                                  structure containing the DNS configuration for DigitalOcean
+                                  Domains
                                 type: object
                                 required:
-                                  - name
+                                  - tokenSecretRef
                                 properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                          cloudflare:
-                            description: ACMEIssuerDNS01ProviderCloudflare is a structure
-                              containing the DNS configuration for Cloudflare
-                            type: object
-                            required:
-                              - email
-                            properties:
-                              apiKeySecretRef:
+                                  tokenSecretRef:
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.
+                                          Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion, kind,
+                                            uid?'
+                                        type: string
+                              rfc2136:
+                                description: ACMEIssuerDNS01ProviderRFC2136 is a structure
+                                  containing the configuration for RFC2136 DNS
                                 type: object
                                 required:
-                                  - name
+                                  - nameserver
                                 properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
+                                  nameserver:
+                                    description: The IP address or hostname of an authoritative
+                                      DNS server supporting RFC2136 in the form host:port.
+                                      If the host is an IPv6 address it must be enclosed
+                                      in square brackets (e.g [2001:db8::1]) ; port is
+                                      optional. This field is required.
                                     type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                  tsigAlgorithm:
+                                    description: 'The TSIG Algorithm configured in the
+                                        DNS supporting RFC2136. Used only when ``tsigSecretSecretRef``
+                                        and ``tsigKeyName`` are defined. Supported values
+                                        are (case-insensitive): ``HMACMD5`` (default), ``HMACSHA1``,
+                                        ``HMACSHA256`` or ``HMACSHA512``.'
                                     type: string
-                              apiTokenSecretRef:
+                                  tsigKeyName:
+                                    description: The TSIG Key name configured in the DNS.
+                                      If ``tsigSecretSecretRef`` is defined, this field
+                                      is required.
+                                    type: string
+                                  tsigSecretSecretRef:
+                                    description: The name of the secret containing the
+                                      TSIG value. If ``tsigKeyName`` is defined, this
+                                      field is required.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.
+                                          Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion, kind,
+                                            uid?'
+                                        type: string
+                              route53:
+                                description: ACMEIssuerDNS01ProviderRoute53 is a structure
+                                  containing the Route 53 configuration for AWS
                                 type: object
                                 required:
-                                  - name
+                                  - region
                                 properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
+                                  accessKeyID:
+                                    description: 'The AccessKeyID is used for authentication.
+                                        If not set we fall-back to using env vars, shared
+                                        credentials file or AWS Instance metadata see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
                                     type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                  hostedZoneID:
+                                    description: If set, the provider will manage only
+                                      this zone in Route53 and will not do an lookup using
+                                      the route53:ListHostedZonesByName api call.
                                     type: string
-                              email:
-                                type: string
-                          cnameStrategy:
-                            description: CNAMEStrategy configures how the DNS01 provider
-                              should handle CNAME records when found in DNS zones.
-                            type: string
-                            enum:
-                              - None
-                              - Follow
-                          digitalocean:
-                            description: ACMEIssuerDNS01ProviderDigitalOcean is a
-                              structure containing the DNS configuration for DigitalOcean
-                              Domains
-                            type: object
-                            required:
-                              - tokenSecretRef
-                            properties:
-                              tokenSecretRef:
+                                  region:
+                                    description: Always set the region when using AccessKeyID
+                                      and SecretAccessKey
+                                    type: string
+                                  role:
+                                    description: Role is a Role ARN which the Route53
+                                      provider will assume using either the explicit credentials
+                                      AccessKeyID/SecretAccessKey or the inferred credentials
+                                      from environment variables, shared credentials file
+                                      or AWS Instance metadata
+                                    type: string
+                                  secretAccessKeySecretRef:
+                                    description: The SecretAccessKey is used for authentication.
+                                      If not set we fall-back to using env vars, shared
+                                      credentials file or AWS Instance metadata https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.
+                                          Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion, kind,
+                                            uid?'
+                                        type: string
+                              webhook:
+                                description: ACMEIssuerDNS01ProviderWebhook specifies
+                                  configuration for a webhook DNS01 provider, including
+                                  where to POST ChallengePayload resources.
                                 type: object
                                 required:
-                                  - name
+                                  - groupName
+                                  - solverName
                                 properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
+                                  config:
+                                    description: Additional configuration that should
+                                      be passed to the webhook apiserver when challenges
+                                      are processed. This can contain arbitrary JSON data.
+                                      Secret values should not be specified in this stanza.
+                                      If secret values are needed (e.g. credentials for
+                                      a DNS service), you should use a SecretKeySelector
+                                      to reference a Secret resource. For details on the
+                                      schema of this field, consult the webhook provider
+                                      implementation's documentation.
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  groupName:
+                                    description: The API group name that should be used
+                                      when POSTing ChallengePayload resources to the webhook
+                                      apiserver. This should be the same as the GroupName
+                                      specified in the webhook provider implementation.
                                     type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                  solverName:
+                                    description: The name of the solver to use, as defined
+                                      in the webhook provider implementation. This will
+                                      typically be the name of the provider, e.g. 'cloudflare'.
                                     type: string
-                          rfc2136:
-                            description: ACMEIssuerDNS01ProviderRFC2136 is a structure
-                              containing the configuration for RFC2136 DNS
-                            type: object
-                            required:
-                              - nameserver
-                            properties:
-                              nameserver:
-                                description: The IP address or hostname of an authoritative
-                                  DNS server supporting RFC2136 in the form host:port.
-                                  If the host is an IPv6 address it must be enclosed
-                                  in square brackets (e.g [2001:db8::1]) ; port is
-                                  optional. This field is required.
-                                type: string
-                              tsigAlgorithm:
-                                description: 'The TSIG Algorithm configured in the
-                                  DNS supporting RFC2136. Used only when ``tsigSecretSecretRef``
-                                  and ``tsigKeyName`` are defined. Supported values
-                                  are (case-insensitive): ``HMACMD5`` (default), ``HMACSHA1``,
-                                  ``HMACSHA256`` or ``HMACSHA512``.'
-                                type: string
-                              tsigKeyName:
-                                description: The TSIG Key name configured in the DNS.
-                                  If ``tsigSecretSecretRef`` is defined, this field
-                                  is required.
-                                type: string
-                              tsigSecretSecretRef:
-                                description: The name of the secret containing the
-                                  TSIG value. If ``tsigKeyName`` is defined, this
-                                  field is required.
-                                type: object
-                                required:
-                                  - name
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                          route53:
-                            description: ACMEIssuerDNS01ProviderRoute53 is a structure
-                              containing the Route 53 configuration for AWS
-                            type: object
-                            required:
-                              - region
-                            properties:
-                              accessKeyID:
-                                description: 'The AccessKeyID is used for authentication.
-                                  If not set we fall-back to using env vars, shared
-                                  credentials file or AWS Instance metadata see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
-                                type: string
-                              hostedZoneID:
-                                description: If set, the provider will manage only
-                                  this zone in Route53 and will not do an lookup using
-                                  the route53:ListHostedZonesByName api call.
-                                type: string
-                              region:
-                                description: Always set the region when using AccessKeyID
-                                  and SecretAccessKey
-                                type: string
-                              role:
-                                description: Role is a Role ARN which the Route53
-                                  provider will assume using either the explicit credentials
-                                  AccessKeyID/SecretAccessKey or the inferred credentials
-                                  from environment variables, shared credentials file
-                                  or AWS Instance metadata
-                                type: string
-                              secretAccessKeySecretRef:
-                                description: The SecretAccessKey is used for authentication.
-                                  If not set we fall-back to using env vars, shared
-                                  credentials file or AWS Instance metadata https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
-                                type: object
-                                required:
-                                  - name
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                          webhook:
-                            description: ACMEIssuerDNS01ProviderWebhook specifies
-                              configuration for a webhook DNS01 provider, including
-                              where to POST ChallengePayload resources.
-                            type: object
-                            required:
-                              - groupName
-                              - solverName
-                            properties:
-                              config:
-                                description: Additional configuration that should
-                                  be passed to the webhook apiserver when challenges
-                                  are processed. This can contain arbitrary JSON data.
-                                  Secret values should not be specified in this stanza.
-                                  If secret values are needed (e.g. credentials for
-                                  a DNS service), you should use a SecretKeySelector
-                                  to reference a Secret resource. For details on the
-                                  schema of this field, consult the webhook provider
-                                  implementation's documentation.
-                                x-kubernetes-preserve-unknown-fields: true
-                              groupName:
-                                description: The API group name that should be used
-                                  when POSTing ChallengePayload resources to the webhook
-                                  apiserver. This should be the same as the GroupName
-                                  specified in the webhook provider implementation.
-                                type: string
-                              solverName:
-                                description: The name of the solver to use, as defined
-                                  in the webhook provider implementation. This will
-                                  typically be the name of the provider, e.g. 'cloudflare'.
-                                type: string
-                      http01:
-                        description: ACMEChallengeSolverHTTP01 contains configuration
-                          detailing how to solve HTTP01 challenges within a Kubernetes
-                          cluster. Typically this is accomplished through creating
-                          'routes' of some description that configure ingress controllers
-                          to direct traffic to 'solver pods', which are responsible
-                          for responding to the ACME server's HTTP requests.
-                        type: object
-                        properties:
-                          ingress:
-                            description: The ingress based HTTP01 challenge solver
-                              will solve challenges by creating or modifying Ingress
-                              resources in order to route requests for '/.well-known/acme-challenge/XYZ'
-                              to 'challenge solver' pods that are provisioned by cert-manager
-                              for each Challenge to be completed.
+                          http01:
+                            description: ACMEChallengeSolverHTTP01 contains configuration
+                              detailing how to solve HTTP01 challenges within a Kubernetes
+                              cluster. Typically this is accomplished through creating
+                              'routes' of some description that configure ingress controllers
+                              to direct traffic to 'solver pods', which are responsible
+                              for responding to the ACME server's HTTP requests.
                             type: object
                             properties:
-                              class:
-                                description: The ingress class to use when creating
-                                  Ingress resources to solve ACME challenges that
-                                  use this challenge solver. Only one of 'class' or
-                                  'name' may be specified.
-                                type: string
-                              ingressTemplate:
-                                description: Optional ingress template used to configure
-                                  the ACME challenge solver ingress used for HTTP01
-                                  challenges
+                              ingress:
+                                description: The ingress based HTTP01 challenge solver
+                                  will solve challenges by creating or modifying Ingress
+                                  resources in order to route requests for '/.well-known/acme-challenge/XYZ'
+                                  to 'challenge solver' pods that are provisioned by cert-manager
+                                  for each Challenge to be completed.
                                 type: object
                                 properties:
-                                  metadata:
-                                    description: ObjectMeta overrides for the ingress
-                                      used to solve HTTP01 challenges. Only the 'labels'
-                                      and 'annotations' fields may be set. If labels
-                                      or annotations overlap with in-built values,
-                                      the values here will override the in-built values.
+                                  class:
+                                    description: The ingress class to use when creating
+                                      Ingress resources to solve ACME challenges that
+                                      use this challenge solver. Only one of 'class' or
+                                      'name' may be specified.
+                                    type: string
+                                  ingressTemplate:
+                                    description: Optional ingress template used to configure
+                                      the ACME challenge solver ingress used for HTTP01
+                                      challenges
                                     type: object
                                     properties:
-                                      annotations:
-                                        description: Annotations that should be added
-                                          to the created ACME HTTP01 solver ingress.
-                                        type: object
-                                        additionalProperties:
-                                          type: string
-                                      labels:
-                                        description: Labels that should be added to
-                                          the created ACME HTTP01 solver ingress.
-                                        type: object
-                                        additionalProperties:
-                                          type: string
-                              name:
-                                description: The name of the ingress resource that
-                                  should have ACME challenge solving routes inserted
-                                  into it in order to solve HTTP01 challenges. This
-                                  is typically used in conjunction with ingress controllers
-                                  like ingress-gce, which maintains a 1:1 mapping
-                                  between external IPs and ingress resources.
-                                type: string
-                              podTemplate:
-                                description: Optional pod template used to configure
-                                  the ACME challenge solver pods used for HTTP01 challenges
-                                type: object
-                                properties:
-                                  metadata:
-                                    description: ObjectMeta overrides for the pod
-                                      used to solve HTTP01 challenges. Only the 'labels'
-                                      and 'annotations' fields may be set. If labels
-                                      or annotations overlap with in-built values,
-                                      the values here will override the in-built values.
-                                    type: object
-                                    properties:
-                                      annotations:
-                                        description: Annotations that should be added
-                                          to the create ACME HTTP01 solver pods.
-                                        type: object
-                                        additionalProperties:
-                                          type: string
-                                      labels:
-                                        description: Labels that should be added to
-                                          the created ACME HTTP01 solver pods.
-                                        type: object
-                                        additionalProperties:
-                                          type: string
-                                  spec:
-                                    description: PodSpec defines overrides for the
-                                      HTTP01 challenge solver pod. Only the 'nodeSelector',
-                                      'affinity' and 'tolerations' fields are supported
-                                      currently. All other fields will be ignored.
-                                    type: object
-                                    properties:
-                                      affinity:
-                                        description: If specified, the pod's scheduling
-                                          constraints
+                                      metadata:
+                                        description: ObjectMeta overrides for the ingress
+                                          used to solve HTTP01 challenges. Only the 'labels'
+                                          and 'annotations' fields may be set. If labels
+                                          or annotations overlap with in-built values,
+                                          the values here will override the in-built values.
                                         type: object
                                         properties:
-                                          nodeAffinity:
-                                            description: Describes node affinity scheduling
-                                              rules for the pod.
+                                          annotations:
+                                            description: Annotations that should be added
+                                              to the created ACME HTTP01 solver ingress.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                          labels:
+                                            description: Labels that should be added to
+                                              the created ACME HTTP01 solver ingress.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                  name:
+                                    description: The name of the ingress resource that
+                                      should have ACME challenge solving routes inserted
+                                      into it in order to solve HTTP01 challenges. This
+                                      is typically used in conjunction with ingress controllers
+                                      like ingress-gce, which maintains a 1:1 mapping
+                                      between external IPs and ingress resources.
+                                    type: string
+                                  podTemplate:
+                                    description: Optional pod template used to configure
+                                      the ACME challenge solver pods used for HTTP01 challenges
+                                    type: object
+                                    properties:
+                                      metadata:
+                                        description: ObjectMeta overrides for the pod
+                                          used to solve HTTP01 challenges. Only the 'labels'
+                                          and 'annotations' fields may be set. If labels
+                                          or annotations overlap with in-built values,
+                                          the values here will override the in-built values.
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            description: Annotations that should be added
+                                              to the create ACME HTTP01 solver pods.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                          labels:
+                                            description: Labels that should be added to
+                                              the created ACME HTTP01 solver pods.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                      spec:
+                                        description: PodSpec defines overrides for the
+                                          HTTP01 challenge solver pod. Only the 'nodeSelector',
+                                          'affinity' and 'tolerations' fields are supported
+                                          currently. All other fields will be ignored.
+                                        type: object
+                                        properties:
+                                          affinity:
+                                            description: If specified, the pod's scheduling
+                                              constraints
                                             type: object
                                             properties:
-                                              preferredDuringSchedulingIgnoredDuringExecution:
-                                                description: The scheduler will prefer
-                                                  to schedule pods to nodes that satisfy
-                                                  the affinity expressions specified
-                                                  by this field, but it may choose
-                                                  a node that violates one or more
-                                                  of the expressions. The node that
-                                                  is most preferred is the one with
-                                                  the greatest sum of weights, i.e.
-                                                  for each node that meets all of
-                                                  the scheduling requirements (resource
-                                                  request, requiredDuringScheduling
-                                                  affinity expressions, etc.), compute
-                                                  a sum by iterating through the elements
-                                                  of this field and adding "weight"
-                                                  to the sum if the node matches the
-                                                  corresponding matchExpressions;
-                                                  the node(s) with the highest sum
-                                                  are the most preferred.
-                                                type: array
-                                                items:
-                                                  description: An empty preferred
-                                                    scheduling term matches all objects
-                                                    with implicit weight 0 (i.e. it's
-                                                    a no-op). A null preferred scheduling
-                                                    term matches no objects (i.e.
-                                                    is also a no-op).
-                                                  type: object
-                                                  required:
-                                                    - preference
-                                                    - weight
-                                                  properties:
-                                                    preference:
-                                                      description: A node selector
-                                                        term, associated with the
-                                                        corresponding weight.
-                                                      type: object
-                                                      properties:
-                                                        matchExpressions:
-                                                          description: A list of node
-                                                            selector requirements
-                                                            by node's labels.
-                                                          type: array
-                                                          items:
-                                                            description: A node selector
-                                                              requirement is a selector
-                                                              that contains values,
-                                                              a key, and an operator
-                                                              that relates the key
-                                                              and values.
-                                                            type: object
-                                                            required:
-                                                              - key
-                                                              - operator
-                                                            properties:
-                                                              key:
-                                                                description: The label
-                                                                  key that the selector
-                                                                  applies to.
-                                                                type: string
-                                                              operator:
-                                                                description: Represents
-                                                                  a key's relationship
-                                                                  to a set of values.
-                                                                  Valid operators
-                                                                  are In, NotIn, Exists,
-                                                                  DoesNotExist. Gt,
-                                                                  and Lt.
-                                                                type: string
-                                                              values:
-                                                                description: An array
-                                                                  of string values.
-                                                                  If the operator
-                                                                  is In or NotIn,
-                                                                  the values array
-                                                                  must be non-empty.
-                                                                  If the operator
-                                                                  is Exists or DoesNotExist,
-                                                                  the values array
-                                                                  must be empty. If
-                                                                  the operator is
-                                                                  Gt or Lt, the values
-                                                                  array must have
-                                                                  a single element,
-                                                                  which will be interpreted
-                                                                  as an integer. This
-                                                                  array is replaced
-                                                                  during a strategic
-                                                                  merge patch.
-                                                                type: array
-                                                                items:
-                                                                  type: string
-                                                        matchFields:
-                                                          description: A list of node
-                                                            selector requirements
-                                                            by node's fields.
-                                                          type: array
-                                                          items:
-                                                            description: A node selector
-                                                              requirement is a selector
-                                                              that contains values,
-                                                              a key, and an operator
-                                                              that relates the key
-                                                              and values.
-                                                            type: object
-                                                            required:
-                                                              - key
-                                                              - operator
-                                                            properties:
-                                                              key:
-                                                                description: The label
-                                                                  key that the selector
-                                                                  applies to.
-                                                                type: string
-                                                              operator:
-                                                                description: Represents
-                                                                  a key's relationship
-                                                                  to a set of values.
-                                                                  Valid operators
-                                                                  are In, NotIn, Exists,
-                                                                  DoesNotExist. Gt,
-                                                                  and Lt.
-                                                                type: string
-                                                              values:
-                                                                description: An array
-                                                                  of string values.
-                                                                  If the operator
-                                                                  is In or NotIn,
-                                                                  the values array
-                                                                  must be non-empty.
-                                                                  If the operator
-                                                                  is Exists or DoesNotExist,
-                                                                  the values array
-                                                                  must be empty. If
-                                                                  the operator is
-                                                                  Gt or Lt, the values
-                                                                  array must have
-                                                                  a single element,
-                                                                  which will be interpreted
-                                                                  as an integer. This
-                                                                  array is replaced
-                                                                  during a strategic
-                                                                  merge patch.
-                                                                type: array
-                                                                items:
-                                                                  type: string
-                                                    weight:
-                                                      description: Weight associated
-                                                        with matching the corresponding
-                                                        nodeSelectorTerm, in the range
-                                                        1-100.
-                                                      type: integer
-                                                      format: int32
-                                              requiredDuringSchedulingIgnoredDuringExecution:
-                                                description: If the affinity requirements
-                                                  specified by this field are not
-                                                  met at scheduling time, the pod
-                                                  will not be scheduled onto the node.
-                                                  If the affinity requirements specified
-                                                  by this field cease to be met at
-                                                  some point during pod execution
-                                                  (e.g. due to an update), the system
-                                                  may or may not try to eventually
-                                                  evict the pod from its node.
+                                              nodeAffinity:
+                                                description: Describes node affinity scheduling
+                                                  rules for the pod.
                                                 type: object
-                                                required:
-                                                  - nodeSelectorTerms
                                                 properties:
-                                                  nodeSelectorTerms:
-                                                    description: Required. A list
-                                                      of node selector terms. The
-                                                      terms are ORed.
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: The scheduler will prefer
+                                                      to schedule pods to nodes that satisfy
+                                                      the affinity expressions specified
+                                                      by this field, but it may choose
+                                                      a node that violates one or more
+                                                      of the expressions. The node that
+                                                      is most preferred is the one with
+                                                      the greatest sum of weights, i.e.
+                                                      for each node that meets all of
+                                                      the scheduling requirements (resource
+                                                      request, requiredDuringScheduling
+                                                      affinity expressions, etc.), compute
+                                                      a sum by iterating through the elements
+                                                      of this field and adding "weight"
+                                                      to the sum if the node matches the
+                                                      corresponding matchExpressions;
+                                                      the node(s) with the highest sum
+                                                      are the most preferred.
                                                     type: array
                                                     items:
-                                                      description: A null or empty
-                                                        node selector term matches
-                                                        no objects. The requirements
-                                                        of them are ANDed. The TopologySelectorTerm
-                                                        type implements a subset of
-                                                        the NodeSelectorTerm.
-                                                      type: object
-                                                      properties:
-                                                        matchExpressions:
-                                                          description: A list of node
-                                                            selector requirements
-                                                            by node's labels.
-                                                          type: array
-                                                          items:
-                                                            description: A node selector
-                                                              requirement is a selector
-                                                              that contains values,
-                                                              a key, and an operator
-                                                              that relates the key
-                                                              and values.
-                                                            type: object
-                                                            required:
-                                                              - key
-                                                              - operator
-                                                            properties:
-                                                              key:
-                                                                description: The label
-                                                                  key that the selector
-                                                                  applies to.
-                                                                type: string
-                                                              operator:
-                                                                description: Represents
-                                                                  a key's relationship
-                                                                  to a set of values.
-                                                                  Valid operators
-                                                                  are In, NotIn, Exists,
-                                                                  DoesNotExist. Gt,
-                                                                  and Lt.
-                                                                type: string
-                                                              values:
-                                                                description: An array
-                                                                  of string values.
-                                                                  If the operator
-                                                                  is In or NotIn,
-                                                                  the values array
-                                                                  must be non-empty.
-                                                                  If the operator
-                                                                  is Exists or DoesNotExist,
-                                                                  the values array
-                                                                  must be empty. If
-                                                                  the operator is
-                                                                  Gt or Lt, the values
-                                                                  array must have
-                                                                  a single element,
-                                                                  which will be interpreted
-                                                                  as an integer. This
-                                                                  array is replaced
-                                                                  during a strategic
-                                                                  merge patch.
-                                                                type: array
-                                                                items:
-                                                                  type: string
-                                                        matchFields:
-                                                          description: A list of node
-                                                            selector requirements
-                                                            by node's fields.
-                                                          type: array
-                                                          items:
-                                                            description: A node selector
-                                                              requirement is a selector
-                                                              that contains values,
-                                                              a key, and an operator
-                                                              that relates the key
-                                                              and values.
-                                                            type: object
-                                                            required:
-                                                              - key
-                                                              - operator
-                                                            properties:
-                                                              key:
-                                                                description: The label
-                                                                  key that the selector
-                                                                  applies to.
-                                                                type: string
-                                                              operator:
-                                                                description: Represents
-                                                                  a key's relationship
-                                                                  to a set of values.
-                                                                  Valid operators
-                                                                  are In, NotIn, Exists,
-                                                                  DoesNotExist. Gt,
-                                                                  and Lt.
-                                                                type: string
-                                                              values:
-                                                                description: An array
-                                                                  of string values.
-                                                                  If the operator
-                                                                  is In or NotIn,
-                                                                  the values array
-                                                                  must be non-empty.
-                                                                  If the operator
-                                                                  is Exists or DoesNotExist,
-                                                                  the values array
-                                                                  must be empty. If
-                                                                  the operator is
-                                                                  Gt or Lt, the values
-                                                                  array must have
-                                                                  a single element,
-                                                                  which will be interpreted
-                                                                  as an integer. This
-                                                                  array is replaced
-                                                                  during a strategic
-                                                                  merge patch.
-                                                                type: array
-                                                                items:
-                                                                  type: string
-                                          podAffinity:
-                                            description: Describes pod affinity scheduling
-                                              rules (e.g. co-locate this pod in the
-                                              same node, zone, etc. as some other
-                                              pod(s)).
-                                            type: object
-                                            properties:
-                                              preferredDuringSchedulingIgnoredDuringExecution:
-                                                description: The scheduler will prefer
-                                                  to schedule pods to nodes that satisfy
-                                                  the affinity expressions specified
-                                                  by this field, but it may choose
-                                                  a node that violates one or more
-                                                  of the expressions. The node that
-                                                  is most preferred is the one with
-                                                  the greatest sum of weights, i.e.
-                                                  for each node that meets all of
-                                                  the scheduling requirements (resource
-                                                  request, requiredDuringScheduling
-                                                  affinity expressions, etc.), compute
-                                                  a sum by iterating through the elements
-                                                  of this field and adding "weight"
-                                                  to the sum if the node has pods
-                                                  which matches the corresponding
-                                                  podAffinityTerm; the node(s) with
-                                                  the highest sum are the most preferred.
-                                                type: array
-                                                items:
-                                                  description: The weights of all
-                                                    of the matched WeightedPodAffinityTerm
-                                                    fields are added per-node to find
-                                                    the most preferred node(s)
-                                                  type: object
-                                                  required:
-                                                    - podAffinityTerm
-                                                    - weight
-                                                  properties:
-                                                    podAffinityTerm:
-                                                      description: Required. A pod
-                                                        affinity term, associated
-                                                        with the corresponding weight.
+                                                      description: An empty preferred
+                                                        scheduling term matches all objects
+                                                        with implicit weight 0 (i.e. it's
+                                                        a no-op). A null preferred scheduling
+                                                        term matches no objects (i.e.
+                                                        is also a no-op).
                                                       type: object
                                                       required:
-                                                        - topologyKey
+                                                        - preference
+                                                        - weight
                                                       properties:
-                                                        labelSelector:
-                                                          description: A label query
-                                                            over a set of resources,
-                                                            in this case pods.
+                                                        preference:
+                                                          description: A node selector
+                                                            term, associated with the
+                                                            corresponding weight.
                                                           type: object
                                                           properties:
                                                             matchExpressions:
-                                                              description: matchExpressions
-                                                                is a list of label
-                                                                selector requirements.
-                                                                The requirements are
-                                                                ANDed.
+                                                              description: A list of node
+                                                                selector requirements
+                                                                by node's labels.
                                                               type: array
                                                               items:
-                                                                description: A label
-                                                                  selector requirement
-                                                                  is a selector that
-                                                                  contains values,
+                                                                description: A node selector
+                                                                  requirement is a selector
+                                                                  that contains values,
                                                                   a key, and an operator
-                                                                  that relates the
-                                                                  key and values.
+                                                                  that relates the key
+                                                                  and values.
                                                                 type: object
                                                                 required:
                                                                   - key
                                                                   - operator
                                                                 properties:
                                                                   key:
-                                                                    description: key
-                                                                      is the label
-                                                                      key that the
-                                                                      selector applies
-                                                                      to.
+                                                                    description: The label
+                                                                      key that the selector
+                                                                      applies to.
                                                                     type: string
                                                                   operator:
-                                                                    description: operator
-                                                                      represents a
-                                                                      key's relationship
-                                                                      to a set of
-                                                                      values. Valid
-                                                                      operators are
-                                                                      In, NotIn, Exists
-                                                                      and DoesNotExist.
+                                                                    description: Represents
+                                                                      a key's relationship
+                                                                      to a set of values.
+                                                                      Valid operators
+                                                                      are In, NotIn, Exists,
+                                                                      DoesNotExist. Gt,
+                                                                      and Lt.
                                                                     type: string
                                                                   values:
-                                                                    description: values
-                                                                      is an array
+                                                                    description: An array
                                                                       of string values.
                                                                       If the operator
                                                                       is In or NotIn,
                                                                       the values array
                                                                       must be non-empty.
                                                                       If the operator
-                                                                      is Exists or
-                                                                      DoesNotExist,
+                                                                      is Exists or DoesNotExist,
                                                                       the values array
-                                                                      must be empty.
-                                                                      This array is
-                                                                      replaced during
-                                                                      a strategic
+                                                                      must be empty. If
+                                                                      the operator is
+                                                                      Gt or Lt, the values
+                                                                      array must have
+                                                                      a single element,
+                                                                      which will be interpreted
+                                                                      as an integer. This
+                                                                      array is replaced
+                                                                      during a strategic
+                                                                      merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchFields:
+                                                              description: A list of node
+                                                                selector requirements
+                                                                by node's fields.
+                                                              type: array
+                                                              items:
+                                                                description: A node selector
+                                                                  requirement is a selector
+                                                                  that contains values,
+                                                                  a key, and an operator
+                                                                  that relates the key
+                                                                  and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label
+                                                                      key that the selector
+                                                                      applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: Represents
+                                                                      a key's relationship
+                                                                      to a set of values.
+                                                                      Valid operators
+                                                                      are In, NotIn, Exists,
+                                                                      DoesNotExist. Gt,
+                                                                      and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: An array
+                                                                      of string values.
+                                                                      If the operator
+                                                                      is In or NotIn,
+                                                                      the values array
+                                                                      must be non-empty.
+                                                                      If the operator
+                                                                      is Exists or DoesNotExist,
+                                                                      the values array
+                                                                      must be empty. If
+                                                                      the operator is
+                                                                      Gt or Lt, the values
+                                                                      array must have
+                                                                      a single element,
+                                                                      which will be interpreted
+                                                                      as an integer. This
+                                                                      array is replaced
+                                                                      during a strategic
+                                                                      merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                        weight:
+                                                          description: Weight associated
+                                                            with matching the corresponding
+                                                            nodeSelectorTerm, in the range
+                                                            1-100.
+                                                          type: integer
+                                                          format: int32
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: If the affinity requirements
+                                                      specified by this field are not
+                                                      met at scheduling time, the pod
+                                                      will not be scheduled onto the node.
+                                                      If the affinity requirements specified
+                                                      by this field cease to be met at
+                                                      some point during pod execution
+                                                      (e.g. due to an update), the system
+                                                      may or may not try to eventually
+                                                      evict the pod from its node.
+                                                    type: object
+                                                    required:
+                                                      - nodeSelectorTerms
+                                                    properties:
+                                                      nodeSelectorTerms:
+                                                        description: Required. A list
+                                                          of node selector terms. The
+                                                          terms are ORed.
+                                                        type: array
+                                                        items:
+                                                          description: A null or empty
+                                                            node selector term matches
+                                                            no objects. The requirements
+                                                            of them are ANDed. The TopologySelectorTerm
+                                                            type implements a subset of
+                                                            the NodeSelectorTerm.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: A list of node
+                                                                selector requirements
+                                                                by node's labels.
+                                                              type: array
+                                                              items:
+                                                                description: A node selector
+                                                                  requirement is a selector
+                                                                  that contains values,
+                                                                  a key, and an operator
+                                                                  that relates the key
+                                                                  and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label
+                                                                      key that the selector
+                                                                      applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: Represents
+                                                                      a key's relationship
+                                                                      to a set of values.
+                                                                      Valid operators
+                                                                      are In, NotIn, Exists,
+                                                                      DoesNotExist. Gt,
+                                                                      and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: An array
+                                                                      of string values.
+                                                                      If the operator
+                                                                      is In or NotIn,
+                                                                      the values array
+                                                                      must be non-empty.
+                                                                      If the operator
+                                                                      is Exists or DoesNotExist,
+                                                                      the values array
+                                                                      must be empty. If
+                                                                      the operator is
+                                                                      Gt or Lt, the values
+                                                                      array must have
+                                                                      a single element,
+                                                                      which will be interpreted
+                                                                      as an integer. This
+                                                                      array is replaced
+                                                                      during a strategic
+                                                                      merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchFields:
+                                                              description: A list of node
+                                                                selector requirements
+                                                                by node's fields.
+                                                              type: array
+                                                              items:
+                                                                description: A node selector
+                                                                  requirement is a selector
+                                                                  that contains values,
+                                                                  a key, and an operator
+                                                                  that relates the key
+                                                                  and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label
+                                                                      key that the selector
+                                                                      applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: Represents
+                                                                      a key's relationship
+                                                                      to a set of values.
+                                                                      Valid operators
+                                                                      are In, NotIn, Exists,
+                                                                      DoesNotExist. Gt,
+                                                                      and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: An array
+                                                                      of string values.
+                                                                      If the operator
+                                                                      is In or NotIn,
+                                                                      the values array
+                                                                      must be non-empty.
+                                                                      If the operator
+                                                                      is Exists or DoesNotExist,
+                                                                      the values array
+                                                                      must be empty. If
+                                                                      the operator is
+                                                                      Gt or Lt, the values
+                                                                      array must have
+                                                                      a single element,
+                                                                      which will be interpreted
+                                                                      as an integer. This
+                                                                      array is replaced
+                                                                      during a strategic
+                                                                      merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                              podAffinity:
+                                                description: Describes pod affinity scheduling
+                                                  rules (e.g. co-locate this pod in the
+                                                  same node, zone, etc. as some other
+                                                  pod(s)).
+                                                type: object
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: The scheduler will prefer
+                                                      to schedule pods to nodes that satisfy
+                                                      the affinity expressions specified
+                                                      by this field, but it may choose
+                                                      a node that violates one or more
+                                                      of the expressions. The node that
+                                                      is most preferred is the one with
+                                                      the greatest sum of weights, i.e.
+                                                      for each node that meets all of
+                                                      the scheduling requirements (resource
+                                                      request, requiredDuringScheduling
+                                                      affinity expressions, etc.), compute
+                                                      a sum by iterating through the elements
+                                                      of this field and adding "weight"
+                                                      to the sum if the node has pods
+                                                      which matches the corresponding
+                                                      podAffinityTerm; the node(s) with
+                                                      the highest sum are the most preferred.
+                                                    type: array
+                                                    items:
+                                                      description: The weights of all
+                                                        of the matched WeightedPodAffinityTerm
+                                                        fields are added per-node to find
+                                                        the most preferred node(s)
+                                                      type: object
+                                                      required:
+                                                        - podAffinityTerm
+                                                        - weight
+                                                      properties:
+                                                        podAffinityTerm:
+                                                          description: Required. A pod
+                                                            affinity term, associated
+                                                            with the corresponding weight.
+                                                          type: object
+                                                          required:
+                                                            - topologyKey
+                                                          properties:
+                                                            labelSelector:
+                                                              description: A label query
+                                                                over a set of resources,
+                                                                in this case pods.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions
+                                                                    is a list of label
+                                                                    selector requirements.
+                                                                    The requirements are
+                                                                    ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: A label
+                                                                      selector requirement
+                                                                      is a selector that
+                                                                      contains values,
+                                                                      a key, and an operator
+                                                                      that relates the
+                                                                      key and values.
+                                                                    type: object
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key
+                                                                          is the label
+                                                                          key that the
+                                                                          selector applies
+                                                                          to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: operator
+                                                                          represents a
+                                                                          key's relationship
+                                                                          to a set of
+                                                                          values. Valid
+                                                                          operators are
+                                                                          In, NotIn, Exists
+                                                                          and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: values
+                                                                          is an array
+                                                                          of string values.
+                                                                          If the operator
+                                                                          is In or NotIn,
+                                                                          the values array
+                                                                          must be non-empty.
+                                                                          If the operator
+                                                                          is Exists or
+                                                                          DoesNotExist,
+                                                                          the values array
+                                                                          must be empty.
+                                                                          This array is
+                                                                          replaced during
+                                                                          a strategic
+                                                                          merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                matchLabels:
+                                                                  description: matchLabels
+                                                                    is a map of {key,value}
+                                                                    pairs. A single {key,value}
+                                                                    in the matchLabels
+                                                                    map is equivalent
+                                                                    to an element of matchExpressions,
+                                                                    whose key field is
+                                                                    "key", the operator
+                                                                    is "In", and the values
+                                                                    array contains only
+                                                                    "value". The requirements
+                                                                    are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                            namespaces:
+                                                              description: namespaces
+                                                                specifies which namespaces
+                                                                the labelSelector applies
+                                                                to (matches against);
+                                                                null or empty list means
+                                                                "this pod's namespace"
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                            topologyKey:
+                                                              description: This pod should
+                                                                be co-located (affinity)
+                                                                or not co-located (anti-affinity)
+                                                                with the pods matching
+                                                                the labelSelector in the
+                                                                specified namespaces,
+                                                                where co-located is defined
+                                                                as running on a node whose
+                                                                value of the label with
+                                                                key topologyKey matches
+                                                                that of any node on which
+                                                                any of the selected pods
+                                                                is running. Empty topologyKey
+                                                                is not allowed.
+                                                              type: string
+                                                        weight:
+                                                          description: weight associated
+                                                            with matching the corresponding
+                                                            podAffinityTerm, in the range
+                                                            1-100.
+                                                          type: integer
+                                                          format: int32
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: If the affinity requirements
+                                                      specified by this field are not
+                                                      met at scheduling time, the pod
+                                                      will not be scheduled onto the node.
+                                                      If the affinity requirements specified
+                                                      by this field cease to be met at
+                                                      some point during pod execution
+                                                      (e.g. due to a pod label update),
+                                                      the system may or may not try to
+                                                      eventually evict the pod from its
+                                                      node. When there are multiple elements,
+                                                      the lists of nodes corresponding
+                                                      to each podAffinityTerm are intersected,
+                                                      i.e. all terms must be satisfied.
+                                                    type: array
+                                                    items:
+                                                      description: Defines a set of pods
+                                                        (namely those matching the labelSelector
+                                                        relative to the given namespace(s))
+                                                        that this pod should be co-located
+                                                        (affinity) or not co-located (anti-affinity)
+                                                        with, where co-located is defined
+                                                        as running on a node whose value
+                                                        of the label with key <topologyKey>
+                                                        matches that of any node on which
+                                                        a pod of the set of pods is running
+                                                      type: object
+                                                      required:
+                                                        - topologyKey
+                                                      properties:
+                                                        labelSelector:
+                                                          description: A label query over
+                                                            a set of resources, in this
+                                                            case pods.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions
+                                                                is a list of label selector
+                                                                requirements. The requirements
+                                                                are ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: A label selector
+                                                                  requirement is a selector
+                                                                  that contains values,
+                                                                  a key, and an operator
+                                                                  that relates the key
+                                                                  and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key is
+                                                                      the label key that
+                                                                      the selector applies
+                                                                      to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator
+                                                                      represents a key's
+                                                                      relationship to
+                                                                      a set of values.
+                                                                      Valid operators
+                                                                      are In, NotIn, Exists
+                                                                      and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values
+                                                                      is an array of string
+                                                                      values. If the operator
+                                                                      is In or NotIn,
+                                                                      the values array
+                                                                      must be non-empty.
+                                                                      If the operator
+                                                                      is Exists or DoesNotExist,
+                                                                      the values array
+                                                                      must be empty. This
+                                                                      array is replaced
+                                                                      during a strategic
                                                                       merge patch.
                                                                     type: array
                                                                     items:
@@ -1005,281 +1119,281 @@ spec:
                                                               description: matchLabels
                                                                 is a map of {key,value}
                                                                 pairs. A single {key,value}
-                                                                in the matchLabels
-                                                                map is equivalent
-                                                                to an element of matchExpressions,
-                                                                whose key field is
-                                                                "key", the operator
-                                                                is "In", and the values
-                                                                array contains only
-                                                                "value". The requirements
+                                                                in the matchLabels map
+                                                                is equivalent to an element
+                                                                of matchExpressions, whose
+                                                                key field is "key", the
+                                                                operator is "In", and
+                                                                the values array contains
+                                                                only "value". The requirements
                                                                 are ANDed.
                                                               type: object
                                                               additionalProperties:
                                                                 type: string
                                                         namespaces:
-                                                          description: namespaces
-                                                            specifies which namespaces
-                                                            the labelSelector applies
-                                                            to (matches against);
-                                                            null or empty list means
-                                                            "this pod's namespace"
+                                                          description: namespaces specifies
+                                                            which namespaces the labelSelector
+                                                            applies to (matches against);
+                                                            null or empty list means "this
+                                                            pod's namespace"
                                                           type: array
                                                           items:
                                                             type: string
                                                         topologyKey:
                                                           description: This pod should
-                                                            be co-located (affinity)
-                                                            or not co-located (anti-affinity)
-                                                            with the pods matching
-                                                            the labelSelector in the
-                                                            specified namespaces,
-                                                            where co-located is defined
-                                                            as running on a node whose
-                                                            value of the label with
-                                                            key topologyKey matches
+                                                            be co-located (affinity) or
+                                                            not co-located (anti-affinity)
+                                                            with the pods matching the
+                                                            labelSelector in the specified
+                                                            namespaces, where co-located
+                                                            is defined as running on a
+                                                            node whose value of the label
+                                                            with key topologyKey matches
                                                             that of any node on which
-                                                            any of the selected pods
-                                                            is running. Empty topologyKey
+                                                            any of the selected pods is
+                                                            running. Empty topologyKey
                                                             is not allowed.
                                                           type: string
-                                                    weight:
-                                                      description: weight associated
-                                                        with matching the corresponding
-                                                        podAffinityTerm, in the range
-                                                        1-100.
-                                                      type: integer
-                                                      format: int32
-                                              requiredDuringSchedulingIgnoredDuringExecution:
-                                                description: If the affinity requirements
-                                                  specified by this field are not
-                                                  met at scheduling time, the pod
-                                                  will not be scheduled onto the node.
-                                                  If the affinity requirements specified
-                                                  by this field cease to be met at
-                                                  some point during pod execution
-                                                  (e.g. due to a pod label update),
-                                                  the system may or may not try to
-                                                  eventually evict the pod from its
-                                                  node. When there are multiple elements,
-                                                  the lists of nodes corresponding
-                                                  to each podAffinityTerm are intersected,
-                                                  i.e. all terms must be satisfied.
-                                                type: array
-                                                items:
-                                                  description: Defines a set of pods
-                                                    (namely those matching the labelSelector
-                                                    relative to the given namespace(s))
-                                                    that this pod should be co-located
-                                                    (affinity) or not co-located (anti-affinity)
-                                                    with, where co-located is defined
-                                                    as running on a node whose value
-                                                    of the label with key <topologyKey>
-                                                    matches that of any node on which
-                                                    a pod of the set of pods is running
-                                                  type: object
-                                                  required:
-                                                    - topologyKey
-                                                  properties:
-                                                    labelSelector:
-                                                      description: A label query over
-                                                        a set of resources, in this
-                                                        case pods.
+                                              podAntiAffinity:
+                                                description: Describes pod anti-affinity
+                                                  scheduling rules (e.g. avoid putting
+                                                  this pod in the same node, zone, etc.
+                                                  as some other pod(s)).
+                                                type: object
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: The scheduler will prefer
+                                                      to schedule pods to nodes that satisfy
+                                                      the anti-affinity expressions specified
+                                                      by this field, but it may choose
+                                                      a node that violates one or more
+                                                      of the expressions. The node that
+                                                      is most preferred is the one with
+                                                      the greatest sum of weights, i.e.
+                                                      for each node that meets all of
+                                                      the scheduling requirements (resource
+                                                      request, requiredDuringScheduling
+                                                      anti-affinity expressions, etc.),
+                                                      compute a sum by iterating through
+                                                      the elements of this field and adding
+                                                      "weight" to the sum if the node
+                                                      has pods which matches the corresponding
+                                                      podAffinityTerm; the node(s) with
+                                                      the highest sum are the most preferred.
+                                                    type: array
+                                                    items:
+                                                      description: The weights of all
+                                                        of the matched WeightedPodAffinityTerm
+                                                        fields are added per-node to find
+                                                        the most preferred node(s)
                                                       type: object
+                                                      required:
+                                                        - podAffinityTerm
+                                                        - weight
                                                       properties:
-                                                        matchExpressions:
-                                                          description: matchExpressions
-                                                            is a list of label selector
-                                                            requirements. The requirements
-                                                            are ANDed.
-                                                          type: array
-                                                          items:
-                                                            description: A label selector
-                                                              requirement is a selector
-                                                              that contains values,
-                                                              a key, and an operator
-                                                              that relates the key
-                                                              and values.
-                                                            type: object
-                                                            required:
-                                                              - key
-                                                              - operator
-                                                            properties:
-                                                              key:
-                                                                description: key is
-                                                                  the label key that
-                                                                  the selector applies
-                                                                  to.
-                                                                type: string
-                                                              operator:
-                                                                description: operator
-                                                                  represents a key's
-                                                                  relationship to
-                                                                  a set of values.
-                                                                  Valid operators
-                                                                  are In, NotIn, Exists
-                                                                  and DoesNotExist.
-                                                                type: string
-                                                              values:
-                                                                description: values
-                                                                  is an array of string
-                                                                  values. If the operator
-                                                                  is In or NotIn,
-                                                                  the values array
-                                                                  must be non-empty.
-                                                                  If the operator
-                                                                  is Exists or DoesNotExist,
-                                                                  the values array
-                                                                  must be empty. This
-                                                                  array is replaced
-                                                                  during a strategic
-                                                                  merge patch.
-                                                                type: array
-                                                                items:
-                                                                  type: string
-                                                        matchLabels:
-                                                          description: matchLabels
-                                                            is a map of {key,value}
-                                                            pairs. A single {key,value}
-                                                            in the matchLabels map
-                                                            is equivalent to an element
-                                                            of matchExpressions, whose
-                                                            key field is "key", the
-                                                            operator is "In", and
-                                                            the values array contains
-                                                            only "value". The requirements
-                                                            are ANDed.
+                                                        podAffinityTerm:
+                                                          description: Required. A pod
+                                                            affinity term, associated
+                                                            with the corresponding weight.
                                                           type: object
-                                                          additionalProperties:
-                                                            type: string
-                                                    namespaces:
-                                                      description: namespaces specifies
-                                                        which namespaces the labelSelector
-                                                        applies to (matches against);
-                                                        null or empty list means "this
-                                                        pod's namespace"
-                                                      type: array
-                                                      items:
-                                                        type: string
-                                                    topologyKey:
-                                                      description: This pod should
-                                                        be co-located (affinity) or
-                                                        not co-located (anti-affinity)
-                                                        with the pods matching the
-                                                        labelSelector in the specified
-                                                        namespaces, where co-located
-                                                        is defined as running on a
-                                                        node whose value of the label
-                                                        with key topologyKey matches
-                                                        that of any node on which
-                                                        any of the selected pods is
-                                                        running. Empty topologyKey
-                                                        is not allowed.
-                                                      type: string
-                                          podAntiAffinity:
-                                            description: Describes pod anti-affinity
-                                              scheduling rules (e.g. avoid putting
-                                              this pod in the same node, zone, etc.
-                                              as some other pod(s)).
-                                            type: object
-                                            properties:
-                                              preferredDuringSchedulingIgnoredDuringExecution:
-                                                description: The scheduler will prefer
-                                                  to schedule pods to nodes that satisfy
-                                                  the anti-affinity expressions specified
-                                                  by this field, but it may choose
-                                                  a node that violates one or more
-                                                  of the expressions. The node that
-                                                  is most preferred is the one with
-                                                  the greatest sum of weights, i.e.
-                                                  for each node that meets all of
-                                                  the scheduling requirements (resource
-                                                  request, requiredDuringScheduling
-                                                  anti-affinity expressions, etc.),
-                                                  compute a sum by iterating through
-                                                  the elements of this field and adding
-                                                  "weight" to the sum if the node
-                                                  has pods which matches the corresponding
-                                                  podAffinityTerm; the node(s) with
-                                                  the highest sum are the most preferred.
-                                                type: array
-                                                items:
-                                                  description: The weights of all
-                                                    of the matched WeightedPodAffinityTerm
-                                                    fields are added per-node to find
-                                                    the most preferred node(s)
-                                                  type: object
-                                                  required:
-                                                    - podAffinityTerm
-                                                    - weight
-                                                  properties:
-                                                    podAffinityTerm:
-                                                      description: Required. A pod
-                                                        affinity term, associated
-                                                        with the corresponding weight.
+                                                          required:
+                                                            - topologyKey
+                                                          properties:
+                                                            labelSelector:
+                                                              description: A label query
+                                                                over a set of resources,
+                                                                in this case pods.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions
+                                                                    is a list of label
+                                                                    selector requirements.
+                                                                    The requirements are
+                                                                    ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: A label
+                                                                      selector requirement
+                                                                      is a selector that
+                                                                      contains values,
+                                                                      a key, and an operator
+                                                                      that relates the
+                                                                      key and values.
+                                                                    type: object
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key
+                                                                          is the label
+                                                                          key that the
+                                                                          selector applies
+                                                                          to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: operator
+                                                                          represents a
+                                                                          key's relationship
+                                                                          to a set of
+                                                                          values. Valid
+                                                                          operators are
+                                                                          In, NotIn, Exists
+                                                                          and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: values
+                                                                          is an array
+                                                                          of string values.
+                                                                          If the operator
+                                                                          is In or NotIn,
+                                                                          the values array
+                                                                          must be non-empty.
+                                                                          If the operator
+                                                                          is Exists or
+                                                                          DoesNotExist,
+                                                                          the values array
+                                                                          must be empty.
+                                                                          This array is
+                                                                          replaced during
+                                                                          a strategic
+                                                                          merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                matchLabels:
+                                                                  description: matchLabels
+                                                                    is a map of {key,value}
+                                                                    pairs. A single {key,value}
+                                                                    in the matchLabels
+                                                                    map is equivalent
+                                                                    to an element of matchExpressions,
+                                                                    whose key field is
+                                                                    "key", the operator
+                                                                    is "In", and the values
+                                                                    array contains only
+                                                                    "value". The requirements
+                                                                    are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                            namespaces:
+                                                              description: namespaces
+                                                                specifies which namespaces
+                                                                the labelSelector applies
+                                                                to (matches against);
+                                                                null or empty list means
+                                                                "this pod's namespace"
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                            topologyKey:
+                                                              description: This pod should
+                                                                be co-located (affinity)
+                                                                or not co-located (anti-affinity)
+                                                                with the pods matching
+                                                                the labelSelector in the
+                                                                specified namespaces,
+                                                                where co-located is defined
+                                                                as running on a node whose
+                                                                value of the label with
+                                                                key topologyKey matches
+                                                                that of any node on which
+                                                                any of the selected pods
+                                                                is running. Empty topologyKey
+                                                                is not allowed.
+                                                              type: string
+                                                        weight:
+                                                          description: weight associated
+                                                            with matching the corresponding
+                                                            podAffinityTerm, in the range
+                                                            1-100.
+                                                          type: integer
+                                                          format: int32
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: If the anti-affinity
+                                                      requirements specified by this field
+                                                      are not met at scheduling time,
+                                                      the pod will not be scheduled onto
+                                                      the node. If the anti-affinity requirements
+                                                      specified by this field cease to
+                                                      be met at some point during pod
+                                                      execution (e.g. due to a pod label
+                                                      update), the system may or may not
+                                                      try to eventually evict the pod
+                                                      from its node. When there are multiple
+                                                      elements, the lists of nodes corresponding
+                                                      to each podAffinityTerm are intersected,
+                                                      i.e. all terms must be satisfied.
+                                                    type: array
+                                                    items:
+                                                      description: Defines a set of pods
+                                                        (namely those matching the labelSelector
+                                                        relative to the given namespace(s))
+                                                        that this pod should be co-located
+                                                        (affinity) or not co-located (anti-affinity)
+                                                        with, where co-located is defined
+                                                        as running on a node whose value
+                                                        of the label with key <topologyKey>
+                                                        matches that of any node on which
+                                                        a pod of the set of pods is running
                                                       type: object
                                                       required:
                                                         - topologyKey
                                                       properties:
                                                         labelSelector:
-                                                          description: A label query
-                                                            over a set of resources,
-                                                            in this case pods.
+                                                          description: A label query over
+                                                            a set of resources, in this
+                                                            case pods.
                                                           type: object
                                                           properties:
                                                             matchExpressions:
                                                               description: matchExpressions
-                                                                is a list of label
-                                                                selector requirements.
-                                                                The requirements are
-                                                                ANDed.
+                                                                is a list of label selector
+                                                                requirements. The requirements
+                                                                are ANDed.
                                                               type: array
                                                               items:
-                                                                description: A label
-                                                                  selector requirement
-                                                                  is a selector that
-                                                                  contains values,
+                                                                description: A label selector
+                                                                  requirement is a selector
+                                                                  that contains values,
                                                                   a key, and an operator
-                                                                  that relates the
-                                                                  key and values.
+                                                                  that relates the key
+                                                                  and values.
                                                                 type: object
                                                                 required:
                                                                   - key
                                                                   - operator
                                                                 properties:
                                                                   key:
-                                                                    description: key
-                                                                      is the label
-                                                                      key that the
-                                                                      selector applies
+                                                                    description: key is
+                                                                      the label key that
+                                                                      the selector applies
                                                                       to.
                                                                     type: string
                                                                   operator:
                                                                     description: operator
-                                                                      represents a
-                                                                      key's relationship
-                                                                      to a set of
-                                                                      values. Valid
-                                                                      operators are
-                                                                      In, NotIn, Exists
+                                                                      represents a key's
+                                                                      relationship to
+                                                                      a set of values.
+                                                                      Valid operators
+                                                                      are In, NotIn, Exists
                                                                       and DoesNotExist.
                                                                     type: string
                                                                   values:
                                                                     description: values
-                                                                      is an array
-                                                                      of string values.
-                                                                      If the operator
+                                                                      is an array of string
+                                                                      values. If the operator
                                                                       is In or NotIn,
                                                                       the values array
                                                                       must be non-empty.
                                                                       If the operator
-                                                                      is Exists or
-                                                                      DoesNotExist,
+                                                                      is Exists or DoesNotExist,
                                                                       the values array
-                                                                      must be empty.
-                                                                      This array is
-                                                                      replaced during
-                                                                      a strategic
+                                                                      must be empty. This
+                                                                      array is replaced
+                                                                      during a strategic
                                                                       merge patch.
                                                                     type: array
                                                                     items:
@@ -1288,523 +1402,2177 @@ spec:
                                                               description: matchLabels
                                                                 is a map of {key,value}
                                                                 pairs. A single {key,value}
-                                                                in the matchLabels
-                                                                map is equivalent
-                                                                to an element of matchExpressions,
-                                                                whose key field is
-                                                                "key", the operator
-                                                                is "In", and the values
-                                                                array contains only
-                                                                "value". The requirements
+                                                                in the matchLabels map
+                                                                is equivalent to an element
+                                                                of matchExpressions, whose
+                                                                key field is "key", the
+                                                                operator is "In", and
+                                                                the values array contains
+                                                                only "value". The requirements
                                                                 are ANDed.
                                                               type: object
                                                               additionalProperties:
                                                                 type: string
                                                         namespaces:
-                                                          description: namespaces
-                                                            specifies which namespaces
-                                                            the labelSelector applies
-                                                            to (matches against);
-                                                            null or empty list means
-                                                            "this pod's namespace"
+                                                          description: namespaces specifies
+                                                            which namespaces the labelSelector
+                                                            applies to (matches against);
+                                                            null or empty list means "this
+                                                            pod's namespace"
                                                           type: array
                                                           items:
                                                             type: string
                                                         topologyKey:
                                                           description: This pod should
-                                                            be co-located (affinity)
-                                                            or not co-located (anti-affinity)
-                                                            with the pods matching
-                                                            the labelSelector in the
-                                                            specified namespaces,
-                                                            where co-located is defined
-                                                            as running on a node whose
-                                                            value of the label with
-                                                            key topologyKey matches
+                                                            be co-located (affinity) or
+                                                            not co-located (anti-affinity)
+                                                            with the pods matching the
+                                                            labelSelector in the specified
+                                                            namespaces, where co-located
+                                                            is defined as running on a
+                                                            node whose value of the label
+                                                            with key topologyKey matches
                                                             that of any node on which
-                                                            any of the selected pods
-                                                            is running. Empty topologyKey
+                                                            any of the selected pods is
+                                                            running. Empty topologyKey
                                                             is not allowed.
                                                           type: string
-                                                    weight:
-                                                      description: weight associated
-                                                        with matching the corresponding
-                                                        podAffinityTerm, in the range
-                                                        1-100.
-                                                      type: integer
-                                                      format: int32
-                                              requiredDuringSchedulingIgnoredDuringExecution:
-                                                description: If the anti-affinity
-                                                  requirements specified by this field
-                                                  are not met at scheduling time,
-                                                  the pod will not be scheduled onto
-                                                  the node. If the anti-affinity requirements
-                                                  specified by this field cease to
-                                                  be met at some point during pod
-                                                  execution (e.g. due to a pod label
-                                                  update), the system may or may not
-                                                  try to eventually evict the pod
-                                                  from its node. When there are multiple
-                                                  elements, the lists of nodes corresponding
-                                                  to each podAffinityTerm are intersected,
-                                                  i.e. all terms must be satisfied.
-                                                type: array
-                                                items:
-                                                  description: Defines a set of pods
-                                                    (namely those matching the labelSelector
-                                                    relative to the given namespace(s))
-                                                    that this pod should be co-located
-                                                    (affinity) or not co-located (anti-affinity)
-                                                    with, where co-located is defined
-                                                    as running on a node whose value
-                                                    of the label with key <topologyKey>
-                                                    matches that of any node on which
-                                                    a pod of the set of pods is running
-                                                  type: object
-                                                  required:
-                                                    - topologyKey
-                                                  properties:
-                                                    labelSelector:
-                                                      description: A label query over
-                                                        a set of resources, in this
-                                                        case pods.
-                                                      type: object
-                                                      properties:
-                                                        matchExpressions:
-                                                          description: matchExpressions
-                                                            is a list of label selector
-                                                            requirements. The requirements
-                                                            are ANDed.
-                                                          type: array
-                                                          items:
-                                                            description: A label selector
-                                                              requirement is a selector
-                                                              that contains values,
-                                                              a key, and an operator
-                                                              that relates the key
-                                                              and values.
-                                                            type: object
-                                                            required:
-                                                              - key
-                                                              - operator
-                                                            properties:
-                                                              key:
-                                                                description: key is
-                                                                  the label key that
-                                                                  the selector applies
-                                                                  to.
-                                                                type: string
-                                                              operator:
-                                                                description: operator
-                                                                  represents a key's
-                                                                  relationship to
-                                                                  a set of values.
-                                                                  Valid operators
-                                                                  are In, NotIn, Exists
-                                                                  and DoesNotExist.
-                                                                type: string
-                                                              values:
-                                                                description: values
-                                                                  is an array of string
-                                                                  values. If the operator
-                                                                  is In or NotIn,
-                                                                  the values array
-                                                                  must be non-empty.
-                                                                  If the operator
-                                                                  is Exists or DoesNotExist,
-                                                                  the values array
-                                                                  must be empty. This
-                                                                  array is replaced
-                                                                  during a strategic
-                                                                  merge patch.
-                                                                type: array
-                                                                items:
-                                                                  type: string
-                                                        matchLabels:
-                                                          description: matchLabels
-                                                            is a map of {key,value}
-                                                            pairs. A single {key,value}
-                                                            in the matchLabels map
-                                                            is equivalent to an element
-                                                            of matchExpressions, whose
-                                                            key field is "key", the
-                                                            operator is "In", and
-                                                            the values array contains
-                                                            only "value". The requirements
-                                                            are ANDed.
-                                                          type: object
-                                                          additionalProperties:
-                                                            type: string
-                                                    namespaces:
-                                                      description: namespaces specifies
-                                                        which namespaces the labelSelector
-                                                        applies to (matches against);
-                                                        null or empty list means "this
-                                                        pod's namespace"
-                                                      type: array
-                                                      items:
-                                                        type: string
-                                                    topologyKey:
-                                                      description: This pod should
-                                                        be co-located (affinity) or
-                                                        not co-located (anti-affinity)
-                                                        with the pods matching the
-                                                        labelSelector in the specified
-                                                        namespaces, where co-located
-                                                        is defined as running on a
-                                                        node whose value of the label
-                                                        with key topologyKey matches
-                                                        that of any node on which
-                                                        any of the selected pods is
-                                                        running. Empty topologyKey
-                                                        is not allowed.
-                                                      type: string
-                                      nodeSelector:
-                                        description: 'NodeSelector is a selector which
-                                          must be true for the pod to fit on a node.
-                                          Selector which must match a node''s labels
-                                          for the pod to be scheduled on that node.
-                                          More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
-                                        type: object
-                                        additionalProperties:
-                                          type: string
-                                      tolerations:
-                                        description: If specified, the pod's tolerations.
-                                        type: array
-                                        items:
-                                          description: The pod this Toleration is
-                                            attached to tolerates any taint that matches
-                                            the triple <key,value,effect> using the
-                                            matching operator <operator>.
-                                          type: object
-                                          properties:
-                                            effect:
-                                              description: Effect indicates the taint
-                                                effect to match. Empty means match
-                                                all taint effects. When specified,
-                                                allowed values are NoSchedule, PreferNoSchedule
-                                                and NoExecute.
+                                          nodeSelector:
+                                            description: 'NodeSelector is a selector which
+                                                must be true for the pod to fit on a node.
+                                                Selector which must match a node''s labels
+                                                for the pod to be scheduled on that node.
+                                                More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                                            type: object
+                                            additionalProperties:
                                               type: string
-                                            key:
-                                              description: Key is the taint key that
-                                                the toleration applies to. Empty means
-                                                match all taint keys. If the key is
-                                                empty, operator must be Exists; this
-                                                combination means to match all values
-                                                and all keys.
-                                              type: string
-                                            operator:
-                                              description: Operator represents a key's
-                                                relationship to the value. Valid operators
-                                                are Exists and Equal. Defaults to
-                                                Equal. Exists is equivalent to wildcard
-                                                for value, so that a pod can tolerate
-                                                all taints of a particular category.
-                                              type: string
-                                            tolerationSeconds:
-                                              description: TolerationSeconds represents
-                                                the period of time the toleration
-                                                (which must be of effect NoExecute,
-                                                otherwise this field is ignored) tolerates
-                                                the taint. By default, it is not set,
-                                                which means tolerate the taint forever
-                                                (do not evict). Zero and negative
-                                                values will be treated as 0 (evict
-                                                immediately) by the system.
-                                              type: integer
-                                              format: int64
-                                            value:
-                                              description: Value is the taint value
-                                                the toleration matches to. If the
-                                                operator is Exists, the value should
-                                                be empty, otherwise just a regular
-                                                string.
-                                              type: string
-                              serviceType:
-                                description: Optional service type for Kubernetes
-                                  solver service
-                                type: string
-                      selector:
-                        description: Selector selects a set of DNSNames on the Certificate
-                          resource that should be solved using this challenge solver.
-                        type: object
-                        properties:
-                          dnsNames:
-                            description: List of DNSNames that this solver will be
-                              used to solve. If specified and a match is found, a
-                              dnsNames selector will take precedence over a dnsZones
-                              selector. If multiple solvers match with the same dnsNames
-                              value, the solver with the most matching labels in matchLabels
-                              will be selected. If neither has more matches, the solver
-                              defined earlier in the list will be selected.
-                            type: array
-                            items:
-                              type: string
-                          dnsZones:
-                            description: List of DNSZones that this solver will be
-                              used to solve. The most specific DNS zone match specified
-                              here will take precedence over other DNS zone matches,
-                              so a solver specifying sys.example.com will be selected
-                              over one specifying example.com for the domain www.sys.example.com.
-                              If multiple solvers match with the same dnsZones value,
-                              the solver with the most matching labels in matchLabels
-                              will be selected. If neither has more matches, the solver
-                              defined earlier in the list will be selected.
-                            type: array
-                            items:
-                              type: string
-                          matchLabels:
-                            description: A label selector that is used to refine the
-                              set of certificate's that this challenge solver will
-                              apply to.
+                                          tolerations:
+                                            description: If specified, the pod's tolerations.
+                                            type: array
+                                            items:
+                                              description: The pod this Toleration is
+                                                attached to tolerates any taint that matches
+                                                the triple <key,value,effect> using the
+                                                matching operator <operator>.
+                                              type: object
+                                              properties:
+                                                effect:
+                                                  description: Effect indicates the taint
+                                                    effect to match. Empty means match
+                                                    all taint effects. When specified,
+                                                    allowed values are NoSchedule, PreferNoSchedule
+                                                    and NoExecute.
+                                                  type: string
+                                                key:
+                                                  description: Key is the taint key that
+                                                    the toleration applies to. Empty means
+                                                    match all taint keys. If the key is
+                                                    empty, operator must be Exists; this
+                                                    combination means to match all values
+                                                    and all keys.
+                                                  type: string
+                                                operator:
+                                                  description: Operator represents a key's
+                                                    relationship to the value. Valid operators
+                                                    are Exists and Equal. Defaults to
+                                                    Equal. Exists is equivalent to wildcard
+                                                    for value, so that a pod can tolerate
+                                                    all taints of a particular category.
+                                                  type: string
+                                                tolerationSeconds:
+                                                  description: TolerationSeconds represents
+                                                    the period of time the toleration
+                                                    (which must be of effect NoExecute,
+                                                    otherwise this field is ignored) tolerates
+                                                    the taint. By default, it is not set,
+                                                    which means tolerate the taint forever
+                                                    (do not evict). Zero and negative
+                                                    values will be treated as 0 (evict
+                                                    immediately) by the system.
+                                                  type: integer
+                                                  format: int64
+                                                value:
+                                                  description: Value is the taint value
+                                                    the toleration matches to. If the
+                                                    operator is Exists, the value should
+                                                    be empty, otherwise just a regular
+                                                    string.
+                                                  type: string
+                                  serviceType:
+                                    description: Optional service type for Kubernetes
+                                      solver service
+                                    type: string
+                          selector:
+                            description: Selector selects a set of DNSNames on the Certificate
+                              resource that should be solved using this challenge solver.
                             type: object
-                            additionalProperties:
-                              type: string
-            ca:
-              type: object
-              required:
-                - secretName
-              properties:
-                crlDistributionPoints:
-                  description: The CRL distribution points is an X.509 v3 certificate
-                    extension which identifies the location of the CRL from which
-                    the revocation of this certificate can be checked. If not set
-                    certificate will be issued without CDP. Values are strings.
-                  type: array
-                  items:
-                    type: string
-                secretName:
-                  description: SecretName is the name of the secret used to sign Certificates
-                    issued by this Issuer.
-                  type: string
-            selfSigned:
-              type: object
-              properties:
-                crlDistributionPoints:
-                  description: The CRL distribution points is an X.509 v3 certificate
-                    extension which identifies the location of the CRL from which
-                    the revocation of this certificate can be checked. If not set
-                    certificate will be issued without CDP. Values are strings.
-                  type: array
-                  items:
-                    type: string
-            vault:
-              type: object
-              required:
-                - auth
-                - path
-                - server
-              properties:
-                auth:
-                  description: Vault authentication
-                  type: object
-                  properties:
-                    appRole:
-                      description: This Secret contains a AppRole and Secret
-                      type: object
-                      required:
-                        - path
-                        - roleId
-                        - secretRef
-                      properties:
-                        path:
-                          description: Where the authentication path is mounted in
-                            Vault.
-                          type: string
-                        roleId:
-                          type: string
-                        secretRef:
-                          type: object
-                          required:
-                            - name
-                          properties:
-                            key:
-                              description: The key of the secret to select from. Must
-                                be a valid secret key.
-                              type: string
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                    kubernetes:
-                      description: This contains a Role and Secret with a ServiceAccount
-                        token to authenticate with vault.
-                      type: object
-                      required:
-                        - role
-                        - secretRef
-                      properties:
-                        mountPath:
-                          description: The Vault mountPath here is the mount path
-                            to use when authenticating with Vault. For example, setting
-                            a value to `/v1/auth/foo`, will use the path `/v1/auth/foo/login`
-                            to authenticate with Vault. If unspecified, the default
-                            value "/v1/auth/kubernetes" will be used.
-                          type: string
-                        role:
-                          description: A required field containing the Vault Role
-                            to assume. A Role binds a Kubernetes ServiceAccount with
-                            a set of Vault policies.
-                          type: string
-                        secretRef:
-                          description: The required Secret field containing a Kubernetes
-                            ServiceAccount JWT used for authenticating with Vault.
-                            Use of 'ambient credentials' is not supported.
-                          type: object
-                          required:
-                            - name
-                          properties:
-                            key:
-                              description: The key of the secret to select from. Must
-                                be a valid secret key.
-                              type: string
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                    tokenSecretRef:
-                      description: This Secret contains the Vault token key
-                      type: object
-                      required:
-                        - name
-                      properties:
-                        key:
-                          description: The key of the secret to select from. Must
-                            be a valid secret key.
-                          type: string
-                        name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
-                          type: string
-                caBundle:
-                  description: Base64 encoded CA bundle to validate Vault server certificate.
-                    Only used if the Server URL is using HTTPS protocol. This parameter
-                    is ignored for plain HTTP protocol connection. If not set the
-                    system root certificates are used to validate the TLS connection.
-                  type: string
-                  format: byte
-                path:
-                  description: Vault URL path to the certificate role
-                  type: string
-                server:
-                  description: Server is the vault connection address
-                  type: string
-            venafi:
-              description: VenafiIssuer describes issuer configuration details for
-                Venafi Cloud.
-              type: object
-              required:
-                - zone
-              properties:
-                cloud:
-                  description: Cloud specifies the Venafi cloud configuration settings.
-                    Only one of TPP or Cloud may be specified.
+                            properties:
+                              dnsNames:
+                                description: List of DNSNames that this solver will be
+                                  used to solve. If specified and a match is found, a
+                                  dnsNames selector will take precedence over a dnsZones
+                                  selector. If multiple solvers match with the same dnsNames
+                                  value, the solver with the most matching labels in matchLabels
+                                  will be selected. If neither has more matches, the solver
+                                  defined earlier in the list will be selected.
+                                type: array
+                                items:
+                                  type: string
+                              dnsZones:
+                                description: List of DNSZones that this solver will be
+                                  used to solve. The most specific DNS zone match specified
+                                  here will take precedence over other DNS zone matches,
+                                  so a solver specifying sys.example.com will be selected
+                                  over one specifying example.com for the domain www.sys.example.com.
+                                  If multiple solvers match with the same dnsZones value,
+                                  the solver with the most matching labels in matchLabels
+                                  will be selected. If neither has more matches, the solver
+                                  defined earlier in the list will be selected.
+                                type: array
+                                items:
+                                  type: string
+                              matchLabels:
+                                description: A label selector that is used to refine the
+                                  set of certificate's that this challenge solver will
+                                  apply to.
+                                type: object
+                                additionalProperties:
+                                  type: string
+                ca:
                   type: object
                   required:
-                    - apiTokenSecretRef
+                    - secretName
                   properties:
-                    apiTokenSecretRef:
-                      description: APITokenSecretRef is a secret key selector for
-                        the Venafi Cloud API token.
-                      type: object
-                      required:
-                        - name
-                      properties:
-                        key:
-                          description: The key of the secret to select from. Must
-                            be a valid secret key.
-                          type: string
-                        name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
-                          type: string
-                    url:
-                      description: URL is the base URL for Venafi Cloud
+                    crlDistributionPoints:
+                      description: The CRL distribution points is an X.509 v3 certificate
+                        extension which identifies the location of the CRL from which
+                        the revocation of this certificate can be checked. If not set
+                        certificate will be issued without CDP. Values are strings.
+                      type: array
+                      items:
+                        type: string
+                    secretName:
+                      description: SecretName is the name of the secret used to sign Certificates
+                        issued by this Issuer.
                       type: string
-                tpp:
-                  description: TPP specifies Trust Protection Platform configuration
-                    settings. Only one of TPP or Cloud may be specified.
+                selfSigned:
+                  type: object
+                  properties:
+                    crlDistributionPoints:
+                      description: The CRL distribution points is an X.509 v3 certificate
+                        extension which identifies the location of the CRL from which
+                        the revocation of this certificate can be checked. If not set
+                        certificate will be issued without CDP. Values are strings.
+                      type: array
+                      items:
+                        type: string
+                vault:
                   type: object
                   required:
-                    - credentialsRef
-                    - url
+                    - auth
+                    - path
+                    - server
                   properties:
+                    auth:
+                      description: Vault authentication
+                      type: object
+                      properties:
+                        appRole:
+                          description: This Secret contains a AppRole and Secret
+                          type: object
+                          required:
+                            - path
+                            - roleId
+                            - secretRef
+                          properties:
+                            path:
+                              description: Where the authentication path is mounted in
+                                Vault.
+                              type: string
+                            roleId:
+                              type: string
+                            secretRef:
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the secret to select from. Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                                  type: string
+                        kubernetes:
+                          description: This contains a Role and Secret with a ServiceAccount
+                            token to authenticate with vault.
+                          type: object
+                          required:
+                            - role
+                            - secretRef
+                          properties:
+                            mountPath:
+                              description: The Vault mountPath here is the mount path
+                                to use when authenticating with Vault. For example, setting
+                                a value to `/v1/auth/foo`, will use the path `/v1/auth/foo/login`
+                                to authenticate with Vault. If unspecified, the default
+                                value "/v1/auth/kubernetes" will be used.
+                              type: string
+                            role:
+                              description: A required field containing the Vault Role
+                                to assume. A Role binds a Kubernetes ServiceAccount with
+                                a set of Vault policies.
+                              type: string
+                            secretRef:
+                              description: The required Secret field containing a Kubernetes
+                                ServiceAccount JWT used for authenticating with Vault.
+                                Use of 'ambient credentials' is not supported.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the secret to select from. Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                                  type: string
+                        tokenSecretRef:
+                          description: This Secret contains the Vault token key
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            key:
+                              description: The key of the secret to select from. Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
                     caBundle:
-                      description: CABundle is a PEM encoded TLS certificate to use
-                        to verify connections to the TPP instance. If specified, system
-                        roots will not be used and the issuing CA for the TPP instance
-                        must be verifiable using the provided root. If not specified,
-                        the connection will be verified using the cert-manager system
-                        root certificates.
+                      description: Base64 encoded CA bundle to validate Vault server certificate.
+                        Only used if the Server URL is using HTTPS protocol. This parameter
+                        is ignored for plain HTTP protocol connection. If not set the
+                        system root certificates are used to validate the TLS connection.
                       type: string
                       format: byte
-                    credentialsRef:
-                      description: CredentialsRef is a reference to a Secret containing
-                        the username and password for the TPP server. The secret must
-                        contain two keys, 'username' and 'password'.
+                    path:
+                      description: Vault URL path to the certificate role
+                      type: string
+                    server:
+                      description: Server is the vault connection address
+                      type: string
+                venafi:
+                  description: VenafiIssuer describes issuer configuration details for
+                    Venafi Cloud.
+                  type: object
+                  required:
+                    - zone
+                  properties:
+                    cloud:
+                      description: Cloud specifies the Venafi cloud configuration settings.
+                        Only one of TPP or Cloud may be specified.
+                      type: object
+                      required:
+                        - apiTokenSecretRef
+                      properties:
+                        apiTokenSecretRef:
+                          description: APITokenSecretRef is a secret key selector for
+                            the Venafi Cloud API token.
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            key:
+                              description: The key of the secret to select from. Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                        url:
+                          description: URL is the base URL for Venafi Cloud
+                          type: string
+                    tpp:
+                      description: TPP specifies Trust Protection Platform configuration
+                        settings. Only one of TPP or Cloud may be specified.
+                      type: object
+                      required:
+                        - credentialsRef
+                        - url
+                      properties:
+                        caBundle:
+                          description: CABundle is a PEM encoded TLS certificate to use
+                            to verify connections to the TPP instance. If specified, system
+                            roots will not be used and the issuing CA for the TPP instance
+                            must be verifiable using the provided root. If not specified,
+                            the connection will be verified using the cert-manager system
+                            root certificates.
+                          type: string
+                          format: byte
+                        credentialsRef:
+                          description: CredentialsRef is a reference to a Secret containing
+                            the username and password for the TPP server. The secret must
+                            contain two keys, 'username' and 'password'.
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                        url:
+                          description: URL is the base URL for the Venafi TPP instance
+                          type: string
+                    zone:
+                      description: Zone is the Venafi Policy Zone to use for this issuer.
+                        All requests made to the Venafi platform will be restricted by
+                        the named zone policy. This field is required.
+                      type: string
+            status:
+              description: IssuerStatus contains status information about an Issuer
+              type: object
+              properties:
+                acme:
+                  type: object
+                  properties:
+                    lastRegisteredEmail:
+                      description: LastRegisteredEmail is the email associated with the
+                        latest registered ACME account, in order to track changes made
+                        to registered account associated with the  Issuer
+                      type: string
+                    uri:
+                      description: URI is the unique account identifier, which can also
+                        be used to retrieve account details from the CA
+                      type: string
+                conditions:
+                  type: array
+                  items:
+                    description: IssuerCondition contains condition information for an
+                      Issuer.
+                    type: object
+                    required:
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: LastTransitionTime is the timestamp corresponding
+                          to the last status change of this condition.
+                        type: string
+                        format: date-time
+                      message:
+                        description: Message is a human readable description of the details
+                          of the last transition, complementing reason.
+                        type: string
+                      reason:
+                        description: Reason is a brief machine readable explanation for
+                          the condition's last transition.
+                        type: string
+                      status:
+                        description: Status of the condition, one of ('True', 'False',
+                          'Unknown').
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      type:
+                        description: Type of the condition, currently ('Ready').
+                        type: string
+      served: true
+      storage: true
+      additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].message
+          name: Status
+          priority: 1
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          description: CreationTimestamp is a timestamp representing the server time when
+            this object was created. It is not guaranteed to be set in happens-before order
+            across separate operations. Clients may not set this value. It is represented
+            in RFC3339 form and is in UTC.
+          name: Age
+          type: date
+      subresources:
+        status: { }
+    - name: v1alpha3
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: IssuerSpec is the specification of an Issuer. This includes
+                any configuration required for the issuer.
+              type: object
+              properties:
+                acme:
+                  description: ACMEIssuer contains the specification for an ACME issuer
+                  type: object
+                  required:
+                    - privateKeySecretRef
+                    - server
+                  properties:
+                    email:
+                      description: Email is the email for this account
+                      type: string
+                    externalAccountBinding:
+                      description: ExternalAccountBinding is a reference to a CA external
+                        account of the ACME server.
+                      type: object
+                      required:
+                        - keyAlgorithm
+                        - keyID
+                        - keySecretRef
+                      properties:
+                        keyAlgorithm:
+                          description: keyAlgorithm is the MAC key algorithm that the
+                            key is used for. Valid values are "HS256", "HS384" and "HS512".
+                          type: string
+                          enum:
+                            - HS256
+                            - HS384
+                            - HS512
+                        keyID:
+                          description: keyID is the ID of the CA key that the External
+                            Account is bound to.
+                          type: string
+                        keySecretRef:
+                          description: keySecretRef is a Secret Key Selector referencing
+                            a data item in a Kubernetes Secret which holds the symmetric
+                            MAC key of the External Account Binding. The `key` is the
+                            index string that is paired with the key data in the Secret
+                            and should not be confused with the key data itself, or indeed
+                            with the External Account Binding keyID above. The secret
+                            key stored in the Secret **must** be un-padded, base64 URL
+                            encoded data.
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            key:
+                              description: The key of the secret to select from. Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                    privateKeySecretRef:
+                      description: PrivateKey is the name of a secret containing the private
+                        key for this user account.
                       type: object
                       required:
                         - name
                       properties:
+                        key:
+                          description: The key of the secret to select from. Must be a
+                            valid secret key.
+                          type: string
                         name:
                           description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
                           type: string
-                    url:
-                      description: URL is the base URL for the Venafi TPP instance
+                    server:
+                      description: Server is the ACME server URL
                       type: string
-                zone:
-                  description: Zone is the Venafi Policy Zone to use for this issuer.
-                    All requests made to the Venafi platform will be restricted by
-                    the named zone policy. This field is required.
-                  type: string
-        status:
-          description: IssuerStatus contains status information about an Issuer
-          type: object
-          properties:
-            acme:
+                    skipTLSVerify:
+                      description: If true, skip verifying the ACME server TLS certificate
+                      type: boolean
+                    solvers:
+                      description: Solvers is a list of challenge solvers that will be
+                        used to solve ACME challenges for the matching domains.
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          dns01:
+                            type: object
+                            properties:
+                              acmedns:
+                                description: ACMEIssuerDNS01ProviderAcmeDNS is a structure
+                                  containing the configuration for ACME-DNS servers
+                                type: object
+                                required:
+                                  - accountSecretRef
+                                  - host
+                                properties:
+                                  accountSecretRef:
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.
+                                          Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion, kind,
+                                            uid?'
+                                        type: string
+                                  host:
+                                    type: string
+                              akamai:
+                                description: ACMEIssuerDNS01ProviderAkamai is a structure
+                                  containing the DNS configuration for Akamai DNS—Zone
+                                  Record Management API
+                                type: object
+                                required:
+                                  - accessTokenSecretRef
+                                  - clientSecretSecretRef
+                                  - clientTokenSecretRef
+                                  - serviceConsumerDomain
+                                properties:
+                                  accessTokenSecretRef:
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.
+                                          Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion, kind,
+                                            uid?'
+                                        type: string
+                                  clientSecretSecretRef:
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.
+                                          Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion, kind,
+                                            uid?'
+                                        type: string
+                                  clientTokenSecretRef:
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.
+                                          Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion, kind,
+                                            uid?'
+                                        type: string
+                                  serviceConsumerDomain:
+                                    type: string
+                              azuredns:
+                                description: ACMEIssuerDNS01ProviderAzureDNS is a structure
+                                  containing the configuration for Azure DNS
+                                type: object
+                                required:
+                                  - resourceGroupName
+                                  - subscriptionID
+                                properties:
+                                  clientID:
+                                    description: if both this and ClientSecret are left
+                                      unset MSI will be used
+                                    type: string
+                                  clientSecretSecretRef:
+                                    description: if both this and ClientID are left unset
+                                      MSI will be used
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.
+                                          Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion, kind,
+                                            uid?'
+                                        type: string
+                                  environment:
+                                    type: string
+                                    enum:
+                                      - AzurePublicCloud
+                                      - AzureChinaCloud
+                                      - AzureGermanCloud
+                                      - AzureUSGovernmentCloud
+                                  hostedZoneName:
+                                    type: string
+                                  resourceGroupName:
+                                    type: string
+                                  subscriptionID:
+                                    type: string
+                                  tenantID:
+                                    description: when specifying ClientID and ClientSecret
+                                      then this field is also needed
+                                    type: string
+                              clouddns:
+                                description: ACMEIssuerDNS01ProviderCloudDNS is a structure
+                                  containing the DNS configuration for Google Cloud DNS
+                                type: object
+                                required:
+                                  - project
+                                properties:
+                                  project:
+                                    type: string
+                                  serviceAccountSecretRef:
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.
+                                          Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion, kind,
+                                            uid?'
+                                        type: string
+                              cloudflare:
+                                description: ACMEIssuerDNS01ProviderCloudflare is a structure
+                                  containing the DNS configuration for Cloudflare
+                                type: object
+                                required:
+                                  - email
+                                properties:
+                                  apiKeySecretRef:
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.
+                                          Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion, kind,
+                                            uid?'
+                                        type: string
+                                  apiTokenSecretRef:
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.
+                                          Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion, kind,
+                                            uid?'
+                                        type: string
+                                  email:
+                                    type: string
+                              cnameStrategy:
+                                description: CNAMEStrategy configures how the DNS01 provider
+                                  should handle CNAME records when found in DNS zones.
+                                type: string
+                                enum:
+                                  - None
+                                  - Follow
+                              digitalocean:
+                                description: ACMEIssuerDNS01ProviderDigitalOcean is a
+                                  structure containing the DNS configuration for DigitalOcean
+                                  Domains
+                                type: object
+                                required:
+                                  - tokenSecretRef
+                                properties:
+                                  tokenSecretRef:
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.
+                                          Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion, kind,
+                                            uid?'
+                                        type: string
+                              rfc2136:
+                                description: ACMEIssuerDNS01ProviderRFC2136 is a structure
+                                  containing the configuration for RFC2136 DNS
+                                type: object
+                                required:
+                                  - nameserver
+                                properties:
+                                  nameserver:
+                                    description: The IP address or hostname of an authoritative
+                                      DNS server supporting RFC2136 in the form host:port.
+                                      If the host is an IPv6 address it must be enclosed
+                                      in square brackets (e.g [2001:db8::1]) ; port is
+                                      optional. This field is required.
+                                    type: string
+                                  tsigAlgorithm:
+                                    description: 'The TSIG Algorithm configured in the
+                                        DNS supporting RFC2136. Used only when ``tsigSecretSecretRef``
+                                        and ``tsigKeyName`` are defined. Supported values
+                                        are (case-insensitive): ``HMACMD5`` (default), ``HMACSHA1``,
+                                        ``HMACSHA256`` or ``HMACSHA512``.'
+                                    type: string
+                                  tsigKeyName:
+                                    description: The TSIG Key name configured in the DNS.
+                                      If ``tsigSecretSecretRef`` is defined, this field
+                                      is required.
+                                    type: string
+                                  tsigSecretSecretRef:
+                                    description: The name of the secret containing the
+                                      TSIG value. If ``tsigKeyName`` is defined, this
+                                      field is required.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.
+                                          Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion, kind,
+                                            uid?'
+                                        type: string
+                              route53:
+                                description: ACMEIssuerDNS01ProviderRoute53 is a structure
+                                  containing the Route 53 configuration for AWS
+                                type: object
+                                required:
+                                  - region
+                                properties:
+                                  accessKeyID:
+                                    description: 'The AccessKeyID is used for authentication.
+                                        If not set we fall-back to using env vars, shared
+                                        credentials file or AWS Instance metadata see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
+                                    type: string
+                                  hostedZoneID:
+                                    description: If set, the provider will manage only
+                                      this zone in Route53 and will not do an lookup using
+                                      the route53:ListHostedZonesByName api call.
+                                    type: string
+                                  region:
+                                    description: Always set the region when using AccessKeyID
+                                      and SecretAccessKey
+                                    type: string
+                                  role:
+                                    description: Role is a Role ARN which the Route53
+                                      provider will assume using either the explicit credentials
+                                      AccessKeyID/SecretAccessKey or the inferred credentials
+                                      from environment variables, shared credentials file
+                                      or AWS Instance metadata
+                                    type: string
+                                  secretAccessKeySecretRef:
+                                    description: The SecretAccessKey is used for authentication.
+                                      If not set we fall-back to using env vars, shared
+                                      credentials file or AWS Instance metadata https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.
+                                          Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion, kind,
+                                            uid?'
+                                        type: string
+                              webhook:
+                                description: ACMEIssuerDNS01ProviderWebhook specifies
+                                  configuration for a webhook DNS01 provider, including
+                                  where to POST ChallengePayload resources.
+                                type: object
+                                required:
+                                  - groupName
+                                  - solverName
+                                properties:
+                                  config:
+                                    description: Additional configuration that should
+                                      be passed to the webhook apiserver when challenges
+                                      are processed. This can contain arbitrary JSON data.
+                                      Secret values should not be specified in this stanza.
+                                      If secret values are needed (e.g. credentials for
+                                      a DNS service), you should use a SecretKeySelector
+                                      to reference a Secret resource. For details on the
+                                      schema of this field, consult the webhook provider
+                                      implementation's documentation.
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  groupName:
+                                    description: The API group name that should be used
+                                      when POSTing ChallengePayload resources to the webhook
+                                      apiserver. This should be the same as the GroupName
+                                      specified in the webhook provider implementation.
+                                    type: string
+                                  solverName:
+                                    description: The name of the solver to use, as defined
+                                      in the webhook provider implementation. This will
+                                      typically be the name of the provider, e.g. 'cloudflare'.
+                                    type: string
+                          http01:
+                            description: ACMEChallengeSolverHTTP01 contains configuration
+                              detailing how to solve HTTP01 challenges within a Kubernetes
+                              cluster. Typically this is accomplished through creating
+                              'routes' of some description that configure ingress controllers
+                              to direct traffic to 'solver pods', which are responsible
+                              for responding to the ACME server's HTTP requests.
+                            type: object
+                            properties:
+                              ingress:
+                                description: The ingress based HTTP01 challenge solver
+                                  will solve challenges by creating or modifying Ingress
+                                  resources in order to route requests for '/.well-known/acme-challenge/XYZ'
+                                  to 'challenge solver' pods that are provisioned by cert-manager
+                                  for each Challenge to be completed.
+                                type: object
+                                properties:
+                                  class:
+                                    description: The ingress class to use when creating
+                                      Ingress resources to solve ACME challenges that
+                                      use this challenge solver. Only one of 'class' or
+                                      'name' may be specified.
+                                    type: string
+                                  ingressTemplate:
+                                    description: Optional ingress template used to configure
+                                      the ACME challenge solver ingress used for HTTP01
+                                      challenges
+                                    type: object
+                                    properties:
+                                      metadata:
+                                        description: ObjectMeta overrides for the ingress
+                                          used to solve HTTP01 challenges. Only the 'labels'
+                                          and 'annotations' fields may be set. If labels
+                                          or annotations overlap with in-built values,
+                                          the values here will override the in-built values.
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            description: Annotations that should be added
+                                              to the created ACME HTTP01 solver ingress.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                          labels:
+                                            description: Labels that should be added to
+                                              the created ACME HTTP01 solver ingress.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                  name:
+                                    description: The name of the ingress resource that
+                                      should have ACME challenge solving routes inserted
+                                      into it in order to solve HTTP01 challenges. This
+                                      is typically used in conjunction with ingress controllers
+                                      like ingress-gce, which maintains a 1:1 mapping
+                                      between external IPs and ingress resources.
+                                    type: string
+                                  podTemplate:
+                                    description: Optional pod template used to configure
+                                      the ACME challenge solver pods used for HTTP01 challenges
+                                    type: object
+                                    properties:
+                                      metadata:
+                                        description: ObjectMeta overrides for the pod
+                                          used to solve HTTP01 challenges. Only the 'labels'
+                                          and 'annotations' fields may be set. If labels
+                                          or annotations overlap with in-built values,
+                                          the values here will override the in-built values.
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            description: Annotations that should be added
+                                              to the create ACME HTTP01 solver pods.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                          labels:
+                                            description: Labels that should be added to
+                                              the created ACME HTTP01 solver pods.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                      spec:
+                                        description: PodSpec defines overrides for the
+                                          HTTP01 challenge solver pod. Only the 'nodeSelector',
+                                          'affinity' and 'tolerations' fields are supported
+                                          currently. All other fields will be ignored.
+                                        type: object
+                                        properties:
+                                          affinity:
+                                            description: If specified, the pod's scheduling
+                                              constraints
+                                            type: object
+                                            properties:
+                                              nodeAffinity:
+                                                description: Describes node affinity scheduling
+                                                  rules for the pod.
+                                                type: object
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: The scheduler will prefer
+                                                      to schedule pods to nodes that satisfy
+                                                      the affinity expressions specified
+                                                      by this field, but it may choose
+                                                      a node that violates one or more
+                                                      of the expressions. The node that
+                                                      is most preferred is the one with
+                                                      the greatest sum of weights, i.e.
+                                                      for each node that meets all of
+                                                      the scheduling requirements (resource
+                                                      request, requiredDuringScheduling
+                                                      affinity expressions, etc.), compute
+                                                      a sum by iterating through the elements
+                                                      of this field and adding "weight"
+                                                      to the sum if the node matches the
+                                                      corresponding matchExpressions;
+                                                      the node(s) with the highest sum
+                                                      are the most preferred.
+                                                    type: array
+                                                    items:
+                                                      description: An empty preferred
+                                                        scheduling term matches all objects
+                                                        with implicit weight 0 (i.e. it's
+                                                        a no-op). A null preferred scheduling
+                                                        term matches no objects (i.e.
+                                                        is also a no-op).
+                                                      type: object
+                                                      required:
+                                                        - preference
+                                                        - weight
+                                                      properties:
+                                                        preference:
+                                                          description: A node selector
+                                                            term, associated with the
+                                                            corresponding weight.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: A list of node
+                                                                selector requirements
+                                                                by node's labels.
+                                                              type: array
+                                                              items:
+                                                                description: A node selector
+                                                                  requirement is a selector
+                                                                  that contains values,
+                                                                  a key, and an operator
+                                                                  that relates the key
+                                                                  and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label
+                                                                      key that the selector
+                                                                      applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: Represents
+                                                                      a key's relationship
+                                                                      to a set of values.
+                                                                      Valid operators
+                                                                      are In, NotIn, Exists,
+                                                                      DoesNotExist. Gt,
+                                                                      and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: An array
+                                                                      of string values.
+                                                                      If the operator
+                                                                      is In or NotIn,
+                                                                      the values array
+                                                                      must be non-empty.
+                                                                      If the operator
+                                                                      is Exists or DoesNotExist,
+                                                                      the values array
+                                                                      must be empty. If
+                                                                      the operator is
+                                                                      Gt or Lt, the values
+                                                                      array must have
+                                                                      a single element,
+                                                                      which will be interpreted
+                                                                      as an integer. This
+                                                                      array is replaced
+                                                                      during a strategic
+                                                                      merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchFields:
+                                                              description: A list of node
+                                                                selector requirements
+                                                                by node's fields.
+                                                              type: array
+                                                              items:
+                                                                description: A node selector
+                                                                  requirement is a selector
+                                                                  that contains values,
+                                                                  a key, and an operator
+                                                                  that relates the key
+                                                                  and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label
+                                                                      key that the selector
+                                                                      applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: Represents
+                                                                      a key's relationship
+                                                                      to a set of values.
+                                                                      Valid operators
+                                                                      are In, NotIn, Exists,
+                                                                      DoesNotExist. Gt,
+                                                                      and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: An array
+                                                                      of string values.
+                                                                      If the operator
+                                                                      is In or NotIn,
+                                                                      the values array
+                                                                      must be non-empty.
+                                                                      If the operator
+                                                                      is Exists or DoesNotExist,
+                                                                      the values array
+                                                                      must be empty. If
+                                                                      the operator is
+                                                                      Gt or Lt, the values
+                                                                      array must have
+                                                                      a single element,
+                                                                      which will be interpreted
+                                                                      as an integer. This
+                                                                      array is replaced
+                                                                      during a strategic
+                                                                      merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                        weight:
+                                                          description: Weight associated
+                                                            with matching the corresponding
+                                                            nodeSelectorTerm, in the range
+                                                            1-100.
+                                                          type: integer
+                                                          format: int32
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: If the affinity requirements
+                                                      specified by this field are not
+                                                      met at scheduling time, the pod
+                                                      will not be scheduled onto the node.
+                                                      If the affinity requirements specified
+                                                      by this field cease to be met at
+                                                      some point during pod execution
+                                                      (e.g. due to an update), the system
+                                                      may or may not try to eventually
+                                                      evict the pod from its node.
+                                                    type: object
+                                                    required:
+                                                      - nodeSelectorTerms
+                                                    properties:
+                                                      nodeSelectorTerms:
+                                                        description: Required. A list
+                                                          of node selector terms. The
+                                                          terms are ORed.
+                                                        type: array
+                                                        items:
+                                                          description: A null or empty
+                                                            node selector term matches
+                                                            no objects. The requirements
+                                                            of them are ANDed. The TopologySelectorTerm
+                                                            type implements a subset of
+                                                            the NodeSelectorTerm.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: A list of node
+                                                                selector requirements
+                                                                by node's labels.
+                                                              type: array
+                                                              items:
+                                                                description: A node selector
+                                                                  requirement is a selector
+                                                                  that contains values,
+                                                                  a key, and an operator
+                                                                  that relates the key
+                                                                  and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label
+                                                                      key that the selector
+                                                                      applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: Represents
+                                                                      a key's relationship
+                                                                      to a set of values.
+                                                                      Valid operators
+                                                                      are In, NotIn, Exists,
+                                                                      DoesNotExist. Gt,
+                                                                      and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: An array
+                                                                      of string values.
+                                                                      If the operator
+                                                                      is In or NotIn,
+                                                                      the values array
+                                                                      must be non-empty.
+                                                                      If the operator
+                                                                      is Exists or DoesNotExist,
+                                                                      the values array
+                                                                      must be empty. If
+                                                                      the operator is
+                                                                      Gt or Lt, the values
+                                                                      array must have
+                                                                      a single element,
+                                                                      which will be interpreted
+                                                                      as an integer. This
+                                                                      array is replaced
+                                                                      during a strategic
+                                                                      merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchFields:
+                                                              description: A list of node
+                                                                selector requirements
+                                                                by node's fields.
+                                                              type: array
+                                                              items:
+                                                                description: A node selector
+                                                                  requirement is a selector
+                                                                  that contains values,
+                                                                  a key, and an operator
+                                                                  that relates the key
+                                                                  and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label
+                                                                      key that the selector
+                                                                      applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: Represents
+                                                                      a key's relationship
+                                                                      to a set of values.
+                                                                      Valid operators
+                                                                      are In, NotIn, Exists,
+                                                                      DoesNotExist. Gt,
+                                                                      and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: An array
+                                                                      of string values.
+                                                                      If the operator
+                                                                      is In or NotIn,
+                                                                      the values array
+                                                                      must be non-empty.
+                                                                      If the operator
+                                                                      is Exists or DoesNotExist,
+                                                                      the values array
+                                                                      must be empty. If
+                                                                      the operator is
+                                                                      Gt or Lt, the values
+                                                                      array must have
+                                                                      a single element,
+                                                                      which will be interpreted
+                                                                      as an integer. This
+                                                                      array is replaced
+                                                                      during a strategic
+                                                                      merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                              podAffinity:
+                                                description: Describes pod affinity scheduling
+                                                  rules (e.g. co-locate this pod in the
+                                                  same node, zone, etc. as some other
+                                                  pod(s)).
+                                                type: object
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: The scheduler will prefer
+                                                      to schedule pods to nodes that satisfy
+                                                      the affinity expressions specified
+                                                      by this field, but it may choose
+                                                      a node that violates one or more
+                                                      of the expressions. The node that
+                                                      is most preferred is the one with
+                                                      the greatest sum of weights, i.e.
+                                                      for each node that meets all of
+                                                      the scheduling requirements (resource
+                                                      request, requiredDuringScheduling
+                                                      affinity expressions, etc.), compute
+                                                      a sum by iterating through the elements
+                                                      of this field and adding "weight"
+                                                      to the sum if the node has pods
+                                                      which matches the corresponding
+                                                      podAffinityTerm; the node(s) with
+                                                      the highest sum are the most preferred.
+                                                    type: array
+                                                    items:
+                                                      description: The weights of all
+                                                        of the matched WeightedPodAffinityTerm
+                                                        fields are added per-node to find
+                                                        the most preferred node(s)
+                                                      type: object
+                                                      required:
+                                                        - podAffinityTerm
+                                                        - weight
+                                                      properties:
+                                                        podAffinityTerm:
+                                                          description: Required. A pod
+                                                            affinity term, associated
+                                                            with the corresponding weight.
+                                                          type: object
+                                                          required:
+                                                            - topologyKey
+                                                          properties:
+                                                            labelSelector:
+                                                              description: A label query
+                                                                over a set of resources,
+                                                                in this case pods.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions
+                                                                    is a list of label
+                                                                    selector requirements.
+                                                                    The requirements are
+                                                                    ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: A label
+                                                                      selector requirement
+                                                                      is a selector that
+                                                                      contains values,
+                                                                      a key, and an operator
+                                                                      that relates the
+                                                                      key and values.
+                                                                    type: object
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key
+                                                                          is the label
+                                                                          key that the
+                                                                          selector applies
+                                                                          to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: operator
+                                                                          represents a
+                                                                          key's relationship
+                                                                          to a set of
+                                                                          values. Valid
+                                                                          operators are
+                                                                          In, NotIn, Exists
+                                                                          and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: values
+                                                                          is an array
+                                                                          of string values.
+                                                                          If the operator
+                                                                          is In or NotIn,
+                                                                          the values array
+                                                                          must be non-empty.
+                                                                          If the operator
+                                                                          is Exists or
+                                                                          DoesNotExist,
+                                                                          the values array
+                                                                          must be empty.
+                                                                          This array is
+                                                                          replaced during
+                                                                          a strategic
+                                                                          merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                matchLabels:
+                                                                  description: matchLabels
+                                                                    is a map of {key,value}
+                                                                    pairs. A single {key,value}
+                                                                    in the matchLabels
+                                                                    map is equivalent
+                                                                    to an element of matchExpressions,
+                                                                    whose key field is
+                                                                    "key", the operator
+                                                                    is "In", and the values
+                                                                    array contains only
+                                                                    "value". The requirements
+                                                                    are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                            namespaces:
+                                                              description: namespaces
+                                                                specifies which namespaces
+                                                                the labelSelector applies
+                                                                to (matches against);
+                                                                null or empty list means
+                                                                "this pod's namespace"
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                            topologyKey:
+                                                              description: This pod should
+                                                                be co-located (affinity)
+                                                                or not co-located (anti-affinity)
+                                                                with the pods matching
+                                                                the labelSelector in the
+                                                                specified namespaces,
+                                                                where co-located is defined
+                                                                as running on a node whose
+                                                                value of the label with
+                                                                key topologyKey matches
+                                                                that of any node on which
+                                                                any of the selected pods
+                                                                is running. Empty topologyKey
+                                                                is not allowed.
+                                                              type: string
+                                                        weight:
+                                                          description: weight associated
+                                                            with matching the corresponding
+                                                            podAffinityTerm, in the range
+                                                            1-100.
+                                                          type: integer
+                                                          format: int32
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: If the affinity requirements
+                                                      specified by this field are not
+                                                      met at scheduling time, the pod
+                                                      will not be scheduled onto the node.
+                                                      If the affinity requirements specified
+                                                      by this field cease to be met at
+                                                      some point during pod execution
+                                                      (e.g. due to a pod label update),
+                                                      the system may or may not try to
+                                                      eventually evict the pod from its
+                                                      node. When there are multiple elements,
+                                                      the lists of nodes corresponding
+                                                      to each podAffinityTerm are intersected,
+                                                      i.e. all terms must be satisfied.
+                                                    type: array
+                                                    items:
+                                                      description: Defines a set of pods
+                                                        (namely those matching the labelSelector
+                                                        relative to the given namespace(s))
+                                                        that this pod should be co-located
+                                                        (affinity) or not co-located (anti-affinity)
+                                                        with, where co-located is defined
+                                                        as running on a node whose value
+                                                        of the label with key <topologyKey>
+                                                        matches that of any node on which
+                                                        a pod of the set of pods is running
+                                                      type: object
+                                                      required:
+                                                        - topologyKey
+                                                      properties:
+                                                        labelSelector:
+                                                          description: A label query over
+                                                            a set of resources, in this
+                                                            case pods.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions
+                                                                is a list of label selector
+                                                                requirements. The requirements
+                                                                are ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: A label selector
+                                                                  requirement is a selector
+                                                                  that contains values,
+                                                                  a key, and an operator
+                                                                  that relates the key
+                                                                  and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key is
+                                                                      the label key that
+                                                                      the selector applies
+                                                                      to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator
+                                                                      represents a key's
+                                                                      relationship to
+                                                                      a set of values.
+                                                                      Valid operators
+                                                                      are In, NotIn, Exists
+                                                                      and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values
+                                                                      is an array of string
+                                                                      values. If the operator
+                                                                      is In or NotIn,
+                                                                      the values array
+                                                                      must be non-empty.
+                                                                      If the operator
+                                                                      is Exists or DoesNotExist,
+                                                                      the values array
+                                                                      must be empty. This
+                                                                      array is replaced
+                                                                      during a strategic
+                                                                      merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchLabels:
+                                                              description: matchLabels
+                                                                is a map of {key,value}
+                                                                pairs. A single {key,value}
+                                                                in the matchLabels map
+                                                                is equivalent to an element
+                                                                of matchExpressions, whose
+                                                                key field is "key", the
+                                                                operator is "In", and
+                                                                the values array contains
+                                                                only "value". The requirements
+                                                                are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                        namespaces:
+                                                          description: namespaces specifies
+                                                            which namespaces the labelSelector
+                                                            applies to (matches against);
+                                                            null or empty list means "this
+                                                            pod's namespace"
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                        topologyKey:
+                                                          description: This pod should
+                                                            be co-located (affinity) or
+                                                            not co-located (anti-affinity)
+                                                            with the pods matching the
+                                                            labelSelector in the specified
+                                                            namespaces, where co-located
+                                                            is defined as running on a
+                                                            node whose value of the label
+                                                            with key topologyKey matches
+                                                            that of any node on which
+                                                            any of the selected pods is
+                                                            running. Empty topologyKey
+                                                            is not allowed.
+                                                          type: string
+                                              podAntiAffinity:
+                                                description: Describes pod anti-affinity
+                                                  scheduling rules (e.g. avoid putting
+                                                  this pod in the same node, zone, etc.
+                                                  as some other pod(s)).
+                                                type: object
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: The scheduler will prefer
+                                                      to schedule pods to nodes that satisfy
+                                                      the anti-affinity expressions specified
+                                                      by this field, but it may choose
+                                                      a node that violates one or more
+                                                      of the expressions. The node that
+                                                      is most preferred is the one with
+                                                      the greatest sum of weights, i.e.
+                                                      for each node that meets all of
+                                                      the scheduling requirements (resource
+                                                      request, requiredDuringScheduling
+                                                      anti-affinity expressions, etc.),
+                                                      compute a sum by iterating through
+                                                      the elements of this field and adding
+                                                      "weight" to the sum if the node
+                                                      has pods which matches the corresponding
+                                                      podAffinityTerm; the node(s) with
+                                                      the highest sum are the most preferred.
+                                                    type: array
+                                                    items:
+                                                      description: The weights of all
+                                                        of the matched WeightedPodAffinityTerm
+                                                        fields are added per-node to find
+                                                        the most preferred node(s)
+                                                      type: object
+                                                      required:
+                                                        - podAffinityTerm
+                                                        - weight
+                                                      properties:
+                                                        podAffinityTerm:
+                                                          description: Required. A pod
+                                                            affinity term, associated
+                                                            with the corresponding weight.
+                                                          type: object
+                                                          required:
+                                                            - topologyKey
+                                                          properties:
+                                                            labelSelector:
+                                                              description: A label query
+                                                                over a set of resources,
+                                                                in this case pods.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions
+                                                                    is a list of label
+                                                                    selector requirements.
+                                                                    The requirements are
+                                                                    ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: A label
+                                                                      selector requirement
+                                                                      is a selector that
+                                                                      contains values,
+                                                                      a key, and an operator
+                                                                      that relates the
+                                                                      key and values.
+                                                                    type: object
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key
+                                                                          is the label
+                                                                          key that the
+                                                                          selector applies
+                                                                          to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: operator
+                                                                          represents a
+                                                                          key's relationship
+                                                                          to a set of
+                                                                          values. Valid
+                                                                          operators are
+                                                                          In, NotIn, Exists
+                                                                          and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: values
+                                                                          is an array
+                                                                          of string values.
+                                                                          If the operator
+                                                                          is In or NotIn,
+                                                                          the values array
+                                                                          must be non-empty.
+                                                                          If the operator
+                                                                          is Exists or
+                                                                          DoesNotExist,
+                                                                          the values array
+                                                                          must be empty.
+                                                                          This array is
+                                                                          replaced during
+                                                                          a strategic
+                                                                          merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                matchLabels:
+                                                                  description: matchLabels
+                                                                    is a map of {key,value}
+                                                                    pairs. A single {key,value}
+                                                                    in the matchLabels
+                                                                    map is equivalent
+                                                                    to an element of matchExpressions,
+                                                                    whose key field is
+                                                                    "key", the operator
+                                                                    is "In", and the values
+                                                                    array contains only
+                                                                    "value". The requirements
+                                                                    are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                            namespaces:
+                                                              description: namespaces
+                                                                specifies which namespaces
+                                                                the labelSelector applies
+                                                                to (matches against);
+                                                                null or empty list means
+                                                                "this pod's namespace"
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                            topologyKey:
+                                                              description: This pod should
+                                                                be co-located (affinity)
+                                                                or not co-located (anti-affinity)
+                                                                with the pods matching
+                                                                the labelSelector in the
+                                                                specified namespaces,
+                                                                where co-located is defined
+                                                                as running on a node whose
+                                                                value of the label with
+                                                                key topologyKey matches
+                                                                that of any node on which
+                                                                any of the selected pods
+                                                                is running. Empty topologyKey
+                                                                is not allowed.
+                                                              type: string
+                                                        weight:
+                                                          description: weight associated
+                                                            with matching the corresponding
+                                                            podAffinityTerm, in the range
+                                                            1-100.
+                                                          type: integer
+                                                          format: int32
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: If the anti-affinity
+                                                      requirements specified by this field
+                                                      are not met at scheduling time,
+                                                      the pod will not be scheduled onto
+                                                      the node. If the anti-affinity requirements
+                                                      specified by this field cease to
+                                                      be met at some point during pod
+                                                      execution (e.g. due to a pod label
+                                                      update), the system may or may not
+                                                      try to eventually evict the pod
+                                                      from its node. When there are multiple
+                                                      elements, the lists of nodes corresponding
+                                                      to each podAffinityTerm are intersected,
+                                                      i.e. all terms must be satisfied.
+                                                    type: array
+                                                    items:
+                                                      description: Defines a set of pods
+                                                        (namely those matching the labelSelector
+                                                        relative to the given namespace(s))
+                                                        that this pod should be co-located
+                                                        (affinity) or not co-located (anti-affinity)
+                                                        with, where co-located is defined
+                                                        as running on a node whose value
+                                                        of the label with key <topologyKey>
+                                                        matches that of any node on which
+                                                        a pod of the set of pods is running
+                                                      type: object
+                                                      required:
+                                                        - topologyKey
+                                                      properties:
+                                                        labelSelector:
+                                                          description: A label query over
+                                                            a set of resources, in this
+                                                            case pods.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions
+                                                                is a list of label selector
+                                                                requirements. The requirements
+                                                                are ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: A label selector
+                                                                  requirement is a selector
+                                                                  that contains values,
+                                                                  a key, and an operator
+                                                                  that relates the key
+                                                                  and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key is
+                                                                      the label key that
+                                                                      the selector applies
+                                                                      to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator
+                                                                      represents a key's
+                                                                      relationship to
+                                                                      a set of values.
+                                                                      Valid operators
+                                                                      are In, NotIn, Exists
+                                                                      and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values
+                                                                      is an array of string
+                                                                      values. If the operator
+                                                                      is In or NotIn,
+                                                                      the values array
+                                                                      must be non-empty.
+                                                                      If the operator
+                                                                      is Exists or DoesNotExist,
+                                                                      the values array
+                                                                      must be empty. This
+                                                                      array is replaced
+                                                                      during a strategic
+                                                                      merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchLabels:
+                                                              description: matchLabels
+                                                                is a map of {key,value}
+                                                                pairs. A single {key,value}
+                                                                in the matchLabels map
+                                                                is equivalent to an element
+                                                                of matchExpressions, whose
+                                                                key field is "key", the
+                                                                operator is "In", and
+                                                                the values array contains
+                                                                only "value". The requirements
+                                                                are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                        namespaces:
+                                                          description: namespaces specifies
+                                                            which namespaces the labelSelector
+                                                            applies to (matches against);
+                                                            null or empty list means "this
+                                                            pod's namespace"
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                        topologyKey:
+                                                          description: This pod should
+                                                            be co-located (affinity) or
+                                                            not co-located (anti-affinity)
+                                                            with the pods matching the
+                                                            labelSelector in the specified
+                                                            namespaces, where co-located
+                                                            is defined as running on a
+                                                            node whose value of the label
+                                                            with key topologyKey matches
+                                                            that of any node on which
+                                                            any of the selected pods is
+                                                            running. Empty topologyKey
+                                                            is not allowed.
+                                                          type: string
+                                          nodeSelector:
+                                            description: 'NodeSelector is a selector which
+                                                must be true for the pod to fit on a node.
+                                                Selector which must match a node''s labels
+                                                for the pod to be scheduled on that node.
+                                                More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                          tolerations:
+                                            description: If specified, the pod's tolerations.
+                                            type: array
+                                            items:
+                                              description: The pod this Toleration is
+                                                attached to tolerates any taint that matches
+                                                the triple <key,value,effect> using the
+                                                matching operator <operator>.
+                                              type: object
+                                              properties:
+                                                effect:
+                                                  description: Effect indicates the taint
+                                                    effect to match. Empty means match
+                                                    all taint effects. When specified,
+                                                    allowed values are NoSchedule, PreferNoSchedule
+                                                    and NoExecute.
+                                                  type: string
+                                                key:
+                                                  description: Key is the taint key that
+                                                    the toleration applies to. Empty means
+                                                    match all taint keys. If the key is
+                                                    empty, operator must be Exists; this
+                                                    combination means to match all values
+                                                    and all keys.
+                                                  type: string
+                                                operator:
+                                                  description: Operator represents a key's
+                                                    relationship to the value. Valid operators
+                                                    are Exists and Equal. Defaults to
+                                                    Equal. Exists is equivalent to wildcard
+                                                    for value, so that a pod can tolerate
+                                                    all taints of a particular category.
+                                                  type: string
+                                                tolerationSeconds:
+                                                  description: TolerationSeconds represents
+                                                    the period of time the toleration
+                                                    (which must be of effect NoExecute,
+                                                    otherwise this field is ignored) tolerates
+                                                    the taint. By default, it is not set,
+                                                    which means tolerate the taint forever
+                                                    (do not evict). Zero and negative
+                                                    values will be treated as 0 (evict
+                                                    immediately) by the system.
+                                                  type: integer
+                                                  format: int64
+                                                value:
+                                                  description: Value is the taint value
+                                                    the toleration matches to. If the
+                                                    operator is Exists, the value should
+                                                    be empty, otherwise just a regular
+                                                    string.
+                                                  type: string
+                                  serviceType:
+                                    description: Optional service type for Kubernetes
+                                      solver service
+                                    type: string
+                          selector:
+                            description: Selector selects a set of DNSNames on the Certificate
+                              resource that should be solved using this challenge solver.
+                            type: object
+                            properties:
+                              dnsNames:
+                                description: List of DNSNames that this solver will be
+                                  used to solve. If specified and a match is found, a
+                                  dnsNames selector will take precedence over a dnsZones
+                                  selector. If multiple solvers match with the same dnsNames
+                                  value, the solver with the most matching labels in matchLabels
+                                  will be selected. If neither has more matches, the solver
+                                  defined earlier in the list will be selected.
+                                type: array
+                                items:
+                                  type: string
+                              dnsZones:
+                                description: List of DNSZones that this solver will be
+                                  used to solve. The most specific DNS zone match specified
+                                  here will take precedence over other DNS zone matches,
+                                  so a solver specifying sys.example.com will be selected
+                                  over one specifying example.com for the domain www.sys.example.com.
+                                  If multiple solvers match with the same dnsZones value,
+                                  the solver with the most matching labels in matchLabels
+                                  will be selected. If neither has more matches, the solver
+                                  defined earlier in the list will be selected.
+                                type: array
+                                items:
+                                  type: string
+                              matchLabels:
+                                description: A label selector that is used to refine the
+                                  set of certificate's that this challenge solver will
+                                  apply to.
+                                type: object
+                                additionalProperties:
+                                  type: string
+                ca:
+                  type: object
+                  required:
+                    - secretName
+                  properties:
+                    crlDistributionPoints:
+                      description: The CRL distribution points is an X.509 v3 certificate
+                        extension which identifies the location of the CRL from which
+                        the revocation of this certificate can be checked. If not set
+                        certificate will be issued without CDP. Values are strings.
+                      type: array
+                      items:
+                        type: string
+                    secretName:
+                      description: SecretName is the name of the secret used to sign Certificates
+                        issued by this Issuer.
+                      type: string
+                selfSigned:
+                  type: object
+                  properties:
+                    crlDistributionPoints:
+                      description: The CRL distribution points is an X.509 v3 certificate
+                        extension which identifies the location of the CRL from which
+                        the revocation of this certificate can be checked. If not set
+                        certificate will be issued without CDP. Values are strings.
+                      type: array
+                      items:
+                        type: string
+                vault:
+                  type: object
+                  required:
+                    - auth
+                    - path
+                    - server
+                  properties:
+                    auth:
+                      description: Vault authentication
+                      type: object
+                      properties:
+                        appRole:
+                          description: This Secret contains a AppRole and Secret
+                          type: object
+                          required:
+                            - path
+                            - roleId
+                            - secretRef
+                          properties:
+                            path:
+                              description: Where the authentication path is mounted in
+                                Vault.
+                              type: string
+                            roleId:
+                              type: string
+                            secretRef:
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the secret to select from. Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                                  type: string
+                        kubernetes:
+                          description: This contains a Role and Secret with a ServiceAccount
+                            token to authenticate with vault.
+                          type: object
+                          required:
+                            - role
+                            - secretRef
+                          properties:
+                            mountPath:
+                              description: The Vault mountPath here is the mount path
+                                to use when authenticating with Vault. For example, setting
+                                a value to `/v1/auth/foo`, will use the path `/v1/auth/foo/login`
+                                to authenticate with Vault. If unspecified, the default
+                                value "/v1/auth/kubernetes" will be used.
+                              type: string
+                            role:
+                              description: A required field containing the Vault Role
+                                to assume. A Role binds a Kubernetes ServiceAccount with
+                                a set of Vault policies.
+                              type: string
+                            secretRef:
+                              description: The required Secret field containing a Kubernetes
+                                ServiceAccount JWT used for authenticating with Vault.
+                                Use of 'ambient credentials' is not supported.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the secret to select from. Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                                  type: string
+                        tokenSecretRef:
+                          description: This Secret contains the Vault token key
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            key:
+                              description: The key of the secret to select from. Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                    caBundle:
+                      description: Base64 encoded CA bundle to validate Vault server certificate.
+                        Only used if the Server URL is using HTTPS protocol. This parameter
+                        is ignored for plain HTTP protocol connection. If not set the
+                        system root certificates are used to validate the TLS connection.
+                      type: string
+                      format: byte
+                    path:
+                      description: Vault URL path to the certificate role
+                      type: string
+                    server:
+                      description: Server is the vault connection address
+                      type: string
+                venafi:
+                  description: VenafiIssuer describes issuer configuration details for
+                    Venafi Cloud.
+                  type: object
+                  required:
+                    - zone
+                  properties:
+                    cloud:
+                      description: Cloud specifies the Venafi cloud configuration settings.
+                        Only one of TPP or Cloud may be specified.
+                      type: object
+                      required:
+                        - apiTokenSecretRef
+                      properties:
+                        apiTokenSecretRef:
+                          description: APITokenSecretRef is a secret key selector for
+                            the Venafi Cloud API token.
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            key:
+                              description: The key of the secret to select from. Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                        url:
+                          description: URL is the base URL for Venafi Cloud
+                          type: string
+                    tpp:
+                      description: TPP specifies Trust Protection Platform configuration
+                        settings. Only one of TPP or Cloud may be specified.
+                      type: object
+                      required:
+                        - credentialsRef
+                        - url
+                      properties:
+                        caBundle:
+                          description: CABundle is a PEM encoded TLS certificate to use
+                            to verify connections to the TPP instance. If specified, system
+                            roots will not be used and the issuing CA for the TPP instance
+                            must be verifiable using the provided root. If not specified,
+                            the connection will be verified using the cert-manager system
+                            root certificates.
+                          type: string
+                          format: byte
+                        credentialsRef:
+                          description: CredentialsRef is a reference to a Secret containing
+                            the username and password for the TPP server. The secret must
+                            contain two keys, 'username' and 'password'.
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                        url:
+                          description: URL is the base URL for the Venafi TPP instance
+                          type: string
+                    zone:
+                      description: Zone is the Venafi Policy Zone to use for this issuer.
+                        All requests made to the Venafi platform will be restricted by
+                        the named zone policy. This field is required.
+                      type: string
+            status:
+              description: IssuerStatus contains status information about an Issuer
               type: object
               properties:
-                lastRegisteredEmail:
-                  description: LastRegisteredEmail is the email associated with the
-                    latest registered ACME account, in order to track changes made
-                    to registered account associated with the  Issuer
-                  type: string
-                uri:
-                  description: URI is the unique account identifier, which can also
-                    be used to retrieve account details from the CA
-                  type: string
-            conditions:
-              type: array
-              items:
-                description: IssuerCondition contains condition information for an
-                  Issuer.
-                type: object
-                required:
-                  - status
-                  - type
-                properties:
-                  lastTransitionTime:
-                    description: LastTransitionTime is the timestamp corresponding
-                      to the last status change of this condition.
-                    type: string
-                    format: date-time
-                  message:
-                    description: Message is a human readable description of the details
-                      of the last transition, complementing reason.
-                    type: string
-                  reason:
-                    description: Reason is a brief machine readable explanation for
-                      the condition's last transition.
-                    type: string
-                  status:
-                    description: Status of the condition, one of ('True', 'False',
-                      'Unknown').
-                    type: string
-                    enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                  type:
-                    description: Type of the condition, currently ('Ready').
-                    type: string
+                acme:
+                  type: object
+                  properties:
+                    lastRegisteredEmail:
+                      description: LastRegisteredEmail is the email associated with the
+                        latest registered ACME account, in order to track changes made
+                        to registered account associated with the  Issuer
+                      type: string
+                    uri:
+                      description: URI is the unique account identifier, which can also
+                        be used to retrieve account details from the CA
+                      type: string
+                conditions:
+                  type: array
+                  items:
+                    description: IssuerCondition contains condition information for an
+                      Issuer.
+                    type: object
+                    required:
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: LastTransitionTime is the timestamp corresponding
+                          to the last status change of this condition.
+                        type: string
+                        format: date-time
+                      message:
+                        description: Message is a human readable description of the details
+                          of the last transition, complementing reason.
+                        type: string
+                      reason:
+                        description: Reason is a brief machine readable explanation for
+                          the condition's last transition.
+                        type: string
+                      status:
+                        description: Status of the condition, one of ('True', 'False',
+                          'Unknown').
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      type:
+                        description: Type of the condition, currently ('Ready').
+                        type: string
+      served: true
+      storage: false
+      additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].message
+          name: Status
+          priority: 1
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          description: CreationTimestamp is a timestamp representing the server time when
+            this object was created. It is not guaranteed to be set in happens-before order
+            across separate operations. Clients may not set this value. It is represented
+            in RFC3339 form and is in UTC.
+          name: Age
+          type: date
+      subresources:
+        status: { }

--- a/config/test/crd/cert-manager/cert-manager.io_issuers.yaml
+++ b/config/test/crd/cert-manager/cert-manager.io_issuers.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: issuers.cert-manager.io
@@ -25,21 +25,6 @@ metadata:
     app.kubernetes.io/managed-by: 'Helm'
     helm.sh/chart: 'cert-manager-v0.15.1'
 spec:
-  additionalPrinterColumns:
-    - JSONPath: .status.conditions[?(@.type=="Ready")].status
-      name: Ready
-      type: string
-    - JSONPath: .status.conditions[?(@.type=="Ready")].message
-      name: Status
-      priority: 1
-      type: string
-    - JSONPath: .metadata.creationTimestamp
-      description: CreationTimestamp is a timestamp representing the server time when
-        this object was created. It is not guaranteed to be set in happens-before order
-        across separate operations. Clients may not set this value. It is represented
-        in RFC3339 form and is in UTC.
-      name: Age
-      type: date
   group: cert-manager.io
   preserveUnknownFields: false
   names:
@@ -48,955 +33,1084 @@ spec:
     plural: issuers
     singular: issuer
   scope: Namespaced
-  subresources:
-    status: {}
   versions:
     - name: v1alpha2
-      served: true
-      storage: true
-    - name: v1alpha3
-      served: true
-      storage: false
-  "validation":
-    "openAPIV3Schema":
-      type: object
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: IssuerSpec is the specification of an Issuer. This includes
-            any configuration required for the issuer.
+      schema:
+        openAPIV3Schema:
           type: object
           properties:
-            acme:
-              description: ACMEIssuer contains the specification for an ACME issuer
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
               type: object
-              required:
-                - privateKeySecretRef
-                - server
+            spec:
+              description: IssuerSpec is the specification of an Issuer. This includes
+                any configuration required for the issuer.
+              type: object
               properties:
-                email:
-                  description: Email is the email for this account
-                  type: string
-                externalAccountBinding:
-                  description: ExternalAccountBinding is a reference to a CA external
-                    account of the ACME server.
+                acme:
+                  description: ACMEIssuer contains the specification for an ACME issuer
                   type: object
                   required:
-                    - keyAlgorithm
-                    - keyID
-                    - keySecretRef
+                    - privateKeySecretRef
+                    - server
                   properties:
-                    keyAlgorithm:
-                      description: keyAlgorithm is the MAC key algorithm that the
-                        key is used for. Valid values are "HS256", "HS384" and "HS512".
+                    email:
+                      description: Email is the email for this account
                       type: string
-                      enum:
-                        - HS256
-                        - HS384
-                        - HS512
-                    keyID:
-                      description: keyID is the ID of the CA key that the External
-                        Account is bound to.
-                      type: string
-                    keySecretRef:
-                      description: keySecretRef is a Secret Key Selector referencing
-                        a data item in a Kubernetes Secret which holds the symmetric
-                        MAC key of the External Account Binding. The `key` is the
-                        index string that is paired with the key data in the Secret
-                        and should not be confused with the key data itself, or indeed
-                        with the External Account Binding keyID above. The secret
-                        key stored in the Secret **must** be un-padded, base64 URL
-                        encoded data.
+                    externalAccountBinding:
+                      description: ExternalAccountBinding is a reference to a CA external
+                        account of the ACME server.
+                      type: object
+                      required:
+                        - keyAlgorithm
+                        - keyID
+                        - keySecretRef
+                      properties:
+                        keyAlgorithm:
+                          description: keyAlgorithm is the MAC key algorithm that the
+                            key is used for. Valid values are "HS256", "HS384" and "HS512".
+                          type: string
+                          enum:
+                            - HS256
+                            - HS384
+                            - HS512
+                        keyID:
+                          description: keyID is the ID of the CA key that the External
+                            Account is bound to.
+                          type: string
+                        keySecretRef:
+                          description: keySecretRef is a Secret Key Selector referencing
+                            a data item in a Kubernetes Secret which holds the symmetric
+                            MAC key of the External Account Binding. The `key` is the
+                            index string that is paired with the key data in the Secret
+                            and should not be confused with the key data itself, or indeed
+                            with the External Account Binding keyID above. The secret
+                            key stored in the Secret **must** be un-padded, base64 URL
+                            encoded data.
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            key:
+                              description: The key of the secret to select from. Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                    privateKeySecretRef:
+                      description: PrivateKey is the name of a secret containing the private
+                        key for this user account.
                       type: object
                       required:
                         - name
                       properties:
                         key:
-                          description: The key of the secret to select from. Must
-                            be a valid secret key.
+                          description: The key of the secret to select from. Must be a
+                            valid secret key.
                           type: string
                         name:
                           description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
                           type: string
-                privateKeySecretRef:
-                  description: PrivateKey is the name of a secret containing the private
-                    key for this user account.
-                  type: object
-                  required:
-                    - name
-                  properties:
-                    key:
-                      description: The key of the secret to select from. Must be a
-                        valid secret key.
+                    server:
+                      description: Server is the ACME server URL
                       type: string
-                    name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                        TODO: Add other useful fields. apiVersion, kind, uid?'
-                      type: string
-                server:
-                  description: Server is the ACME server URL
-                  type: string
-                skipTLSVerify:
-                  description: If true, skip verifying the ACME server TLS certificate
-                  type: boolean
-                solvers:
-                  description: Solvers is a list of challenge solvers that will be
-                    used to solve ACME challenges for the matching domains.
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      dns01:
+                    skipTLSVerify:
+                      description: If true, skip verifying the ACME server TLS certificate
+                      type: boolean
+                    solvers:
+                      description: Solvers is a list of challenge solvers that will be
+                        used to solve ACME challenges for the matching domains.
+                      type: array
+                      items:
                         type: object
                         properties:
-                          acmedns:
-                            description: ACMEIssuerDNS01ProviderAcmeDNS is a structure
-                              containing the configuration for ACME-DNS servers
+                          dns01:
                             type: object
-                            required:
-                              - accountSecretRef
-                              - host
                             properties:
-                              accountSecretRef:
+                              acmedns:
+                                description: ACMEIssuerDNS01ProviderAcmeDNS is a structure
+                                  containing the configuration for ACME-DNS servers
                                 type: object
                                 required:
-                                  - name
+                                  - accountSecretRef
+                                  - host
                                 properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
+                                  accountSecretRef:
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.
+                                          Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion, kind,
+                                            uid?'
+                                        type: string
+                                  host:
                                     type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                              host:
-                                type: string
-                          akamai:
-                            description: ACMEIssuerDNS01ProviderAkamai is a structure
-                              containing the DNS configuration for Akamai DNS—Zone
-                              Record Management API
-                            type: object
-                            required:
-                              - accessTokenSecretRef
-                              - clientSecretSecretRef
-                              - clientTokenSecretRef
-                              - serviceConsumerDomain
-                            properties:
-                              accessTokenSecretRef:
+                              akamai:
+                                description: ACMEIssuerDNS01ProviderAkamai is a structure
+                                  containing the DNS configuration for Akamai DNS—Zone
+                                  Record Management API
                                 type: object
                                 required:
-                                  - name
+                                  - accessTokenSecretRef
+                                  - clientSecretSecretRef
+                                  - clientTokenSecretRef
+                                  - serviceConsumerDomain
                                 properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
+                                  accessTokenSecretRef:
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.
+                                          Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion, kind,
+                                            uid?'
+                                        type: string
+                                  clientSecretSecretRef:
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.
+                                          Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion, kind,
+                                            uid?'
+                                        type: string
+                                  clientTokenSecretRef:
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.
+                                          Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion, kind,
+                                            uid?'
+                                        type: string
+                                  serviceConsumerDomain:
                                     type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                              clientSecretSecretRef:
+                              azuredns:
+                                description: ACMEIssuerDNS01ProviderAzureDNS is a structure
+                                  containing the configuration for Azure DNS
                                 type: object
                                 required:
-                                  - name
+                                  - resourceGroupName
+                                  - subscriptionID
                                 properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
+                                  clientID:
+                                    description: if both this and ClientSecret are left
+                                      unset MSI will be used
                                     type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                  clientSecretSecretRef:
+                                    description: if both this and ClientID are left unset
+                                      MSI will be used
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.
+                                          Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion, kind,
+                                            uid?'
+                                        type: string
+                                  environment:
                                     type: string
-                              clientTokenSecretRef:
+                                    enum:
+                                      - AzurePublicCloud
+                                      - AzureChinaCloud
+                                      - AzureGermanCloud
+                                      - AzureUSGovernmentCloud
+                                  hostedZoneName:
+                                    type: string
+                                  resourceGroupName:
+                                    type: string
+                                  subscriptionID:
+                                    type: string
+                                  tenantID:
+                                    description: when specifying ClientID and ClientSecret
+                                      then this field is also needed
+                                    type: string
+                              clouddns:
+                                description: ACMEIssuerDNS01ProviderCloudDNS is a structure
+                                  containing the DNS configuration for Google Cloud DNS
                                 type: object
                                 required:
-                                  - name
+                                  - project
                                 properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
+                                  project:
                                     type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                              serviceConsumerDomain:
-                                type: string
-                          azuredns:
-                            description: ACMEIssuerDNS01ProviderAzureDNS is a structure
-                              containing the configuration for Azure DNS
-                            type: object
-                            required:
-                              - resourceGroupName
-                              - subscriptionID
-                            properties:
-                              clientID:
-                                description: if both this and ClientSecret are left
-                                  unset MSI will be used
-                                type: string
-                              clientSecretSecretRef:
-                                description: if both this and ClientID are left unset
-                                  MSI will be used
+                                  serviceAccountSecretRef:
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.
+                                          Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion, kind,
+                                            uid?'
+                                        type: string
+                              cloudflare:
+                                description: ACMEIssuerDNS01ProviderCloudflare is a structure
+                                  containing the DNS configuration for Cloudflare
                                 type: object
                                 required:
-                                  - name
+                                  - email
                                 properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
+                                  apiKeySecretRef:
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.
+                                          Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion, kind,
+                                            uid?'
+                                        type: string
+                                  apiTokenSecretRef:
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.
+                                          Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion, kind,
+                                            uid?'
+                                        type: string
+                                  email:
                                     type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                              environment:
+                              cnameStrategy:
+                                description: CNAMEStrategy configures how the DNS01 provider
+                                  should handle CNAME records when found in DNS zones.
                                 type: string
                                 enum:
-                                  - AzurePublicCloud
-                                  - AzureChinaCloud
-                                  - AzureGermanCloud
-                                  - AzureUSGovernmentCloud
-                              hostedZoneName:
-                                type: string
-                              resourceGroupName:
-                                type: string
-                              subscriptionID:
-                                type: string
-                              tenantID:
-                                description: when specifying ClientID and ClientSecret
-                                  then this field is also needed
-                                type: string
-                          clouddns:
-                            description: ACMEIssuerDNS01ProviderCloudDNS is a structure
-                              containing the DNS configuration for Google Cloud DNS
-                            type: object
-                            required:
-                              - project
-                            properties:
-                              project:
-                                type: string
-                              serviceAccountSecretRef:
+                                  - None
+                                  - Follow
+                              digitalocean:
+                                description: ACMEIssuerDNS01ProviderDigitalOcean is a
+                                  structure containing the DNS configuration for DigitalOcean
+                                  Domains
                                 type: object
                                 required:
-                                  - name
+                                  - tokenSecretRef
                                 properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                          cloudflare:
-                            description: ACMEIssuerDNS01ProviderCloudflare is a structure
-                              containing the DNS configuration for Cloudflare
-                            type: object
-                            required:
-                              - email
-                            properties:
-                              apiKeySecretRef:
+                                  tokenSecretRef:
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.
+                                          Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion, kind,
+                                            uid?'
+                                        type: string
+                              rfc2136:
+                                description: ACMEIssuerDNS01ProviderRFC2136 is a structure
+                                  containing the configuration for RFC2136 DNS
                                 type: object
                                 required:
-                                  - name
+                                  - nameserver
                                 properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
+                                  nameserver:
+                                    description: The IP address or hostname of an authoritative
+                                      DNS server supporting RFC2136 in the form host:port.
+                                      If the host is an IPv6 address it must be enclosed
+                                      in square brackets (e.g [2001:db8::1]) ; port is
+                                      optional. This field is required.
                                     type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                  tsigAlgorithm:
+                                    description: 'The TSIG Algorithm configured in the
+                                        DNS supporting RFC2136. Used only when ``tsigSecretSecretRef``
+                                        and ``tsigKeyName`` are defined. Supported values
+                                        are (case-insensitive): ``HMACMD5`` (default), ``HMACSHA1``,
+                                        ``HMACSHA256`` or ``HMACSHA512``.'
                                     type: string
-                              apiTokenSecretRef:
+                                  tsigKeyName:
+                                    description: The TSIG Key name configured in the DNS.
+                                      If ``tsigSecretSecretRef`` is defined, this field
+                                      is required.
+                                    type: string
+                                  tsigSecretSecretRef:
+                                    description: The name of the secret containing the
+                                      TSIG value. If ``tsigKeyName`` is defined, this
+                                      field is required.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.
+                                          Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion, kind,
+                                            uid?'
+                                        type: string
+                              route53:
+                                description: ACMEIssuerDNS01ProviderRoute53 is a structure
+                                  containing the Route 53 configuration for AWS
                                 type: object
                                 required:
-                                  - name
+                                  - region
                                 properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
+                                  accessKeyID:
+                                    description: 'The AccessKeyID is used for authentication.
+                                        If not set we fall-back to using env vars, shared
+                                        credentials file or AWS Instance metadata see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
                                     type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                  hostedZoneID:
+                                    description: If set, the provider will manage only
+                                      this zone in Route53 and will not do an lookup using
+                                      the route53:ListHostedZonesByName api call.
                                     type: string
-                              email:
-                                type: string
-                          cnameStrategy:
-                            description: CNAMEStrategy configures how the DNS01 provider
-                              should handle CNAME records when found in DNS zones.
-                            type: string
-                            enum:
-                              - None
-                              - Follow
-                          digitalocean:
-                            description: ACMEIssuerDNS01ProviderDigitalOcean is a
-                              structure containing the DNS configuration for DigitalOcean
-                              Domains
-                            type: object
-                            required:
-                              - tokenSecretRef
-                            properties:
-                              tokenSecretRef:
+                                  region:
+                                    description: Always set the region when using AccessKeyID
+                                      and SecretAccessKey
+                                    type: string
+                                  role:
+                                    description: Role is a Role ARN which the Route53
+                                      provider will assume using either the explicit credentials
+                                      AccessKeyID/SecretAccessKey or the inferred credentials
+                                      from environment variables, shared credentials file
+                                      or AWS Instance metadata
+                                    type: string
+                                  secretAccessKeySecretRef:
+                                    description: The SecretAccessKey is used for authentication.
+                                      If not set we fall-back to using env vars, shared
+                                      credentials file or AWS Instance metadata https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.
+                                          Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion, kind,
+                                            uid?'
+                                        type: string
+                              webhook:
+                                description: ACMEIssuerDNS01ProviderWebhook specifies
+                                  configuration for a webhook DNS01 provider, including
+                                  where to POST ChallengePayload resources.
                                 type: object
                                 required:
-                                  - name
+                                  - groupName
+                                  - solverName
                                 properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
+                                  config:
+                                    description: Additional configuration that should
+                                      be passed to the webhook apiserver when challenges
+                                      are processed. This can contain arbitrary JSON data.
+                                      Secret values should not be specified in this stanza.
+                                      If secret values are needed (e.g. credentials for
+                                      a DNS service), you should use a SecretKeySelector
+                                      to reference a Secret resource. For details on the
+                                      schema of this field, consult the webhook provider
+                                      implementation's documentation.
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  groupName:
+                                    description: The API group name that should be used
+                                      when POSTing ChallengePayload resources to the webhook
+                                      apiserver. This should be the same as the GroupName
+                                      specified in the webhook provider implementation.
                                     type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                  solverName:
+                                    description: The name of the solver to use, as defined
+                                      in the webhook provider implementation. This will
+                                      typically be the name of the provider, e.g. 'cloudflare'.
                                     type: string
-                          rfc2136:
-                            description: ACMEIssuerDNS01ProviderRFC2136 is a structure
-                              containing the configuration for RFC2136 DNS
-                            type: object
-                            required:
-                              - nameserver
-                            properties:
-                              nameserver:
-                                description: The IP address or hostname of an authoritative
-                                  DNS server supporting RFC2136 in the form host:port.
-                                  If the host is an IPv6 address it must be enclosed
-                                  in square brackets (e.g [2001:db8::1]) ; port is
-                                  optional. This field is required.
-                                type: string
-                              tsigAlgorithm:
-                                description: 'The TSIG Algorithm configured in the
-                                  DNS supporting RFC2136. Used only when ``tsigSecretSecretRef``
-                                  and ``tsigKeyName`` are defined. Supported values
-                                  are (case-insensitive): ``HMACMD5`` (default), ``HMACSHA1``,
-                                  ``HMACSHA256`` or ``HMACSHA512``.'
-                                type: string
-                              tsigKeyName:
-                                description: The TSIG Key name configured in the DNS.
-                                  If ``tsigSecretSecretRef`` is defined, this field
-                                  is required.
-                                type: string
-                              tsigSecretSecretRef:
-                                description: The name of the secret containing the
-                                  TSIG value. If ``tsigKeyName`` is defined, this
-                                  field is required.
-                                type: object
-                                required:
-                                  - name
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                          route53:
-                            description: ACMEIssuerDNS01ProviderRoute53 is a structure
-                              containing the Route 53 configuration for AWS
-                            type: object
-                            required:
-                              - region
-                            properties:
-                              accessKeyID:
-                                description: 'The AccessKeyID is used for authentication.
-                                  If not set we fall-back to using env vars, shared
-                                  credentials file or AWS Instance metadata see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
-                                type: string
-                              hostedZoneID:
-                                description: If set, the provider will manage only
-                                  this zone in Route53 and will not do an lookup using
-                                  the route53:ListHostedZonesByName api call.
-                                type: string
-                              region:
-                                description: Always set the region when using AccessKeyID
-                                  and SecretAccessKey
-                                type: string
-                              role:
-                                description: Role is a Role ARN which the Route53
-                                  provider will assume using either the explicit credentials
-                                  AccessKeyID/SecretAccessKey or the inferred credentials
-                                  from environment variables, shared credentials file
-                                  or AWS Instance metadata
-                                type: string
-                              secretAccessKeySecretRef:
-                                description: The SecretAccessKey is used for authentication.
-                                  If not set we fall-back to using env vars, shared
-                                  credentials file or AWS Instance metadata https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
-                                type: object
-                                required:
-                                  - name
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.
-                                      Must be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                          webhook:
-                            description: ACMEIssuerDNS01ProviderWebhook specifies
-                              configuration for a webhook DNS01 provider, including
-                              where to POST ChallengePayload resources.
-                            type: object
-                            required:
-                              - groupName
-                              - solverName
-                            properties:
-                              config:
-                                description: Additional configuration that should
-                                  be passed to the webhook apiserver when challenges
-                                  are processed. This can contain arbitrary JSON data.
-                                  Secret values should not be specified in this stanza.
-                                  If secret values are needed (e.g. credentials for
-                                  a DNS service), you should use a SecretKeySelector
-                                  to reference a Secret resource. For details on the
-                                  schema of this field, consult the webhook provider
-                                  implementation's documentation.
-                                x-kubernetes-preserve-unknown-fields: true
-                              groupName:
-                                description: The API group name that should be used
-                                  when POSTing ChallengePayload resources to the webhook
-                                  apiserver. This should be the same as the GroupName
-                                  specified in the webhook provider implementation.
-                                type: string
-                              solverName:
-                                description: The name of the solver to use, as defined
-                                  in the webhook provider implementation. This will
-                                  typically be the name of the provider, e.g. 'cloudflare'.
-                                type: string
-                      http01:
-                        description: ACMEChallengeSolverHTTP01 contains configuration
-                          detailing how to solve HTTP01 challenges within a Kubernetes
-                          cluster. Typically this is accomplished through creating
-                          'routes' of some description that configure ingress controllers
-                          to direct traffic to 'solver pods', which are responsible
-                          for responding to the ACME server's HTTP requests.
-                        type: object
-                        properties:
-                          ingress:
-                            description: The ingress based HTTP01 challenge solver
-                              will solve challenges by creating or modifying Ingress
-                              resources in order to route requests for '/.well-known/acme-challenge/XYZ'
-                              to 'challenge solver' pods that are provisioned by cert-manager
-                              for each Challenge to be completed.
+                          http01:
+                            description: ACMEChallengeSolverHTTP01 contains configuration
+                              detailing how to solve HTTP01 challenges within a Kubernetes
+                              cluster. Typically this is accomplished through creating
+                              'routes' of some description that configure ingress controllers
+                              to direct traffic to 'solver pods', which are responsible
+                              for responding to the ACME server's HTTP requests.
                             type: object
                             properties:
-                              class:
-                                description: The ingress class to use when creating
-                                  Ingress resources to solve ACME challenges that
-                                  use this challenge solver. Only one of 'class' or
-                                  'name' may be specified.
-                                type: string
-                              ingressTemplate:
-                                description: Optional ingress template used to configure
-                                  the ACME challenge solver ingress used for HTTP01
-                                  challenges
+                              ingress:
+                                description: The ingress based HTTP01 challenge solver
+                                  will solve challenges by creating or modifying Ingress
+                                  resources in order to route requests for '/.well-known/acme-challenge/XYZ'
+                                  to 'challenge solver' pods that are provisioned by cert-manager
+                                  for each Challenge to be completed.
                                 type: object
                                 properties:
-                                  metadata:
-                                    description: ObjectMeta overrides for the ingress
-                                      used to solve HTTP01 challenges. Only the 'labels'
-                                      and 'annotations' fields may be set. If labels
-                                      or annotations overlap with in-built values,
-                                      the values here will override the in-built values.
+                                  class:
+                                    description: The ingress class to use when creating
+                                      Ingress resources to solve ACME challenges that
+                                      use this challenge solver. Only one of 'class' or
+                                      'name' may be specified.
+                                    type: string
+                                  ingressTemplate:
+                                    description: Optional ingress template used to configure
+                                      the ACME challenge solver ingress used for HTTP01
+                                      challenges
                                     type: object
                                     properties:
-                                      annotations:
-                                        description: Annotations that should be added
-                                          to the created ACME HTTP01 solver ingress.
-                                        type: object
-                                        additionalProperties:
-                                          type: string
-                                      labels:
-                                        description: Labels that should be added to
-                                          the created ACME HTTP01 solver ingress.
-                                        type: object
-                                        additionalProperties:
-                                          type: string
-                              name:
-                                description: The name of the ingress resource that
-                                  should have ACME challenge solving routes inserted
-                                  into it in order to solve HTTP01 challenges. This
-                                  is typically used in conjunction with ingress controllers
-                                  like ingress-gce, which maintains a 1:1 mapping
-                                  between external IPs and ingress resources.
-                                type: string
-                              podTemplate:
-                                description: Optional pod template used to configure
-                                  the ACME challenge solver pods used for HTTP01 challenges
-                                type: object
-                                properties:
-                                  metadata:
-                                    description: ObjectMeta overrides for the pod
-                                      used to solve HTTP01 challenges. Only the 'labels'
-                                      and 'annotations' fields may be set. If labels
-                                      or annotations overlap with in-built values,
-                                      the values here will override the in-built values.
-                                    type: object
-                                    properties:
-                                      annotations:
-                                        description: Annotations that should be added
-                                          to the create ACME HTTP01 solver pods.
-                                        type: object
-                                        additionalProperties:
-                                          type: string
-                                      labels:
-                                        description: Labels that should be added to
-                                          the created ACME HTTP01 solver pods.
-                                        type: object
-                                        additionalProperties:
-                                          type: string
-                                  spec:
-                                    description: PodSpec defines overrides for the
-                                      HTTP01 challenge solver pod. Only the 'nodeSelector',
-                                      'affinity' and 'tolerations' fields are supported
-                                      currently. All other fields will be ignored.
-                                    type: object
-                                    properties:
-                                      affinity:
-                                        description: If specified, the pod's scheduling
-                                          constraints
+                                      metadata:
+                                        description: ObjectMeta overrides for the ingress
+                                          used to solve HTTP01 challenges. Only the 'labels'
+                                          and 'annotations' fields may be set. If labels
+                                          or annotations overlap with in-built values,
+                                          the values here will override the in-built values.
                                         type: object
                                         properties:
-                                          nodeAffinity:
-                                            description: Describes node affinity scheduling
-                                              rules for the pod.
+                                          annotations:
+                                            description: Annotations that should be added
+                                              to the created ACME HTTP01 solver ingress.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                          labels:
+                                            description: Labels that should be added to
+                                              the created ACME HTTP01 solver ingress.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                  name:
+                                    description: The name of the ingress resource that
+                                      should have ACME challenge solving routes inserted
+                                      into it in order to solve HTTP01 challenges. This
+                                      is typically used in conjunction with ingress controllers
+                                      like ingress-gce, which maintains a 1:1 mapping
+                                      between external IPs and ingress resources.
+                                    type: string
+                                  podTemplate:
+                                    description: Optional pod template used to configure
+                                      the ACME challenge solver pods used for HTTP01 challenges
+                                    type: object
+                                    properties:
+                                      metadata:
+                                        description: ObjectMeta overrides for the pod
+                                          used to solve HTTP01 challenges. Only the 'labels'
+                                          and 'annotations' fields may be set. If labels
+                                          or annotations overlap with in-built values,
+                                          the values here will override the in-built values.
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            description: Annotations that should be added
+                                              to the create ACME HTTP01 solver pods.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                          labels:
+                                            description: Labels that should be added to
+                                              the created ACME HTTP01 solver pods.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                      spec:
+                                        description: PodSpec defines overrides for the
+                                          HTTP01 challenge solver pod. Only the 'nodeSelector',
+                                          'affinity' and 'tolerations' fields are supported
+                                          currently. All other fields will be ignored.
+                                        type: object
+                                        properties:
+                                          affinity:
+                                            description: If specified, the pod's scheduling
+                                              constraints
                                             type: object
                                             properties:
-                                              preferredDuringSchedulingIgnoredDuringExecution:
-                                                description: The scheduler will prefer
-                                                  to schedule pods to nodes that satisfy
-                                                  the affinity expressions specified
-                                                  by this field, but it may choose
-                                                  a node that violates one or more
-                                                  of the expressions. The node that
-                                                  is most preferred is the one with
-                                                  the greatest sum of weights, i.e.
-                                                  for each node that meets all of
-                                                  the scheduling requirements (resource
-                                                  request, requiredDuringScheduling
-                                                  affinity expressions, etc.), compute
-                                                  a sum by iterating through the elements
-                                                  of this field and adding "weight"
-                                                  to the sum if the node matches the
-                                                  corresponding matchExpressions;
-                                                  the node(s) with the highest sum
-                                                  are the most preferred.
-                                                type: array
-                                                items:
-                                                  description: An empty preferred
-                                                    scheduling term matches all objects
-                                                    with implicit weight 0 (i.e. it's
-                                                    a no-op). A null preferred scheduling
-                                                    term matches no objects (i.e.
-                                                    is also a no-op).
-                                                  type: object
-                                                  required:
-                                                    - preference
-                                                    - weight
-                                                  properties:
-                                                    preference:
-                                                      description: A node selector
-                                                        term, associated with the
-                                                        corresponding weight.
-                                                      type: object
-                                                      properties:
-                                                        matchExpressions:
-                                                          description: A list of node
-                                                            selector requirements
-                                                            by node's labels.
-                                                          type: array
-                                                          items:
-                                                            description: A node selector
-                                                              requirement is a selector
-                                                              that contains values,
-                                                              a key, and an operator
-                                                              that relates the key
-                                                              and values.
-                                                            type: object
-                                                            required:
-                                                              - key
-                                                              - operator
-                                                            properties:
-                                                              key:
-                                                                description: The label
-                                                                  key that the selector
-                                                                  applies to.
-                                                                type: string
-                                                              operator:
-                                                                description: Represents
-                                                                  a key's relationship
-                                                                  to a set of values.
-                                                                  Valid operators
-                                                                  are In, NotIn, Exists,
-                                                                  DoesNotExist. Gt,
-                                                                  and Lt.
-                                                                type: string
-                                                              values:
-                                                                description: An array
-                                                                  of string values.
-                                                                  If the operator
-                                                                  is In or NotIn,
-                                                                  the values array
-                                                                  must be non-empty.
-                                                                  If the operator
-                                                                  is Exists or DoesNotExist,
-                                                                  the values array
-                                                                  must be empty. If
-                                                                  the operator is
-                                                                  Gt or Lt, the values
-                                                                  array must have
-                                                                  a single element,
-                                                                  which will be interpreted
-                                                                  as an integer. This
-                                                                  array is replaced
-                                                                  during a strategic
-                                                                  merge patch.
-                                                                type: array
-                                                                items:
-                                                                  type: string
-                                                        matchFields:
-                                                          description: A list of node
-                                                            selector requirements
-                                                            by node's fields.
-                                                          type: array
-                                                          items:
-                                                            description: A node selector
-                                                              requirement is a selector
-                                                              that contains values,
-                                                              a key, and an operator
-                                                              that relates the key
-                                                              and values.
-                                                            type: object
-                                                            required:
-                                                              - key
-                                                              - operator
-                                                            properties:
-                                                              key:
-                                                                description: The label
-                                                                  key that the selector
-                                                                  applies to.
-                                                                type: string
-                                                              operator:
-                                                                description: Represents
-                                                                  a key's relationship
-                                                                  to a set of values.
-                                                                  Valid operators
-                                                                  are In, NotIn, Exists,
-                                                                  DoesNotExist. Gt,
-                                                                  and Lt.
-                                                                type: string
-                                                              values:
-                                                                description: An array
-                                                                  of string values.
-                                                                  If the operator
-                                                                  is In or NotIn,
-                                                                  the values array
-                                                                  must be non-empty.
-                                                                  If the operator
-                                                                  is Exists or DoesNotExist,
-                                                                  the values array
-                                                                  must be empty. If
-                                                                  the operator is
-                                                                  Gt or Lt, the values
-                                                                  array must have
-                                                                  a single element,
-                                                                  which will be interpreted
-                                                                  as an integer. This
-                                                                  array is replaced
-                                                                  during a strategic
-                                                                  merge patch.
-                                                                type: array
-                                                                items:
-                                                                  type: string
-                                                    weight:
-                                                      description: Weight associated
-                                                        with matching the corresponding
-                                                        nodeSelectorTerm, in the range
-                                                        1-100.
-                                                      type: integer
-                                                      format: int32
-                                              requiredDuringSchedulingIgnoredDuringExecution:
-                                                description: If the affinity requirements
-                                                  specified by this field are not
-                                                  met at scheduling time, the pod
-                                                  will not be scheduled onto the node.
-                                                  If the affinity requirements specified
-                                                  by this field cease to be met at
-                                                  some point during pod execution
-                                                  (e.g. due to an update), the system
-                                                  may or may not try to eventually
-                                                  evict the pod from its node.
+                                              nodeAffinity:
+                                                description: Describes node affinity scheduling
+                                                  rules for the pod.
                                                 type: object
-                                                required:
-                                                  - nodeSelectorTerms
                                                 properties:
-                                                  nodeSelectorTerms:
-                                                    description: Required. A list
-                                                      of node selector terms. The
-                                                      terms are ORed.
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: The scheduler will prefer
+                                                      to schedule pods to nodes that satisfy
+                                                      the affinity expressions specified
+                                                      by this field, but it may choose
+                                                      a node that violates one or more
+                                                      of the expressions. The node that
+                                                      is most preferred is the one with
+                                                      the greatest sum of weights, i.e.
+                                                      for each node that meets all of
+                                                      the scheduling requirements (resource
+                                                      request, requiredDuringScheduling
+                                                      affinity expressions, etc.), compute
+                                                      a sum by iterating through the elements
+                                                      of this field and adding "weight"
+                                                      to the sum if the node matches the
+                                                      corresponding matchExpressions;
+                                                      the node(s) with the highest sum
+                                                      are the most preferred.
                                                     type: array
                                                     items:
-                                                      description: A null or empty
-                                                        node selector term matches
-                                                        no objects. The requirements
-                                                        of them are ANDed. The TopologySelectorTerm
-                                                        type implements a subset of
-                                                        the NodeSelectorTerm.
-                                                      type: object
-                                                      properties:
-                                                        matchExpressions:
-                                                          description: A list of node
-                                                            selector requirements
-                                                            by node's labels.
-                                                          type: array
-                                                          items:
-                                                            description: A node selector
-                                                              requirement is a selector
-                                                              that contains values,
-                                                              a key, and an operator
-                                                              that relates the key
-                                                              and values.
-                                                            type: object
-                                                            required:
-                                                              - key
-                                                              - operator
-                                                            properties:
-                                                              key:
-                                                                description: The label
-                                                                  key that the selector
-                                                                  applies to.
-                                                                type: string
-                                                              operator:
-                                                                description: Represents
-                                                                  a key's relationship
-                                                                  to a set of values.
-                                                                  Valid operators
-                                                                  are In, NotIn, Exists,
-                                                                  DoesNotExist. Gt,
-                                                                  and Lt.
-                                                                type: string
-                                                              values:
-                                                                description: An array
-                                                                  of string values.
-                                                                  If the operator
-                                                                  is In or NotIn,
-                                                                  the values array
-                                                                  must be non-empty.
-                                                                  If the operator
-                                                                  is Exists or DoesNotExist,
-                                                                  the values array
-                                                                  must be empty. If
-                                                                  the operator is
-                                                                  Gt or Lt, the values
-                                                                  array must have
-                                                                  a single element,
-                                                                  which will be interpreted
-                                                                  as an integer. This
-                                                                  array is replaced
-                                                                  during a strategic
-                                                                  merge patch.
-                                                                type: array
-                                                                items:
-                                                                  type: string
-                                                        matchFields:
-                                                          description: A list of node
-                                                            selector requirements
-                                                            by node's fields.
-                                                          type: array
-                                                          items:
-                                                            description: A node selector
-                                                              requirement is a selector
-                                                              that contains values,
-                                                              a key, and an operator
-                                                              that relates the key
-                                                              and values.
-                                                            type: object
-                                                            required:
-                                                              - key
-                                                              - operator
-                                                            properties:
-                                                              key:
-                                                                description: The label
-                                                                  key that the selector
-                                                                  applies to.
-                                                                type: string
-                                                              operator:
-                                                                description: Represents
-                                                                  a key's relationship
-                                                                  to a set of values.
-                                                                  Valid operators
-                                                                  are In, NotIn, Exists,
-                                                                  DoesNotExist. Gt,
-                                                                  and Lt.
-                                                                type: string
-                                                              values:
-                                                                description: An array
-                                                                  of string values.
-                                                                  If the operator
-                                                                  is In or NotIn,
-                                                                  the values array
-                                                                  must be non-empty.
-                                                                  If the operator
-                                                                  is Exists or DoesNotExist,
-                                                                  the values array
-                                                                  must be empty. If
-                                                                  the operator is
-                                                                  Gt or Lt, the values
-                                                                  array must have
-                                                                  a single element,
-                                                                  which will be interpreted
-                                                                  as an integer. This
-                                                                  array is replaced
-                                                                  during a strategic
-                                                                  merge patch.
-                                                                type: array
-                                                                items:
-                                                                  type: string
-                                          podAffinity:
-                                            description: Describes pod affinity scheduling
-                                              rules (e.g. co-locate this pod in the
-                                              same node, zone, etc. as some other
-                                              pod(s)).
-                                            type: object
-                                            properties:
-                                              preferredDuringSchedulingIgnoredDuringExecution:
-                                                description: The scheduler will prefer
-                                                  to schedule pods to nodes that satisfy
-                                                  the affinity expressions specified
-                                                  by this field, but it may choose
-                                                  a node that violates one or more
-                                                  of the expressions. The node that
-                                                  is most preferred is the one with
-                                                  the greatest sum of weights, i.e.
-                                                  for each node that meets all of
-                                                  the scheduling requirements (resource
-                                                  request, requiredDuringScheduling
-                                                  affinity expressions, etc.), compute
-                                                  a sum by iterating through the elements
-                                                  of this field and adding "weight"
-                                                  to the sum if the node has pods
-                                                  which matches the corresponding
-                                                  podAffinityTerm; the node(s) with
-                                                  the highest sum are the most preferred.
-                                                type: array
-                                                items:
-                                                  description: The weights of all
-                                                    of the matched WeightedPodAffinityTerm
-                                                    fields are added per-node to find
-                                                    the most preferred node(s)
-                                                  type: object
-                                                  required:
-                                                    - podAffinityTerm
-                                                    - weight
-                                                  properties:
-                                                    podAffinityTerm:
-                                                      description: Required. A pod
-                                                        affinity term, associated
-                                                        with the corresponding weight.
+                                                      description: An empty preferred
+                                                        scheduling term matches all objects
+                                                        with implicit weight 0 (i.e. it's
+                                                        a no-op). A null preferred scheduling
+                                                        term matches no objects (i.e.
+                                                        is also a no-op).
                                                       type: object
                                                       required:
-                                                        - topologyKey
+                                                        - preference
+                                                        - weight
                                                       properties:
-                                                        labelSelector:
-                                                          description: A label query
-                                                            over a set of resources,
-                                                            in this case pods.
+                                                        preference:
+                                                          description: A node selector
+                                                            term, associated with the
+                                                            corresponding weight.
                                                           type: object
                                                           properties:
                                                             matchExpressions:
-                                                              description: matchExpressions
-                                                                is a list of label
-                                                                selector requirements.
-                                                                The requirements are
-                                                                ANDed.
+                                                              description: A list of node
+                                                                selector requirements
+                                                                by node's labels.
                                                               type: array
                                                               items:
-                                                                description: A label
-                                                                  selector requirement
-                                                                  is a selector that
-                                                                  contains values,
+                                                                description: A node selector
+                                                                  requirement is a selector
+                                                                  that contains values,
                                                                   a key, and an operator
-                                                                  that relates the
-                                                                  key and values.
+                                                                  that relates the key
+                                                                  and values.
                                                                 type: object
                                                                 required:
                                                                   - key
                                                                   - operator
                                                                 properties:
                                                                   key:
-                                                                    description: key
-                                                                      is the label
-                                                                      key that the
-                                                                      selector applies
-                                                                      to.
+                                                                    description: The label
+                                                                      key that the selector
+                                                                      applies to.
                                                                     type: string
                                                                   operator:
-                                                                    description: operator
-                                                                      represents a
-                                                                      key's relationship
-                                                                      to a set of
-                                                                      values. Valid
-                                                                      operators are
-                                                                      In, NotIn, Exists
-                                                                      and DoesNotExist.
+                                                                    description: Represents
+                                                                      a key's relationship
+                                                                      to a set of values.
+                                                                      Valid operators
+                                                                      are In, NotIn, Exists,
+                                                                      DoesNotExist. Gt,
+                                                                      and Lt.
                                                                     type: string
                                                                   values:
-                                                                    description: values
-                                                                      is an array
+                                                                    description: An array
                                                                       of string values.
                                                                       If the operator
                                                                       is In or NotIn,
                                                                       the values array
                                                                       must be non-empty.
                                                                       If the operator
-                                                                      is Exists or
-                                                                      DoesNotExist,
+                                                                      is Exists or DoesNotExist,
                                                                       the values array
-                                                                      must be empty.
-                                                                      This array is
-                                                                      replaced during
-                                                                      a strategic
+                                                                      must be empty. If
+                                                                      the operator is
+                                                                      Gt or Lt, the values
+                                                                      array must have
+                                                                      a single element,
+                                                                      which will be interpreted
+                                                                      as an integer. This
+                                                                      array is replaced
+                                                                      during a strategic
+                                                                      merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchFields:
+                                                              description: A list of node
+                                                                selector requirements
+                                                                by node's fields.
+                                                              type: array
+                                                              items:
+                                                                description: A node selector
+                                                                  requirement is a selector
+                                                                  that contains values,
+                                                                  a key, and an operator
+                                                                  that relates the key
+                                                                  and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label
+                                                                      key that the selector
+                                                                      applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: Represents
+                                                                      a key's relationship
+                                                                      to a set of values.
+                                                                      Valid operators
+                                                                      are In, NotIn, Exists,
+                                                                      DoesNotExist. Gt,
+                                                                      and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: An array
+                                                                      of string values.
+                                                                      If the operator
+                                                                      is In or NotIn,
+                                                                      the values array
+                                                                      must be non-empty.
+                                                                      If the operator
+                                                                      is Exists or DoesNotExist,
+                                                                      the values array
+                                                                      must be empty. If
+                                                                      the operator is
+                                                                      Gt or Lt, the values
+                                                                      array must have
+                                                                      a single element,
+                                                                      which will be interpreted
+                                                                      as an integer. This
+                                                                      array is replaced
+                                                                      during a strategic
+                                                                      merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                        weight:
+                                                          description: Weight associated
+                                                            with matching the corresponding
+                                                            nodeSelectorTerm, in the range
+                                                            1-100.
+                                                          type: integer
+                                                          format: int32
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: If the affinity requirements
+                                                      specified by this field are not
+                                                      met at scheduling time, the pod
+                                                      will not be scheduled onto the node.
+                                                      If the affinity requirements specified
+                                                      by this field cease to be met at
+                                                      some point during pod execution
+                                                      (e.g. due to an update), the system
+                                                      may or may not try to eventually
+                                                      evict the pod from its node.
+                                                    type: object
+                                                    required:
+                                                      - nodeSelectorTerms
+                                                    properties:
+                                                      nodeSelectorTerms:
+                                                        description: Required. A list
+                                                          of node selector terms. The
+                                                          terms are ORed.
+                                                        type: array
+                                                        items:
+                                                          description: A null or empty
+                                                            node selector term matches
+                                                            no objects. The requirements
+                                                            of them are ANDed. The TopologySelectorTerm
+                                                            type implements a subset of
+                                                            the NodeSelectorTerm.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: A list of node
+                                                                selector requirements
+                                                                by node's labels.
+                                                              type: array
+                                                              items:
+                                                                description: A node selector
+                                                                  requirement is a selector
+                                                                  that contains values,
+                                                                  a key, and an operator
+                                                                  that relates the key
+                                                                  and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label
+                                                                      key that the selector
+                                                                      applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: Represents
+                                                                      a key's relationship
+                                                                      to a set of values.
+                                                                      Valid operators
+                                                                      are In, NotIn, Exists,
+                                                                      DoesNotExist. Gt,
+                                                                      and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: An array
+                                                                      of string values.
+                                                                      If the operator
+                                                                      is In or NotIn,
+                                                                      the values array
+                                                                      must be non-empty.
+                                                                      If the operator
+                                                                      is Exists or DoesNotExist,
+                                                                      the values array
+                                                                      must be empty. If
+                                                                      the operator is
+                                                                      Gt or Lt, the values
+                                                                      array must have
+                                                                      a single element,
+                                                                      which will be interpreted
+                                                                      as an integer. This
+                                                                      array is replaced
+                                                                      during a strategic
+                                                                      merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchFields:
+                                                              description: A list of node
+                                                                selector requirements
+                                                                by node's fields.
+                                                              type: array
+                                                              items:
+                                                                description: A node selector
+                                                                  requirement is a selector
+                                                                  that contains values,
+                                                                  a key, and an operator
+                                                                  that relates the key
+                                                                  and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label
+                                                                      key that the selector
+                                                                      applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: Represents
+                                                                      a key's relationship
+                                                                      to a set of values.
+                                                                      Valid operators
+                                                                      are In, NotIn, Exists,
+                                                                      DoesNotExist. Gt,
+                                                                      and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: An array
+                                                                      of string values.
+                                                                      If the operator
+                                                                      is In or NotIn,
+                                                                      the values array
+                                                                      must be non-empty.
+                                                                      If the operator
+                                                                      is Exists or DoesNotExist,
+                                                                      the values array
+                                                                      must be empty. If
+                                                                      the operator is
+                                                                      Gt or Lt, the values
+                                                                      array must have
+                                                                      a single element,
+                                                                      which will be interpreted
+                                                                      as an integer. This
+                                                                      array is replaced
+                                                                      during a strategic
+                                                                      merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                              podAffinity:
+                                                description: Describes pod affinity scheduling
+                                                  rules (e.g. co-locate this pod in the
+                                                  same node, zone, etc. as some other
+                                                  pod(s)).
+                                                type: object
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: The scheduler will prefer
+                                                      to schedule pods to nodes that satisfy
+                                                      the affinity expressions specified
+                                                      by this field, but it may choose
+                                                      a node that violates one or more
+                                                      of the expressions. The node that
+                                                      is most preferred is the one with
+                                                      the greatest sum of weights, i.e.
+                                                      for each node that meets all of
+                                                      the scheduling requirements (resource
+                                                      request, requiredDuringScheduling
+                                                      affinity expressions, etc.), compute
+                                                      a sum by iterating through the elements
+                                                      of this field and adding "weight"
+                                                      to the sum if the node has pods
+                                                      which matches the corresponding
+                                                      podAffinityTerm; the node(s) with
+                                                      the highest sum are the most preferred.
+                                                    type: array
+                                                    items:
+                                                      description: The weights of all
+                                                        of the matched WeightedPodAffinityTerm
+                                                        fields are added per-node to find
+                                                        the most preferred node(s)
+                                                      type: object
+                                                      required:
+                                                        - podAffinityTerm
+                                                        - weight
+                                                      properties:
+                                                        podAffinityTerm:
+                                                          description: Required. A pod
+                                                            affinity term, associated
+                                                            with the corresponding weight.
+                                                          type: object
+                                                          required:
+                                                            - topologyKey
+                                                          properties:
+                                                            labelSelector:
+                                                              description: A label query
+                                                                over a set of resources,
+                                                                in this case pods.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions
+                                                                    is a list of label
+                                                                    selector requirements.
+                                                                    The requirements are
+                                                                    ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: A label
+                                                                      selector requirement
+                                                                      is a selector that
+                                                                      contains values,
+                                                                      a key, and an operator
+                                                                      that relates the
+                                                                      key and values.
+                                                                    type: object
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key
+                                                                          is the label
+                                                                          key that the
+                                                                          selector applies
+                                                                          to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: operator
+                                                                          represents a
+                                                                          key's relationship
+                                                                          to a set of
+                                                                          values. Valid
+                                                                          operators are
+                                                                          In, NotIn, Exists
+                                                                          and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: values
+                                                                          is an array
+                                                                          of string values.
+                                                                          If the operator
+                                                                          is In or NotIn,
+                                                                          the values array
+                                                                          must be non-empty.
+                                                                          If the operator
+                                                                          is Exists or
+                                                                          DoesNotExist,
+                                                                          the values array
+                                                                          must be empty.
+                                                                          This array is
+                                                                          replaced during
+                                                                          a strategic
+                                                                          merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                matchLabels:
+                                                                  description: matchLabels
+                                                                    is a map of {key,value}
+                                                                    pairs. A single {key,value}
+                                                                    in the matchLabels
+                                                                    map is equivalent
+                                                                    to an element of matchExpressions,
+                                                                    whose key field is
+                                                                    "key", the operator
+                                                                    is "In", and the values
+                                                                    array contains only
+                                                                    "value". The requirements
+                                                                    are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                            namespaces:
+                                                              description: namespaces
+                                                                specifies which namespaces
+                                                                the labelSelector applies
+                                                                to (matches against);
+                                                                null or empty list means
+                                                                "this pod's namespace"
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                            topologyKey:
+                                                              description: This pod should
+                                                                be co-located (affinity)
+                                                                or not co-located (anti-affinity)
+                                                                with the pods matching
+                                                                the labelSelector in the
+                                                                specified namespaces,
+                                                                where co-located is defined
+                                                                as running on a node whose
+                                                                value of the label with
+                                                                key topologyKey matches
+                                                                that of any node on which
+                                                                any of the selected pods
+                                                                is running. Empty topologyKey
+                                                                is not allowed.
+                                                              type: string
+                                                        weight:
+                                                          description: weight associated
+                                                            with matching the corresponding
+                                                            podAffinityTerm, in the range
+                                                            1-100.
+                                                          type: integer
+                                                          format: int32
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: If the affinity requirements
+                                                      specified by this field are not
+                                                      met at scheduling time, the pod
+                                                      will not be scheduled onto the node.
+                                                      If the affinity requirements specified
+                                                      by this field cease to be met at
+                                                      some point during pod execution
+                                                      (e.g. due to a pod label update),
+                                                      the system may or may not try to
+                                                      eventually evict the pod from its
+                                                      node. When there are multiple elements,
+                                                      the lists of nodes corresponding
+                                                      to each podAffinityTerm are intersected,
+                                                      i.e. all terms must be satisfied.
+                                                    type: array
+                                                    items:
+                                                      description: Defines a set of pods
+                                                        (namely those matching the labelSelector
+                                                        relative to the given namespace(s))
+                                                        that this pod should be co-located
+                                                        (affinity) or not co-located (anti-affinity)
+                                                        with, where co-located is defined
+                                                        as running on a node whose value
+                                                        of the label with key <topologyKey>
+                                                        matches that of any node on which
+                                                        a pod of the set of pods is running
+                                                      type: object
+                                                      required:
+                                                        - topologyKey
+                                                      properties:
+                                                        labelSelector:
+                                                          description: A label query over
+                                                            a set of resources, in this
+                                                            case pods.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions
+                                                                is a list of label selector
+                                                                requirements. The requirements
+                                                                are ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: A label selector
+                                                                  requirement is a selector
+                                                                  that contains values,
+                                                                  a key, and an operator
+                                                                  that relates the key
+                                                                  and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key is
+                                                                      the label key that
+                                                                      the selector applies
+                                                                      to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator
+                                                                      represents a key's
+                                                                      relationship to
+                                                                      a set of values.
+                                                                      Valid operators
+                                                                      are In, NotIn, Exists
+                                                                      and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values
+                                                                      is an array of string
+                                                                      values. If the operator
+                                                                      is In or NotIn,
+                                                                      the values array
+                                                                      must be non-empty.
+                                                                      If the operator
+                                                                      is Exists or DoesNotExist,
+                                                                      the values array
+                                                                      must be empty. This
+                                                                      array is replaced
+                                                                      during a strategic
                                                                       merge patch.
                                                                     type: array
                                                                     items:
@@ -1005,281 +1119,281 @@ spec:
                                                               description: matchLabels
                                                                 is a map of {key,value}
                                                                 pairs. A single {key,value}
-                                                                in the matchLabels
-                                                                map is equivalent
-                                                                to an element of matchExpressions,
-                                                                whose key field is
-                                                                "key", the operator
-                                                                is "In", and the values
-                                                                array contains only
-                                                                "value". The requirements
+                                                                in the matchLabels map
+                                                                is equivalent to an element
+                                                                of matchExpressions, whose
+                                                                key field is "key", the
+                                                                operator is "In", and
+                                                                the values array contains
+                                                                only "value". The requirements
                                                                 are ANDed.
                                                               type: object
                                                               additionalProperties:
                                                                 type: string
                                                         namespaces:
-                                                          description: namespaces
-                                                            specifies which namespaces
-                                                            the labelSelector applies
-                                                            to (matches against);
-                                                            null or empty list means
-                                                            "this pod's namespace"
+                                                          description: namespaces specifies
+                                                            which namespaces the labelSelector
+                                                            applies to (matches against);
+                                                            null or empty list means "this
+                                                            pod's namespace"
                                                           type: array
                                                           items:
                                                             type: string
                                                         topologyKey:
                                                           description: This pod should
-                                                            be co-located (affinity)
-                                                            or not co-located (anti-affinity)
-                                                            with the pods matching
-                                                            the labelSelector in the
-                                                            specified namespaces,
-                                                            where co-located is defined
-                                                            as running on a node whose
-                                                            value of the label with
-                                                            key topologyKey matches
+                                                            be co-located (affinity) or
+                                                            not co-located (anti-affinity)
+                                                            with the pods matching the
+                                                            labelSelector in the specified
+                                                            namespaces, where co-located
+                                                            is defined as running on a
+                                                            node whose value of the label
+                                                            with key topologyKey matches
                                                             that of any node on which
-                                                            any of the selected pods
-                                                            is running. Empty topologyKey
+                                                            any of the selected pods is
+                                                            running. Empty topologyKey
                                                             is not allowed.
                                                           type: string
-                                                    weight:
-                                                      description: weight associated
-                                                        with matching the corresponding
-                                                        podAffinityTerm, in the range
-                                                        1-100.
-                                                      type: integer
-                                                      format: int32
-                                              requiredDuringSchedulingIgnoredDuringExecution:
-                                                description: If the affinity requirements
-                                                  specified by this field are not
-                                                  met at scheduling time, the pod
-                                                  will not be scheduled onto the node.
-                                                  If the affinity requirements specified
-                                                  by this field cease to be met at
-                                                  some point during pod execution
-                                                  (e.g. due to a pod label update),
-                                                  the system may or may not try to
-                                                  eventually evict the pod from its
-                                                  node. When there are multiple elements,
-                                                  the lists of nodes corresponding
-                                                  to each podAffinityTerm are intersected,
-                                                  i.e. all terms must be satisfied.
-                                                type: array
-                                                items:
-                                                  description: Defines a set of pods
-                                                    (namely those matching the labelSelector
-                                                    relative to the given namespace(s))
-                                                    that this pod should be co-located
-                                                    (affinity) or not co-located (anti-affinity)
-                                                    with, where co-located is defined
-                                                    as running on a node whose value
-                                                    of the label with key <topologyKey>
-                                                    matches that of any node on which
-                                                    a pod of the set of pods is running
-                                                  type: object
-                                                  required:
-                                                    - topologyKey
-                                                  properties:
-                                                    labelSelector:
-                                                      description: A label query over
-                                                        a set of resources, in this
-                                                        case pods.
+                                              podAntiAffinity:
+                                                description: Describes pod anti-affinity
+                                                  scheduling rules (e.g. avoid putting
+                                                  this pod in the same node, zone, etc.
+                                                  as some other pod(s)).
+                                                type: object
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: The scheduler will prefer
+                                                      to schedule pods to nodes that satisfy
+                                                      the anti-affinity expressions specified
+                                                      by this field, but it may choose
+                                                      a node that violates one or more
+                                                      of the expressions. The node that
+                                                      is most preferred is the one with
+                                                      the greatest sum of weights, i.e.
+                                                      for each node that meets all of
+                                                      the scheduling requirements (resource
+                                                      request, requiredDuringScheduling
+                                                      anti-affinity expressions, etc.),
+                                                      compute a sum by iterating through
+                                                      the elements of this field and adding
+                                                      "weight" to the sum if the node
+                                                      has pods which matches the corresponding
+                                                      podAffinityTerm; the node(s) with
+                                                      the highest sum are the most preferred.
+                                                    type: array
+                                                    items:
+                                                      description: The weights of all
+                                                        of the matched WeightedPodAffinityTerm
+                                                        fields are added per-node to find
+                                                        the most preferred node(s)
                                                       type: object
+                                                      required:
+                                                        - podAffinityTerm
+                                                        - weight
                                                       properties:
-                                                        matchExpressions:
-                                                          description: matchExpressions
-                                                            is a list of label selector
-                                                            requirements. The requirements
-                                                            are ANDed.
-                                                          type: array
-                                                          items:
-                                                            description: A label selector
-                                                              requirement is a selector
-                                                              that contains values,
-                                                              a key, and an operator
-                                                              that relates the key
-                                                              and values.
-                                                            type: object
-                                                            required:
-                                                              - key
-                                                              - operator
-                                                            properties:
-                                                              key:
-                                                                description: key is
-                                                                  the label key that
-                                                                  the selector applies
-                                                                  to.
-                                                                type: string
-                                                              operator:
-                                                                description: operator
-                                                                  represents a key's
-                                                                  relationship to
-                                                                  a set of values.
-                                                                  Valid operators
-                                                                  are In, NotIn, Exists
-                                                                  and DoesNotExist.
-                                                                type: string
-                                                              values:
-                                                                description: values
-                                                                  is an array of string
-                                                                  values. If the operator
-                                                                  is In or NotIn,
-                                                                  the values array
-                                                                  must be non-empty.
-                                                                  If the operator
-                                                                  is Exists or DoesNotExist,
-                                                                  the values array
-                                                                  must be empty. This
-                                                                  array is replaced
-                                                                  during a strategic
-                                                                  merge patch.
-                                                                type: array
-                                                                items:
-                                                                  type: string
-                                                        matchLabels:
-                                                          description: matchLabels
-                                                            is a map of {key,value}
-                                                            pairs. A single {key,value}
-                                                            in the matchLabels map
-                                                            is equivalent to an element
-                                                            of matchExpressions, whose
-                                                            key field is "key", the
-                                                            operator is "In", and
-                                                            the values array contains
-                                                            only "value". The requirements
-                                                            are ANDed.
+                                                        podAffinityTerm:
+                                                          description: Required. A pod
+                                                            affinity term, associated
+                                                            with the corresponding weight.
                                                           type: object
-                                                          additionalProperties:
-                                                            type: string
-                                                    namespaces:
-                                                      description: namespaces specifies
-                                                        which namespaces the labelSelector
-                                                        applies to (matches against);
-                                                        null or empty list means "this
-                                                        pod's namespace"
-                                                      type: array
-                                                      items:
-                                                        type: string
-                                                    topologyKey:
-                                                      description: This pod should
-                                                        be co-located (affinity) or
-                                                        not co-located (anti-affinity)
-                                                        with the pods matching the
-                                                        labelSelector in the specified
-                                                        namespaces, where co-located
-                                                        is defined as running on a
-                                                        node whose value of the label
-                                                        with key topologyKey matches
-                                                        that of any node on which
-                                                        any of the selected pods is
-                                                        running. Empty topologyKey
-                                                        is not allowed.
-                                                      type: string
-                                          podAntiAffinity:
-                                            description: Describes pod anti-affinity
-                                              scheduling rules (e.g. avoid putting
-                                              this pod in the same node, zone, etc.
-                                              as some other pod(s)).
-                                            type: object
-                                            properties:
-                                              preferredDuringSchedulingIgnoredDuringExecution:
-                                                description: The scheduler will prefer
-                                                  to schedule pods to nodes that satisfy
-                                                  the anti-affinity expressions specified
-                                                  by this field, but it may choose
-                                                  a node that violates one or more
-                                                  of the expressions. The node that
-                                                  is most preferred is the one with
-                                                  the greatest sum of weights, i.e.
-                                                  for each node that meets all of
-                                                  the scheduling requirements (resource
-                                                  request, requiredDuringScheduling
-                                                  anti-affinity expressions, etc.),
-                                                  compute a sum by iterating through
-                                                  the elements of this field and adding
-                                                  "weight" to the sum if the node
-                                                  has pods which matches the corresponding
-                                                  podAffinityTerm; the node(s) with
-                                                  the highest sum are the most preferred.
-                                                type: array
-                                                items:
-                                                  description: The weights of all
-                                                    of the matched WeightedPodAffinityTerm
-                                                    fields are added per-node to find
-                                                    the most preferred node(s)
-                                                  type: object
-                                                  required:
-                                                    - podAffinityTerm
-                                                    - weight
-                                                  properties:
-                                                    podAffinityTerm:
-                                                      description: Required. A pod
-                                                        affinity term, associated
-                                                        with the corresponding weight.
+                                                          required:
+                                                            - topologyKey
+                                                          properties:
+                                                            labelSelector:
+                                                              description: A label query
+                                                                over a set of resources,
+                                                                in this case pods.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions
+                                                                    is a list of label
+                                                                    selector requirements.
+                                                                    The requirements are
+                                                                    ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: A label
+                                                                      selector requirement
+                                                                      is a selector that
+                                                                      contains values,
+                                                                      a key, and an operator
+                                                                      that relates the
+                                                                      key and values.
+                                                                    type: object
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key
+                                                                          is the label
+                                                                          key that the
+                                                                          selector applies
+                                                                          to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: operator
+                                                                          represents a
+                                                                          key's relationship
+                                                                          to a set of
+                                                                          values. Valid
+                                                                          operators are
+                                                                          In, NotIn, Exists
+                                                                          and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: values
+                                                                          is an array
+                                                                          of string values.
+                                                                          If the operator
+                                                                          is In or NotIn,
+                                                                          the values array
+                                                                          must be non-empty.
+                                                                          If the operator
+                                                                          is Exists or
+                                                                          DoesNotExist,
+                                                                          the values array
+                                                                          must be empty.
+                                                                          This array is
+                                                                          replaced during
+                                                                          a strategic
+                                                                          merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                matchLabels:
+                                                                  description: matchLabels
+                                                                    is a map of {key,value}
+                                                                    pairs. A single {key,value}
+                                                                    in the matchLabels
+                                                                    map is equivalent
+                                                                    to an element of matchExpressions,
+                                                                    whose key field is
+                                                                    "key", the operator
+                                                                    is "In", and the values
+                                                                    array contains only
+                                                                    "value". The requirements
+                                                                    are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                            namespaces:
+                                                              description: namespaces
+                                                                specifies which namespaces
+                                                                the labelSelector applies
+                                                                to (matches against);
+                                                                null or empty list means
+                                                                "this pod's namespace"
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                            topologyKey:
+                                                              description: This pod should
+                                                                be co-located (affinity)
+                                                                or not co-located (anti-affinity)
+                                                                with the pods matching
+                                                                the labelSelector in the
+                                                                specified namespaces,
+                                                                where co-located is defined
+                                                                as running on a node whose
+                                                                value of the label with
+                                                                key topologyKey matches
+                                                                that of any node on which
+                                                                any of the selected pods
+                                                                is running. Empty topologyKey
+                                                                is not allowed.
+                                                              type: string
+                                                        weight:
+                                                          description: weight associated
+                                                            with matching the corresponding
+                                                            podAffinityTerm, in the range
+                                                            1-100.
+                                                          type: integer
+                                                          format: int32
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: If the anti-affinity
+                                                      requirements specified by this field
+                                                      are not met at scheduling time,
+                                                      the pod will not be scheduled onto
+                                                      the node. If the anti-affinity requirements
+                                                      specified by this field cease to
+                                                      be met at some point during pod
+                                                      execution (e.g. due to a pod label
+                                                      update), the system may or may not
+                                                      try to eventually evict the pod
+                                                      from its node. When there are multiple
+                                                      elements, the lists of nodes corresponding
+                                                      to each podAffinityTerm are intersected,
+                                                      i.e. all terms must be satisfied.
+                                                    type: array
+                                                    items:
+                                                      description: Defines a set of pods
+                                                        (namely those matching the labelSelector
+                                                        relative to the given namespace(s))
+                                                        that this pod should be co-located
+                                                        (affinity) or not co-located (anti-affinity)
+                                                        with, where co-located is defined
+                                                        as running on a node whose value
+                                                        of the label with key <topologyKey>
+                                                        matches that of any node on which
+                                                        a pod of the set of pods is running
                                                       type: object
                                                       required:
                                                         - topologyKey
                                                       properties:
                                                         labelSelector:
-                                                          description: A label query
-                                                            over a set of resources,
-                                                            in this case pods.
+                                                          description: A label query over
+                                                            a set of resources, in this
+                                                            case pods.
                                                           type: object
                                                           properties:
                                                             matchExpressions:
                                                               description: matchExpressions
-                                                                is a list of label
-                                                                selector requirements.
-                                                                The requirements are
-                                                                ANDed.
+                                                                is a list of label selector
+                                                                requirements. The requirements
+                                                                are ANDed.
                                                               type: array
                                                               items:
-                                                                description: A label
-                                                                  selector requirement
-                                                                  is a selector that
-                                                                  contains values,
+                                                                description: A label selector
+                                                                  requirement is a selector
+                                                                  that contains values,
                                                                   a key, and an operator
-                                                                  that relates the
-                                                                  key and values.
+                                                                  that relates the key
+                                                                  and values.
                                                                 type: object
                                                                 required:
                                                                   - key
                                                                   - operator
                                                                 properties:
                                                                   key:
-                                                                    description: key
-                                                                      is the label
-                                                                      key that the
-                                                                      selector applies
+                                                                    description: key is
+                                                                      the label key that
+                                                                      the selector applies
                                                                       to.
                                                                     type: string
                                                                   operator:
                                                                     description: operator
-                                                                      represents a
-                                                                      key's relationship
-                                                                      to a set of
-                                                                      values. Valid
-                                                                      operators are
-                                                                      In, NotIn, Exists
+                                                                      represents a key's
+                                                                      relationship to
+                                                                      a set of values.
+                                                                      Valid operators
+                                                                      are In, NotIn, Exists
                                                                       and DoesNotExist.
                                                                     type: string
                                                                   values:
                                                                     description: values
-                                                                      is an array
-                                                                      of string values.
-                                                                      If the operator
+                                                                      is an array of string
+                                                                      values. If the operator
                                                                       is In or NotIn,
                                                                       the values array
                                                                       must be non-empty.
                                                                       If the operator
-                                                                      is Exists or
-                                                                      DoesNotExist,
+                                                                      is Exists or DoesNotExist,
                                                                       the values array
-                                                                      must be empty.
-                                                                      This array is
-                                                                      replaced during
-                                                                      a strategic
+                                                                      must be empty. This
+                                                                      array is replaced
+                                                                      during a strategic
                                                                       merge patch.
                                                                     type: array
                                                                     items:
@@ -1288,523 +1402,2177 @@ spec:
                                                               description: matchLabels
                                                                 is a map of {key,value}
                                                                 pairs. A single {key,value}
-                                                                in the matchLabels
-                                                                map is equivalent
-                                                                to an element of matchExpressions,
-                                                                whose key field is
-                                                                "key", the operator
-                                                                is "In", and the values
-                                                                array contains only
-                                                                "value". The requirements
+                                                                in the matchLabels map
+                                                                is equivalent to an element
+                                                                of matchExpressions, whose
+                                                                key field is "key", the
+                                                                operator is "In", and
+                                                                the values array contains
+                                                                only "value". The requirements
                                                                 are ANDed.
                                                               type: object
                                                               additionalProperties:
                                                                 type: string
                                                         namespaces:
-                                                          description: namespaces
-                                                            specifies which namespaces
-                                                            the labelSelector applies
-                                                            to (matches against);
-                                                            null or empty list means
-                                                            "this pod's namespace"
+                                                          description: namespaces specifies
+                                                            which namespaces the labelSelector
+                                                            applies to (matches against);
+                                                            null or empty list means "this
+                                                            pod's namespace"
                                                           type: array
                                                           items:
                                                             type: string
                                                         topologyKey:
                                                           description: This pod should
-                                                            be co-located (affinity)
-                                                            or not co-located (anti-affinity)
-                                                            with the pods matching
-                                                            the labelSelector in the
-                                                            specified namespaces,
-                                                            where co-located is defined
-                                                            as running on a node whose
-                                                            value of the label with
-                                                            key topologyKey matches
+                                                            be co-located (affinity) or
+                                                            not co-located (anti-affinity)
+                                                            with the pods matching the
+                                                            labelSelector in the specified
+                                                            namespaces, where co-located
+                                                            is defined as running on a
+                                                            node whose value of the label
+                                                            with key topologyKey matches
                                                             that of any node on which
-                                                            any of the selected pods
-                                                            is running. Empty topologyKey
+                                                            any of the selected pods is
+                                                            running. Empty topologyKey
                                                             is not allowed.
                                                           type: string
-                                                    weight:
-                                                      description: weight associated
-                                                        with matching the corresponding
-                                                        podAffinityTerm, in the range
-                                                        1-100.
-                                                      type: integer
-                                                      format: int32
-                                              requiredDuringSchedulingIgnoredDuringExecution:
-                                                description: If the anti-affinity
-                                                  requirements specified by this field
-                                                  are not met at scheduling time,
-                                                  the pod will not be scheduled onto
-                                                  the node. If the anti-affinity requirements
-                                                  specified by this field cease to
-                                                  be met at some point during pod
-                                                  execution (e.g. due to a pod label
-                                                  update), the system may or may not
-                                                  try to eventually evict the pod
-                                                  from its node. When there are multiple
-                                                  elements, the lists of nodes corresponding
-                                                  to each podAffinityTerm are intersected,
-                                                  i.e. all terms must be satisfied.
-                                                type: array
-                                                items:
-                                                  description: Defines a set of pods
-                                                    (namely those matching the labelSelector
-                                                    relative to the given namespace(s))
-                                                    that this pod should be co-located
-                                                    (affinity) or not co-located (anti-affinity)
-                                                    with, where co-located is defined
-                                                    as running on a node whose value
-                                                    of the label with key <topologyKey>
-                                                    matches that of any node on which
-                                                    a pod of the set of pods is running
-                                                  type: object
-                                                  required:
-                                                    - topologyKey
-                                                  properties:
-                                                    labelSelector:
-                                                      description: A label query over
-                                                        a set of resources, in this
-                                                        case pods.
-                                                      type: object
-                                                      properties:
-                                                        matchExpressions:
-                                                          description: matchExpressions
-                                                            is a list of label selector
-                                                            requirements. The requirements
-                                                            are ANDed.
-                                                          type: array
-                                                          items:
-                                                            description: A label selector
-                                                              requirement is a selector
-                                                              that contains values,
-                                                              a key, and an operator
-                                                              that relates the key
-                                                              and values.
-                                                            type: object
-                                                            required:
-                                                              - key
-                                                              - operator
-                                                            properties:
-                                                              key:
-                                                                description: key is
-                                                                  the label key that
-                                                                  the selector applies
-                                                                  to.
-                                                                type: string
-                                                              operator:
-                                                                description: operator
-                                                                  represents a key's
-                                                                  relationship to
-                                                                  a set of values.
-                                                                  Valid operators
-                                                                  are In, NotIn, Exists
-                                                                  and DoesNotExist.
-                                                                type: string
-                                                              values:
-                                                                description: values
-                                                                  is an array of string
-                                                                  values. If the operator
-                                                                  is In or NotIn,
-                                                                  the values array
-                                                                  must be non-empty.
-                                                                  If the operator
-                                                                  is Exists or DoesNotExist,
-                                                                  the values array
-                                                                  must be empty. This
-                                                                  array is replaced
-                                                                  during a strategic
-                                                                  merge patch.
-                                                                type: array
-                                                                items:
-                                                                  type: string
-                                                        matchLabels:
-                                                          description: matchLabels
-                                                            is a map of {key,value}
-                                                            pairs. A single {key,value}
-                                                            in the matchLabels map
-                                                            is equivalent to an element
-                                                            of matchExpressions, whose
-                                                            key field is "key", the
-                                                            operator is "In", and
-                                                            the values array contains
-                                                            only "value". The requirements
-                                                            are ANDed.
-                                                          type: object
-                                                          additionalProperties:
-                                                            type: string
-                                                    namespaces:
-                                                      description: namespaces specifies
-                                                        which namespaces the labelSelector
-                                                        applies to (matches against);
-                                                        null or empty list means "this
-                                                        pod's namespace"
-                                                      type: array
-                                                      items:
-                                                        type: string
-                                                    topologyKey:
-                                                      description: This pod should
-                                                        be co-located (affinity) or
-                                                        not co-located (anti-affinity)
-                                                        with the pods matching the
-                                                        labelSelector in the specified
-                                                        namespaces, where co-located
-                                                        is defined as running on a
-                                                        node whose value of the label
-                                                        with key topologyKey matches
-                                                        that of any node on which
-                                                        any of the selected pods is
-                                                        running. Empty topologyKey
-                                                        is not allowed.
-                                                      type: string
-                                      nodeSelector:
-                                        description: 'NodeSelector is a selector which
-                                          must be true for the pod to fit on a node.
-                                          Selector which must match a node''s labels
-                                          for the pod to be scheduled on that node.
-                                          More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
-                                        type: object
-                                        additionalProperties:
-                                          type: string
-                                      tolerations:
-                                        description: If specified, the pod's tolerations.
-                                        type: array
-                                        items:
-                                          description: The pod this Toleration is
-                                            attached to tolerates any taint that matches
-                                            the triple <key,value,effect> using the
-                                            matching operator <operator>.
-                                          type: object
-                                          properties:
-                                            effect:
-                                              description: Effect indicates the taint
-                                                effect to match. Empty means match
-                                                all taint effects. When specified,
-                                                allowed values are NoSchedule, PreferNoSchedule
-                                                and NoExecute.
+                                          nodeSelector:
+                                            description: 'NodeSelector is a selector which
+                                                must be true for the pod to fit on a node.
+                                                Selector which must match a node''s labels
+                                                for the pod to be scheduled on that node.
+                                                More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                                            type: object
+                                            additionalProperties:
                                               type: string
-                                            key:
-                                              description: Key is the taint key that
-                                                the toleration applies to. Empty means
-                                                match all taint keys. If the key is
-                                                empty, operator must be Exists; this
-                                                combination means to match all values
-                                                and all keys.
-                                              type: string
-                                            operator:
-                                              description: Operator represents a key's
-                                                relationship to the value. Valid operators
-                                                are Exists and Equal. Defaults to
-                                                Equal. Exists is equivalent to wildcard
-                                                for value, so that a pod can tolerate
-                                                all taints of a particular category.
-                                              type: string
-                                            tolerationSeconds:
-                                              description: TolerationSeconds represents
-                                                the period of time the toleration
-                                                (which must be of effect NoExecute,
-                                                otherwise this field is ignored) tolerates
-                                                the taint. By default, it is not set,
-                                                which means tolerate the taint forever
-                                                (do not evict). Zero and negative
-                                                values will be treated as 0 (evict
-                                                immediately) by the system.
-                                              type: integer
-                                              format: int64
-                                            value:
-                                              description: Value is the taint value
-                                                the toleration matches to. If the
-                                                operator is Exists, the value should
-                                                be empty, otherwise just a regular
-                                                string.
-                                              type: string
-                              serviceType:
-                                description: Optional service type for Kubernetes
-                                  solver service
-                                type: string
-                      selector:
-                        description: Selector selects a set of DNSNames on the Certificate
-                          resource that should be solved using this challenge solver.
-                        type: object
-                        properties:
-                          dnsNames:
-                            description: List of DNSNames that this solver will be
-                              used to solve. If specified and a match is found, a
-                              dnsNames selector will take precedence over a dnsZones
-                              selector. If multiple solvers match with the same dnsNames
-                              value, the solver with the most matching labels in matchLabels
-                              will be selected. If neither has more matches, the solver
-                              defined earlier in the list will be selected.
-                            type: array
-                            items:
-                              type: string
-                          dnsZones:
-                            description: List of DNSZones that this solver will be
-                              used to solve. The most specific DNS zone match specified
-                              here will take precedence over other DNS zone matches,
-                              so a solver specifying sys.example.com will be selected
-                              over one specifying example.com for the domain www.sys.example.com.
-                              If multiple solvers match with the same dnsZones value,
-                              the solver with the most matching labels in matchLabels
-                              will be selected. If neither has more matches, the solver
-                              defined earlier in the list will be selected.
-                            type: array
-                            items:
-                              type: string
-                          matchLabels:
-                            description: A label selector that is used to refine the
-                              set of certificate's that this challenge solver will
-                              apply to.
+                                          tolerations:
+                                            description: If specified, the pod's tolerations.
+                                            type: array
+                                            items:
+                                              description: The pod this Toleration is
+                                                attached to tolerates any taint that matches
+                                                the triple <key,value,effect> using the
+                                                matching operator <operator>.
+                                              type: object
+                                              properties:
+                                                effect:
+                                                  description: Effect indicates the taint
+                                                    effect to match. Empty means match
+                                                    all taint effects. When specified,
+                                                    allowed values are NoSchedule, PreferNoSchedule
+                                                    and NoExecute.
+                                                  type: string
+                                                key:
+                                                  description: Key is the taint key that
+                                                    the toleration applies to. Empty means
+                                                    match all taint keys. If the key is
+                                                    empty, operator must be Exists; this
+                                                    combination means to match all values
+                                                    and all keys.
+                                                  type: string
+                                                operator:
+                                                  description: Operator represents a key's
+                                                    relationship to the value. Valid operators
+                                                    are Exists and Equal. Defaults to
+                                                    Equal. Exists is equivalent to wildcard
+                                                    for value, so that a pod can tolerate
+                                                    all taints of a particular category.
+                                                  type: string
+                                                tolerationSeconds:
+                                                  description: TolerationSeconds represents
+                                                    the period of time the toleration
+                                                    (which must be of effect NoExecute,
+                                                    otherwise this field is ignored) tolerates
+                                                    the taint. By default, it is not set,
+                                                    which means tolerate the taint forever
+                                                    (do not evict). Zero and negative
+                                                    values will be treated as 0 (evict
+                                                    immediately) by the system.
+                                                  type: integer
+                                                  format: int64
+                                                value:
+                                                  description: Value is the taint value
+                                                    the toleration matches to. If the
+                                                    operator is Exists, the value should
+                                                    be empty, otherwise just a regular
+                                                    string.
+                                                  type: string
+                                  serviceType:
+                                    description: Optional service type for Kubernetes
+                                      solver service
+                                    type: string
+                          selector:
+                            description: Selector selects a set of DNSNames on the Certificate
+                              resource that should be solved using this challenge solver.
                             type: object
-                            additionalProperties:
-                              type: string
-            ca:
-              type: object
-              required:
-                - secretName
-              properties:
-                crlDistributionPoints:
-                  description: The CRL distribution points is an X.509 v3 certificate
-                    extension which identifies the location of the CRL from which
-                    the revocation of this certificate can be checked. If not set
-                    certificate will be issued without CDP. Values are strings.
-                  type: array
-                  items:
-                    type: string
-                secretName:
-                  description: SecretName is the name of the secret used to sign Certificates
-                    issued by this Issuer.
-                  type: string
-            selfSigned:
-              type: object
-              properties:
-                crlDistributionPoints:
-                  description: The CRL distribution points is an X.509 v3 certificate
-                    extension which identifies the location of the CRL from which
-                    the revocation of this certificate can be checked. If not set
-                    certificate will be issued without CDP. Values are strings.
-                  type: array
-                  items:
-                    type: string
-            vault:
-              type: object
-              required:
-                - auth
-                - path
-                - server
-              properties:
-                auth:
-                  description: Vault authentication
-                  type: object
-                  properties:
-                    appRole:
-                      description: This Secret contains a AppRole and Secret
-                      type: object
-                      required:
-                        - path
-                        - roleId
-                        - secretRef
-                      properties:
-                        path:
-                          description: Where the authentication path is mounted in
-                            Vault.
-                          type: string
-                        roleId:
-                          type: string
-                        secretRef:
-                          type: object
-                          required:
-                            - name
-                          properties:
-                            key:
-                              description: The key of the secret to select from. Must
-                                be a valid secret key.
-                              type: string
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                    kubernetes:
-                      description: This contains a Role and Secret with a ServiceAccount
-                        token to authenticate with vault.
-                      type: object
-                      required:
-                        - role
-                        - secretRef
-                      properties:
-                        mountPath:
-                          description: The Vault mountPath here is the mount path
-                            to use when authenticating with Vault. For example, setting
-                            a value to `/v1/auth/foo`, will use the path `/v1/auth/foo/login`
-                            to authenticate with Vault. If unspecified, the default
-                            value "/v1/auth/kubernetes" will be used.
-                          type: string
-                        role:
-                          description: A required field containing the Vault Role
-                            to assume. A Role binds a Kubernetes ServiceAccount with
-                            a set of Vault policies.
-                          type: string
-                        secretRef:
-                          description: The required Secret field containing a Kubernetes
-                            ServiceAccount JWT used for authenticating with Vault.
-                            Use of 'ambient credentials' is not supported.
-                          type: object
-                          required:
-                            - name
-                          properties:
-                            key:
-                              description: The key of the secret to select from. Must
-                                be a valid secret key.
-                              type: string
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                    tokenSecretRef:
-                      description: This Secret contains the Vault token key
-                      type: object
-                      required:
-                        - name
-                      properties:
-                        key:
-                          description: The key of the secret to select from. Must
-                            be a valid secret key.
-                          type: string
-                        name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
-                          type: string
-                caBundle:
-                  description: Base64 encoded CA bundle to validate Vault server certificate.
-                    Only used if the Server URL is using HTTPS protocol. This parameter
-                    is ignored for plain HTTP protocol connection. If not set the
-                    system root certificates are used to validate the TLS connection.
-                  type: string
-                  format: byte
-                path:
-                  description: Vault URL path to the certificate role
-                  type: string
-                server:
-                  description: Server is the vault connection address
-                  type: string
-            venafi:
-              description: VenafiIssuer describes issuer configuration details for
-                Venafi Cloud.
-              type: object
-              required:
-                - zone
-              properties:
-                cloud:
-                  description: Cloud specifies the Venafi cloud configuration settings.
-                    Only one of TPP or Cloud may be specified.
+                            properties:
+                              dnsNames:
+                                description: List of DNSNames that this solver will be
+                                  used to solve. If specified and a match is found, a
+                                  dnsNames selector will take precedence over a dnsZones
+                                  selector. If multiple solvers match with the same dnsNames
+                                  value, the solver with the most matching labels in matchLabels
+                                  will be selected. If neither has more matches, the solver
+                                  defined earlier in the list will be selected.
+                                type: array
+                                items:
+                                  type: string
+                              dnsZones:
+                                description: List of DNSZones that this solver will be
+                                  used to solve. The most specific DNS zone match specified
+                                  here will take precedence over other DNS zone matches,
+                                  so a solver specifying sys.example.com will be selected
+                                  over one specifying example.com for the domain www.sys.example.com.
+                                  If multiple solvers match with the same dnsZones value,
+                                  the solver with the most matching labels in matchLabels
+                                  will be selected. If neither has more matches, the solver
+                                  defined earlier in the list will be selected.
+                                type: array
+                                items:
+                                  type: string
+                              matchLabels:
+                                description: A label selector that is used to refine the
+                                  set of certificate's that this challenge solver will
+                                  apply to.
+                                type: object
+                                additionalProperties:
+                                  type: string
+                ca:
                   type: object
                   required:
-                    - apiTokenSecretRef
+                    - secretName
                   properties:
-                    apiTokenSecretRef:
-                      description: APITokenSecretRef is a secret key selector for
-                        the Venafi Cloud API token.
-                      type: object
-                      required:
-                        - name
-                      properties:
-                        key:
-                          description: The key of the secret to select from. Must
-                            be a valid secret key.
-                          type: string
-                        name:
-                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
-                          type: string
-                    url:
-                      description: URL is the base URL for Venafi Cloud
+                    crlDistributionPoints:
+                      description: The CRL distribution points is an X.509 v3 certificate
+                        extension which identifies the location of the CRL from which
+                        the revocation of this certificate can be checked. If not set
+                        certificate will be issued without CDP. Values are strings.
+                      type: array
+                      items:
+                        type: string
+                    secretName:
+                      description: SecretName is the name of the secret used to sign Certificates
+                        issued by this Issuer.
                       type: string
-                tpp:
-                  description: TPP specifies Trust Protection Platform configuration
-                    settings. Only one of TPP or Cloud may be specified.
+                selfSigned:
+                  type: object
+                  properties:
+                    crlDistributionPoints:
+                      description: The CRL distribution points is an X.509 v3 certificate
+                        extension which identifies the location of the CRL from which
+                        the revocation of this certificate can be checked. If not set
+                        certificate will be issued without CDP. Values are strings.
+                      type: array
+                      items:
+                        type: string
+                vault:
                   type: object
                   required:
-                    - credentialsRef
-                    - url
+                    - auth
+                    - path
+                    - server
                   properties:
+                    auth:
+                      description: Vault authentication
+                      type: object
+                      properties:
+                        appRole:
+                          description: This Secret contains a AppRole and Secret
+                          type: object
+                          required:
+                            - path
+                            - roleId
+                            - secretRef
+                          properties:
+                            path:
+                              description: Where the authentication path is mounted in
+                                Vault.
+                              type: string
+                            roleId:
+                              type: string
+                            secretRef:
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the secret to select from. Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                                  type: string
+                        kubernetes:
+                          description: This contains a Role and Secret with a ServiceAccount
+                            token to authenticate with vault.
+                          type: object
+                          required:
+                            - role
+                            - secretRef
+                          properties:
+                            mountPath:
+                              description: The Vault mountPath here is the mount path
+                                to use when authenticating with Vault. For example, setting
+                                a value to `/v1/auth/foo`, will use the path `/v1/auth/foo/login`
+                                to authenticate with Vault. If unspecified, the default
+                                value "/v1/auth/kubernetes" will be used.
+                              type: string
+                            role:
+                              description: A required field containing the Vault Role
+                                to assume. A Role binds a Kubernetes ServiceAccount with
+                                a set of Vault policies.
+                              type: string
+                            secretRef:
+                              description: The required Secret field containing a Kubernetes
+                                ServiceAccount JWT used for authenticating with Vault.
+                                Use of 'ambient credentials' is not supported.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the secret to select from. Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                                  type: string
+                        tokenSecretRef:
+                          description: This Secret contains the Vault token key
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            key:
+                              description: The key of the secret to select from. Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
                     caBundle:
-                      description: CABundle is a PEM encoded TLS certificate to use
-                        to verify connections to the TPP instance. If specified, system
-                        roots will not be used and the issuing CA for the TPP instance
-                        must be verifiable using the provided root. If not specified,
-                        the connection will be verified using the cert-manager system
-                        root certificates.
+                      description: Base64 encoded CA bundle to validate Vault server certificate.
+                        Only used if the Server URL is using HTTPS protocol. This parameter
+                        is ignored for plain HTTP protocol connection. If not set the
+                        system root certificates are used to validate the TLS connection.
                       type: string
                       format: byte
-                    credentialsRef:
-                      description: CredentialsRef is a reference to a Secret containing
-                        the username and password for the TPP server. The secret must
-                        contain two keys, 'username' and 'password'.
+                    path:
+                      description: Vault URL path to the certificate role
+                      type: string
+                    server:
+                      description: Server is the vault connection address
+                      type: string
+                venafi:
+                  description: VenafiIssuer describes issuer configuration details for
+                    Venafi Cloud.
+                  type: object
+                  required:
+                    - zone
+                  properties:
+                    cloud:
+                      description: Cloud specifies the Venafi cloud configuration settings.
+                        Only one of TPP or Cloud may be specified.
+                      type: object
+                      required:
+                        - apiTokenSecretRef
+                      properties:
+                        apiTokenSecretRef:
+                          description: APITokenSecretRef is a secret key selector for
+                            the Venafi Cloud API token.
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            key:
+                              description: The key of the secret to select from. Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                        url:
+                          description: URL is the base URL for Venafi Cloud
+                          type: string
+                    tpp:
+                      description: TPP specifies Trust Protection Platform configuration
+                        settings. Only one of TPP or Cloud may be specified.
+                      type: object
+                      required:
+                        - credentialsRef
+                        - url
+                      properties:
+                        caBundle:
+                          description: CABundle is a PEM encoded TLS certificate to use
+                            to verify connections to the TPP instance. If specified, system
+                            roots will not be used and the issuing CA for the TPP instance
+                            must be verifiable using the provided root. If not specified,
+                            the connection will be verified using the cert-manager system
+                            root certificates.
+                          type: string
+                          format: byte
+                        credentialsRef:
+                          description: CredentialsRef is a reference to a Secret containing
+                            the username and password for the TPP server. The secret must
+                            contain two keys, 'username' and 'password'.
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                        url:
+                          description: URL is the base URL for the Venafi TPP instance
+                          type: string
+                    zone:
+                      description: Zone is the Venafi Policy Zone to use for this issuer.
+                        All requests made to the Venafi platform will be restricted by
+                        the named zone policy. This field is required.
+                      type: string
+            status:
+              description: IssuerStatus contains status information about an Issuer
+              type: object
+              properties:
+                acme:
+                  type: object
+                  properties:
+                    lastRegisteredEmail:
+                      description: LastRegisteredEmail is the email associated with the
+                        latest registered ACME account, in order to track changes made
+                        to registered account associated with the  Issuer
+                      type: string
+                    uri:
+                      description: URI is the unique account identifier, which can also
+                        be used to retrieve account details from the CA
+                      type: string
+                conditions:
+                  type: array
+                  items:
+                    description: IssuerCondition contains condition information for an
+                      Issuer.
+                    type: object
+                    required:
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: LastTransitionTime is the timestamp corresponding
+                          to the last status change of this condition.
+                        type: string
+                        format: date-time
+                      message:
+                        description: Message is a human readable description of the details
+                          of the last transition, complementing reason.
+                        type: string
+                      reason:
+                        description: Reason is a brief machine readable explanation for
+                          the condition's last transition.
+                        type: string
+                      status:
+                        description: Status of the condition, one of ('True', 'False',
+                          'Unknown').
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      type:
+                        description: Type of the condition, currently ('Ready').
+                        type: string
+      served: true
+      storage: true
+      additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].message
+          name: Status
+          priority: 1
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          description: CreationTimestamp is a timestamp representing the server time when
+            this object was created. It is not guaranteed to be set in happens-before order
+            across separate operations. Clients may not set this value. It is represented
+            in RFC3339 form and is in UTC.
+          name: Age
+          type: date
+      subresources:
+        status: { }
+    - name: v1alpha3
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+                  of an object. Servers should convert recognized schemas to the latest
+                  internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+                  object represents. Servers may infer this from the endpoint the client
+                  submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: IssuerSpec is the specification of an Issuer. This includes
+                any configuration required for the issuer.
+              type: object
+              properties:
+                acme:
+                  description: ACMEIssuer contains the specification for an ACME issuer
+                  type: object
+                  required:
+                    - privateKeySecretRef
+                    - server
+                  properties:
+                    email:
+                      description: Email is the email for this account
+                      type: string
+                    externalAccountBinding:
+                      description: ExternalAccountBinding is a reference to a CA external
+                        account of the ACME server.
+                      type: object
+                      required:
+                        - keyAlgorithm
+                        - keyID
+                        - keySecretRef
+                      properties:
+                        keyAlgorithm:
+                          description: keyAlgorithm is the MAC key algorithm that the
+                            key is used for. Valid values are "HS256", "HS384" and "HS512".
+                          type: string
+                          enum:
+                            - HS256
+                            - HS384
+                            - HS512
+                        keyID:
+                          description: keyID is the ID of the CA key that the External
+                            Account is bound to.
+                          type: string
+                        keySecretRef:
+                          description: keySecretRef is a Secret Key Selector referencing
+                            a data item in a Kubernetes Secret which holds the symmetric
+                            MAC key of the External Account Binding. The `key` is the
+                            index string that is paired with the key data in the Secret
+                            and should not be confused with the key data itself, or indeed
+                            with the External Account Binding keyID above. The secret
+                            key stored in the Secret **must** be un-padded, base64 URL
+                            encoded data.
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            key:
+                              description: The key of the secret to select from. Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                    privateKeySecretRef:
+                      description: PrivateKey is the name of a secret containing the private
+                        key for this user account.
                       type: object
                       required:
                         - name
                       properties:
+                        key:
+                          description: The key of the secret to select from. Must be a
+                            valid secret key.
+                          type: string
                         name:
                           description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                              TODO: Add other useful fields. apiVersion, kind, uid?'
                           type: string
-                    url:
-                      description: URL is the base URL for the Venafi TPP instance
+                    server:
+                      description: Server is the ACME server URL
                       type: string
-                zone:
-                  description: Zone is the Venafi Policy Zone to use for this issuer.
-                    All requests made to the Venafi platform will be restricted by
-                    the named zone policy. This field is required.
-                  type: string
-        status:
-          description: IssuerStatus contains status information about an Issuer
-          type: object
-          properties:
-            acme:
+                    skipTLSVerify:
+                      description: If true, skip verifying the ACME server TLS certificate
+                      type: boolean
+                    solvers:
+                      description: Solvers is a list of challenge solvers that will be
+                        used to solve ACME challenges for the matching domains.
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          dns01:
+                            type: object
+                            properties:
+                              acmedns:
+                                description: ACMEIssuerDNS01ProviderAcmeDNS is a structure
+                                  containing the configuration for ACME-DNS servers
+                                type: object
+                                required:
+                                  - accountSecretRef
+                                  - host
+                                properties:
+                                  accountSecretRef:
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.
+                                          Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion, kind,
+                                            uid?'
+                                        type: string
+                                  host:
+                                    type: string
+                              akamai:
+                                description: ACMEIssuerDNS01ProviderAkamai is a structure
+                                  containing the DNS configuration for Akamai DNS—Zone
+                                  Record Management API
+                                type: object
+                                required:
+                                  - accessTokenSecretRef
+                                  - clientSecretSecretRef
+                                  - clientTokenSecretRef
+                                  - serviceConsumerDomain
+                                properties:
+                                  accessTokenSecretRef:
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.
+                                          Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion, kind,
+                                            uid?'
+                                        type: string
+                                  clientSecretSecretRef:
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.
+                                          Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion, kind,
+                                            uid?'
+                                        type: string
+                                  clientTokenSecretRef:
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.
+                                          Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion, kind,
+                                            uid?'
+                                        type: string
+                                  serviceConsumerDomain:
+                                    type: string
+                              azuredns:
+                                description: ACMEIssuerDNS01ProviderAzureDNS is a structure
+                                  containing the configuration for Azure DNS
+                                type: object
+                                required:
+                                  - resourceGroupName
+                                  - subscriptionID
+                                properties:
+                                  clientID:
+                                    description: if both this and ClientSecret are left
+                                      unset MSI will be used
+                                    type: string
+                                  clientSecretSecretRef:
+                                    description: if both this and ClientID are left unset
+                                      MSI will be used
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.
+                                          Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion, kind,
+                                            uid?'
+                                        type: string
+                                  environment:
+                                    type: string
+                                    enum:
+                                      - AzurePublicCloud
+                                      - AzureChinaCloud
+                                      - AzureGermanCloud
+                                      - AzureUSGovernmentCloud
+                                  hostedZoneName:
+                                    type: string
+                                  resourceGroupName:
+                                    type: string
+                                  subscriptionID:
+                                    type: string
+                                  tenantID:
+                                    description: when specifying ClientID and ClientSecret
+                                      then this field is also needed
+                                    type: string
+                              clouddns:
+                                description: ACMEIssuerDNS01ProviderCloudDNS is a structure
+                                  containing the DNS configuration for Google Cloud DNS
+                                type: object
+                                required:
+                                  - project
+                                properties:
+                                  project:
+                                    type: string
+                                  serviceAccountSecretRef:
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.
+                                          Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion, kind,
+                                            uid?'
+                                        type: string
+                              cloudflare:
+                                description: ACMEIssuerDNS01ProviderCloudflare is a structure
+                                  containing the DNS configuration for Cloudflare
+                                type: object
+                                required:
+                                  - email
+                                properties:
+                                  apiKeySecretRef:
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.
+                                          Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion, kind,
+                                            uid?'
+                                        type: string
+                                  apiTokenSecretRef:
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.
+                                          Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion, kind,
+                                            uid?'
+                                        type: string
+                                  email:
+                                    type: string
+                              cnameStrategy:
+                                description: CNAMEStrategy configures how the DNS01 provider
+                                  should handle CNAME records when found in DNS zones.
+                                type: string
+                                enum:
+                                  - None
+                                  - Follow
+                              digitalocean:
+                                description: ACMEIssuerDNS01ProviderDigitalOcean is a
+                                  structure containing the DNS configuration for DigitalOcean
+                                  Domains
+                                type: object
+                                required:
+                                  - tokenSecretRef
+                                properties:
+                                  tokenSecretRef:
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.
+                                          Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion, kind,
+                                            uid?'
+                                        type: string
+                              rfc2136:
+                                description: ACMEIssuerDNS01ProviderRFC2136 is a structure
+                                  containing the configuration for RFC2136 DNS
+                                type: object
+                                required:
+                                  - nameserver
+                                properties:
+                                  nameserver:
+                                    description: The IP address or hostname of an authoritative
+                                      DNS server supporting RFC2136 in the form host:port.
+                                      If the host is an IPv6 address it must be enclosed
+                                      in square brackets (e.g [2001:db8::1]) ; port is
+                                      optional. This field is required.
+                                    type: string
+                                  tsigAlgorithm:
+                                    description: 'The TSIG Algorithm configured in the
+                                        DNS supporting RFC2136. Used only when ``tsigSecretSecretRef``
+                                        and ``tsigKeyName`` are defined. Supported values
+                                        are (case-insensitive): ``HMACMD5`` (default), ``HMACSHA1``,
+                                        ``HMACSHA256`` or ``HMACSHA512``.'
+                                    type: string
+                                  tsigKeyName:
+                                    description: The TSIG Key name configured in the DNS.
+                                      If ``tsigSecretSecretRef`` is defined, this field
+                                      is required.
+                                    type: string
+                                  tsigSecretSecretRef:
+                                    description: The name of the secret containing the
+                                      TSIG value. If ``tsigKeyName`` is defined, this
+                                      field is required.
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.
+                                          Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion, kind,
+                                            uid?'
+                                        type: string
+                              route53:
+                                description: ACMEIssuerDNS01ProviderRoute53 is a structure
+                                  containing the Route 53 configuration for AWS
+                                type: object
+                                required:
+                                  - region
+                                properties:
+                                  accessKeyID:
+                                    description: 'The AccessKeyID is used for authentication.
+                                        If not set we fall-back to using env vars, shared
+                                        credentials file or AWS Instance metadata see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials'
+                                    type: string
+                                  hostedZoneID:
+                                    description: If set, the provider will manage only
+                                      this zone in Route53 and will not do an lookup using
+                                      the route53:ListHostedZonesByName api call.
+                                    type: string
+                                  region:
+                                    description: Always set the region when using AccessKeyID
+                                      and SecretAccessKey
+                                    type: string
+                                  role:
+                                    description: Role is a Role ARN which the Route53
+                                      provider will assume using either the explicit credentials
+                                      AccessKeyID/SecretAccessKey or the inferred credentials
+                                      from environment variables, shared credentials file
+                                      or AWS Instance metadata
+                                    type: string
+                                  secretAccessKeySecretRef:
+                                    description: The SecretAccessKey is used for authentication.
+                                      If not set we fall-back to using env vars, shared
+                                      credentials file or AWS Instance metadata https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                                    type: object
+                                    required:
+                                      - name
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.
+                                          Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion, kind,
+                                            uid?'
+                                        type: string
+                              webhook:
+                                description: ACMEIssuerDNS01ProviderWebhook specifies
+                                  configuration for a webhook DNS01 provider, including
+                                  where to POST ChallengePayload resources.
+                                type: object
+                                required:
+                                  - groupName
+                                  - solverName
+                                properties:
+                                  config:
+                                    description: Additional configuration that should
+                                      be passed to the webhook apiserver when challenges
+                                      are processed. This can contain arbitrary JSON data.
+                                      Secret values should not be specified in this stanza.
+                                      If secret values are needed (e.g. credentials for
+                                      a DNS service), you should use a SecretKeySelector
+                                      to reference a Secret resource. For details on the
+                                      schema of this field, consult the webhook provider
+                                      implementation's documentation.
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  groupName:
+                                    description: The API group name that should be used
+                                      when POSTing ChallengePayload resources to the webhook
+                                      apiserver. This should be the same as the GroupName
+                                      specified in the webhook provider implementation.
+                                    type: string
+                                  solverName:
+                                    description: The name of the solver to use, as defined
+                                      in the webhook provider implementation. This will
+                                      typically be the name of the provider, e.g. 'cloudflare'.
+                                    type: string
+                          http01:
+                            description: ACMEChallengeSolverHTTP01 contains configuration
+                              detailing how to solve HTTP01 challenges within a Kubernetes
+                              cluster. Typically this is accomplished through creating
+                              'routes' of some description that configure ingress controllers
+                              to direct traffic to 'solver pods', which are responsible
+                              for responding to the ACME server's HTTP requests.
+                            type: object
+                            properties:
+                              ingress:
+                                description: The ingress based HTTP01 challenge solver
+                                  will solve challenges by creating or modifying Ingress
+                                  resources in order to route requests for '/.well-known/acme-challenge/XYZ'
+                                  to 'challenge solver' pods that are provisioned by cert-manager
+                                  for each Challenge to be completed.
+                                type: object
+                                properties:
+                                  class:
+                                    description: The ingress class to use when creating
+                                      Ingress resources to solve ACME challenges that
+                                      use this challenge solver. Only one of 'class' or
+                                      'name' may be specified.
+                                    type: string
+                                  ingressTemplate:
+                                    description: Optional ingress template used to configure
+                                      the ACME challenge solver ingress used for HTTP01
+                                      challenges
+                                    type: object
+                                    properties:
+                                      metadata:
+                                        description: ObjectMeta overrides for the ingress
+                                          used to solve HTTP01 challenges. Only the 'labels'
+                                          and 'annotations' fields may be set. If labels
+                                          or annotations overlap with in-built values,
+                                          the values here will override the in-built values.
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            description: Annotations that should be added
+                                              to the created ACME HTTP01 solver ingress.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                          labels:
+                                            description: Labels that should be added to
+                                              the created ACME HTTP01 solver ingress.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                  name:
+                                    description: The name of the ingress resource that
+                                      should have ACME challenge solving routes inserted
+                                      into it in order to solve HTTP01 challenges. This
+                                      is typically used in conjunction with ingress controllers
+                                      like ingress-gce, which maintains a 1:1 mapping
+                                      between external IPs and ingress resources.
+                                    type: string
+                                  podTemplate:
+                                    description: Optional pod template used to configure
+                                      the ACME challenge solver pods used for HTTP01 challenges
+                                    type: object
+                                    properties:
+                                      metadata:
+                                        description: ObjectMeta overrides for the pod
+                                          used to solve HTTP01 challenges. Only the 'labels'
+                                          and 'annotations' fields may be set. If labels
+                                          or annotations overlap with in-built values,
+                                          the values here will override the in-built values.
+                                        type: object
+                                        properties:
+                                          annotations:
+                                            description: Annotations that should be added
+                                              to the create ACME HTTP01 solver pods.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                          labels:
+                                            description: Labels that should be added to
+                                              the created ACME HTTP01 solver pods.
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                      spec:
+                                        description: PodSpec defines overrides for the
+                                          HTTP01 challenge solver pod. Only the 'nodeSelector',
+                                          'affinity' and 'tolerations' fields are supported
+                                          currently. All other fields will be ignored.
+                                        type: object
+                                        properties:
+                                          affinity:
+                                            description: If specified, the pod's scheduling
+                                              constraints
+                                            type: object
+                                            properties:
+                                              nodeAffinity:
+                                                description: Describes node affinity scheduling
+                                                  rules for the pod.
+                                                type: object
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: The scheduler will prefer
+                                                      to schedule pods to nodes that satisfy
+                                                      the affinity expressions specified
+                                                      by this field, but it may choose
+                                                      a node that violates one or more
+                                                      of the expressions. The node that
+                                                      is most preferred is the one with
+                                                      the greatest sum of weights, i.e.
+                                                      for each node that meets all of
+                                                      the scheduling requirements (resource
+                                                      request, requiredDuringScheduling
+                                                      affinity expressions, etc.), compute
+                                                      a sum by iterating through the elements
+                                                      of this field and adding "weight"
+                                                      to the sum if the node matches the
+                                                      corresponding matchExpressions;
+                                                      the node(s) with the highest sum
+                                                      are the most preferred.
+                                                    type: array
+                                                    items:
+                                                      description: An empty preferred
+                                                        scheduling term matches all objects
+                                                        with implicit weight 0 (i.e. it's
+                                                        a no-op). A null preferred scheduling
+                                                        term matches no objects (i.e.
+                                                        is also a no-op).
+                                                      type: object
+                                                      required:
+                                                        - preference
+                                                        - weight
+                                                      properties:
+                                                        preference:
+                                                          description: A node selector
+                                                            term, associated with the
+                                                            corresponding weight.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: A list of node
+                                                                selector requirements
+                                                                by node's labels.
+                                                              type: array
+                                                              items:
+                                                                description: A node selector
+                                                                  requirement is a selector
+                                                                  that contains values,
+                                                                  a key, and an operator
+                                                                  that relates the key
+                                                                  and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label
+                                                                      key that the selector
+                                                                      applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: Represents
+                                                                      a key's relationship
+                                                                      to a set of values.
+                                                                      Valid operators
+                                                                      are In, NotIn, Exists,
+                                                                      DoesNotExist. Gt,
+                                                                      and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: An array
+                                                                      of string values.
+                                                                      If the operator
+                                                                      is In or NotIn,
+                                                                      the values array
+                                                                      must be non-empty.
+                                                                      If the operator
+                                                                      is Exists or DoesNotExist,
+                                                                      the values array
+                                                                      must be empty. If
+                                                                      the operator is
+                                                                      Gt or Lt, the values
+                                                                      array must have
+                                                                      a single element,
+                                                                      which will be interpreted
+                                                                      as an integer. This
+                                                                      array is replaced
+                                                                      during a strategic
+                                                                      merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchFields:
+                                                              description: A list of node
+                                                                selector requirements
+                                                                by node's fields.
+                                                              type: array
+                                                              items:
+                                                                description: A node selector
+                                                                  requirement is a selector
+                                                                  that contains values,
+                                                                  a key, and an operator
+                                                                  that relates the key
+                                                                  and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label
+                                                                      key that the selector
+                                                                      applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: Represents
+                                                                      a key's relationship
+                                                                      to a set of values.
+                                                                      Valid operators
+                                                                      are In, NotIn, Exists,
+                                                                      DoesNotExist. Gt,
+                                                                      and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: An array
+                                                                      of string values.
+                                                                      If the operator
+                                                                      is In or NotIn,
+                                                                      the values array
+                                                                      must be non-empty.
+                                                                      If the operator
+                                                                      is Exists or DoesNotExist,
+                                                                      the values array
+                                                                      must be empty. If
+                                                                      the operator is
+                                                                      Gt or Lt, the values
+                                                                      array must have
+                                                                      a single element,
+                                                                      which will be interpreted
+                                                                      as an integer. This
+                                                                      array is replaced
+                                                                      during a strategic
+                                                                      merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                        weight:
+                                                          description: Weight associated
+                                                            with matching the corresponding
+                                                            nodeSelectorTerm, in the range
+                                                            1-100.
+                                                          type: integer
+                                                          format: int32
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: If the affinity requirements
+                                                      specified by this field are not
+                                                      met at scheduling time, the pod
+                                                      will not be scheduled onto the node.
+                                                      If the affinity requirements specified
+                                                      by this field cease to be met at
+                                                      some point during pod execution
+                                                      (e.g. due to an update), the system
+                                                      may or may not try to eventually
+                                                      evict the pod from its node.
+                                                    type: object
+                                                    required:
+                                                      - nodeSelectorTerms
+                                                    properties:
+                                                      nodeSelectorTerms:
+                                                        description: Required. A list
+                                                          of node selector terms. The
+                                                          terms are ORed.
+                                                        type: array
+                                                        items:
+                                                          description: A null or empty
+                                                            node selector term matches
+                                                            no objects. The requirements
+                                                            of them are ANDed. The TopologySelectorTerm
+                                                            type implements a subset of
+                                                            the NodeSelectorTerm.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: A list of node
+                                                                selector requirements
+                                                                by node's labels.
+                                                              type: array
+                                                              items:
+                                                                description: A node selector
+                                                                  requirement is a selector
+                                                                  that contains values,
+                                                                  a key, and an operator
+                                                                  that relates the key
+                                                                  and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label
+                                                                      key that the selector
+                                                                      applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: Represents
+                                                                      a key's relationship
+                                                                      to a set of values.
+                                                                      Valid operators
+                                                                      are In, NotIn, Exists,
+                                                                      DoesNotExist. Gt,
+                                                                      and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: An array
+                                                                      of string values.
+                                                                      If the operator
+                                                                      is In or NotIn,
+                                                                      the values array
+                                                                      must be non-empty.
+                                                                      If the operator
+                                                                      is Exists or DoesNotExist,
+                                                                      the values array
+                                                                      must be empty. If
+                                                                      the operator is
+                                                                      Gt or Lt, the values
+                                                                      array must have
+                                                                      a single element,
+                                                                      which will be interpreted
+                                                                      as an integer. This
+                                                                      array is replaced
+                                                                      during a strategic
+                                                                      merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchFields:
+                                                              description: A list of node
+                                                                selector requirements
+                                                                by node's fields.
+                                                              type: array
+                                                              items:
+                                                                description: A node selector
+                                                                  requirement is a selector
+                                                                  that contains values,
+                                                                  a key, and an operator
+                                                                  that relates the key
+                                                                  and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: The label
+                                                                      key that the selector
+                                                                      applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: Represents
+                                                                      a key's relationship
+                                                                      to a set of values.
+                                                                      Valid operators
+                                                                      are In, NotIn, Exists,
+                                                                      DoesNotExist. Gt,
+                                                                      and Lt.
+                                                                    type: string
+                                                                  values:
+                                                                    description: An array
+                                                                      of string values.
+                                                                      If the operator
+                                                                      is In or NotIn,
+                                                                      the values array
+                                                                      must be non-empty.
+                                                                      If the operator
+                                                                      is Exists or DoesNotExist,
+                                                                      the values array
+                                                                      must be empty. If
+                                                                      the operator is
+                                                                      Gt or Lt, the values
+                                                                      array must have
+                                                                      a single element,
+                                                                      which will be interpreted
+                                                                      as an integer. This
+                                                                      array is replaced
+                                                                      during a strategic
+                                                                      merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                              podAffinity:
+                                                description: Describes pod affinity scheduling
+                                                  rules (e.g. co-locate this pod in the
+                                                  same node, zone, etc. as some other
+                                                  pod(s)).
+                                                type: object
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: The scheduler will prefer
+                                                      to schedule pods to nodes that satisfy
+                                                      the affinity expressions specified
+                                                      by this field, but it may choose
+                                                      a node that violates one or more
+                                                      of the expressions. The node that
+                                                      is most preferred is the one with
+                                                      the greatest sum of weights, i.e.
+                                                      for each node that meets all of
+                                                      the scheduling requirements (resource
+                                                      request, requiredDuringScheduling
+                                                      affinity expressions, etc.), compute
+                                                      a sum by iterating through the elements
+                                                      of this field and adding "weight"
+                                                      to the sum if the node has pods
+                                                      which matches the corresponding
+                                                      podAffinityTerm; the node(s) with
+                                                      the highest sum are the most preferred.
+                                                    type: array
+                                                    items:
+                                                      description: The weights of all
+                                                        of the matched WeightedPodAffinityTerm
+                                                        fields are added per-node to find
+                                                        the most preferred node(s)
+                                                      type: object
+                                                      required:
+                                                        - podAffinityTerm
+                                                        - weight
+                                                      properties:
+                                                        podAffinityTerm:
+                                                          description: Required. A pod
+                                                            affinity term, associated
+                                                            with the corresponding weight.
+                                                          type: object
+                                                          required:
+                                                            - topologyKey
+                                                          properties:
+                                                            labelSelector:
+                                                              description: A label query
+                                                                over a set of resources,
+                                                                in this case pods.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions
+                                                                    is a list of label
+                                                                    selector requirements.
+                                                                    The requirements are
+                                                                    ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: A label
+                                                                      selector requirement
+                                                                      is a selector that
+                                                                      contains values,
+                                                                      a key, and an operator
+                                                                      that relates the
+                                                                      key and values.
+                                                                    type: object
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key
+                                                                          is the label
+                                                                          key that the
+                                                                          selector applies
+                                                                          to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: operator
+                                                                          represents a
+                                                                          key's relationship
+                                                                          to a set of
+                                                                          values. Valid
+                                                                          operators are
+                                                                          In, NotIn, Exists
+                                                                          and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: values
+                                                                          is an array
+                                                                          of string values.
+                                                                          If the operator
+                                                                          is In or NotIn,
+                                                                          the values array
+                                                                          must be non-empty.
+                                                                          If the operator
+                                                                          is Exists or
+                                                                          DoesNotExist,
+                                                                          the values array
+                                                                          must be empty.
+                                                                          This array is
+                                                                          replaced during
+                                                                          a strategic
+                                                                          merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                matchLabels:
+                                                                  description: matchLabels
+                                                                    is a map of {key,value}
+                                                                    pairs. A single {key,value}
+                                                                    in the matchLabels
+                                                                    map is equivalent
+                                                                    to an element of matchExpressions,
+                                                                    whose key field is
+                                                                    "key", the operator
+                                                                    is "In", and the values
+                                                                    array contains only
+                                                                    "value". The requirements
+                                                                    are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                            namespaces:
+                                                              description: namespaces
+                                                                specifies which namespaces
+                                                                the labelSelector applies
+                                                                to (matches against);
+                                                                null or empty list means
+                                                                "this pod's namespace"
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                            topologyKey:
+                                                              description: This pod should
+                                                                be co-located (affinity)
+                                                                or not co-located (anti-affinity)
+                                                                with the pods matching
+                                                                the labelSelector in the
+                                                                specified namespaces,
+                                                                where co-located is defined
+                                                                as running on a node whose
+                                                                value of the label with
+                                                                key topologyKey matches
+                                                                that of any node on which
+                                                                any of the selected pods
+                                                                is running. Empty topologyKey
+                                                                is not allowed.
+                                                              type: string
+                                                        weight:
+                                                          description: weight associated
+                                                            with matching the corresponding
+                                                            podAffinityTerm, in the range
+                                                            1-100.
+                                                          type: integer
+                                                          format: int32
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: If the affinity requirements
+                                                      specified by this field are not
+                                                      met at scheduling time, the pod
+                                                      will not be scheduled onto the node.
+                                                      If the affinity requirements specified
+                                                      by this field cease to be met at
+                                                      some point during pod execution
+                                                      (e.g. due to a pod label update),
+                                                      the system may or may not try to
+                                                      eventually evict the pod from its
+                                                      node. When there are multiple elements,
+                                                      the lists of nodes corresponding
+                                                      to each podAffinityTerm are intersected,
+                                                      i.e. all terms must be satisfied.
+                                                    type: array
+                                                    items:
+                                                      description: Defines a set of pods
+                                                        (namely those matching the labelSelector
+                                                        relative to the given namespace(s))
+                                                        that this pod should be co-located
+                                                        (affinity) or not co-located (anti-affinity)
+                                                        with, where co-located is defined
+                                                        as running on a node whose value
+                                                        of the label with key <topologyKey>
+                                                        matches that of any node on which
+                                                        a pod of the set of pods is running
+                                                      type: object
+                                                      required:
+                                                        - topologyKey
+                                                      properties:
+                                                        labelSelector:
+                                                          description: A label query over
+                                                            a set of resources, in this
+                                                            case pods.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions
+                                                                is a list of label selector
+                                                                requirements. The requirements
+                                                                are ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: A label selector
+                                                                  requirement is a selector
+                                                                  that contains values,
+                                                                  a key, and an operator
+                                                                  that relates the key
+                                                                  and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key is
+                                                                      the label key that
+                                                                      the selector applies
+                                                                      to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator
+                                                                      represents a key's
+                                                                      relationship to
+                                                                      a set of values.
+                                                                      Valid operators
+                                                                      are In, NotIn, Exists
+                                                                      and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values
+                                                                      is an array of string
+                                                                      values. If the operator
+                                                                      is In or NotIn,
+                                                                      the values array
+                                                                      must be non-empty.
+                                                                      If the operator
+                                                                      is Exists or DoesNotExist,
+                                                                      the values array
+                                                                      must be empty. This
+                                                                      array is replaced
+                                                                      during a strategic
+                                                                      merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchLabels:
+                                                              description: matchLabels
+                                                                is a map of {key,value}
+                                                                pairs. A single {key,value}
+                                                                in the matchLabels map
+                                                                is equivalent to an element
+                                                                of matchExpressions, whose
+                                                                key field is "key", the
+                                                                operator is "In", and
+                                                                the values array contains
+                                                                only "value". The requirements
+                                                                are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                        namespaces:
+                                                          description: namespaces specifies
+                                                            which namespaces the labelSelector
+                                                            applies to (matches against);
+                                                            null or empty list means "this
+                                                            pod's namespace"
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                        topologyKey:
+                                                          description: This pod should
+                                                            be co-located (affinity) or
+                                                            not co-located (anti-affinity)
+                                                            with the pods matching the
+                                                            labelSelector in the specified
+                                                            namespaces, where co-located
+                                                            is defined as running on a
+                                                            node whose value of the label
+                                                            with key topologyKey matches
+                                                            that of any node on which
+                                                            any of the selected pods is
+                                                            running. Empty topologyKey
+                                                            is not allowed.
+                                                          type: string
+                                              podAntiAffinity:
+                                                description: Describes pod anti-affinity
+                                                  scheduling rules (e.g. avoid putting
+                                                  this pod in the same node, zone, etc.
+                                                  as some other pod(s)).
+                                                type: object
+                                                properties:
+                                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                                    description: The scheduler will prefer
+                                                      to schedule pods to nodes that satisfy
+                                                      the anti-affinity expressions specified
+                                                      by this field, but it may choose
+                                                      a node that violates one or more
+                                                      of the expressions. The node that
+                                                      is most preferred is the one with
+                                                      the greatest sum of weights, i.e.
+                                                      for each node that meets all of
+                                                      the scheduling requirements (resource
+                                                      request, requiredDuringScheduling
+                                                      anti-affinity expressions, etc.),
+                                                      compute a sum by iterating through
+                                                      the elements of this field and adding
+                                                      "weight" to the sum if the node
+                                                      has pods which matches the corresponding
+                                                      podAffinityTerm; the node(s) with
+                                                      the highest sum are the most preferred.
+                                                    type: array
+                                                    items:
+                                                      description: The weights of all
+                                                        of the matched WeightedPodAffinityTerm
+                                                        fields are added per-node to find
+                                                        the most preferred node(s)
+                                                      type: object
+                                                      required:
+                                                        - podAffinityTerm
+                                                        - weight
+                                                      properties:
+                                                        podAffinityTerm:
+                                                          description: Required. A pod
+                                                            affinity term, associated
+                                                            with the corresponding weight.
+                                                          type: object
+                                                          required:
+                                                            - topologyKey
+                                                          properties:
+                                                            labelSelector:
+                                                              description: A label query
+                                                                over a set of resources,
+                                                                in this case pods.
+                                                              type: object
+                                                              properties:
+                                                                matchExpressions:
+                                                                  description: matchExpressions
+                                                                    is a list of label
+                                                                    selector requirements.
+                                                                    The requirements are
+                                                                    ANDed.
+                                                                  type: array
+                                                                  items:
+                                                                    description: A label
+                                                                      selector requirement
+                                                                      is a selector that
+                                                                      contains values,
+                                                                      a key, and an operator
+                                                                      that relates the
+                                                                      key and values.
+                                                                    type: object
+                                                                    required:
+                                                                      - key
+                                                                      - operator
+                                                                    properties:
+                                                                      key:
+                                                                        description: key
+                                                                          is the label
+                                                                          key that the
+                                                                          selector applies
+                                                                          to.
+                                                                        type: string
+                                                                      operator:
+                                                                        description: operator
+                                                                          represents a
+                                                                          key's relationship
+                                                                          to a set of
+                                                                          values. Valid
+                                                                          operators are
+                                                                          In, NotIn, Exists
+                                                                          and DoesNotExist.
+                                                                        type: string
+                                                                      values:
+                                                                        description: values
+                                                                          is an array
+                                                                          of string values.
+                                                                          If the operator
+                                                                          is In or NotIn,
+                                                                          the values array
+                                                                          must be non-empty.
+                                                                          If the operator
+                                                                          is Exists or
+                                                                          DoesNotExist,
+                                                                          the values array
+                                                                          must be empty.
+                                                                          This array is
+                                                                          replaced during
+                                                                          a strategic
+                                                                          merge patch.
+                                                                        type: array
+                                                                        items:
+                                                                          type: string
+                                                                matchLabels:
+                                                                  description: matchLabels
+                                                                    is a map of {key,value}
+                                                                    pairs. A single {key,value}
+                                                                    in the matchLabels
+                                                                    map is equivalent
+                                                                    to an element of matchExpressions,
+                                                                    whose key field is
+                                                                    "key", the operator
+                                                                    is "In", and the values
+                                                                    array contains only
+                                                                    "value". The requirements
+                                                                    are ANDed.
+                                                                  type: object
+                                                                  additionalProperties:
+                                                                    type: string
+                                                            namespaces:
+                                                              description: namespaces
+                                                                specifies which namespaces
+                                                                the labelSelector applies
+                                                                to (matches against);
+                                                                null or empty list means
+                                                                "this pod's namespace"
+                                                              type: array
+                                                              items:
+                                                                type: string
+                                                            topologyKey:
+                                                              description: This pod should
+                                                                be co-located (affinity)
+                                                                or not co-located (anti-affinity)
+                                                                with the pods matching
+                                                                the labelSelector in the
+                                                                specified namespaces,
+                                                                where co-located is defined
+                                                                as running on a node whose
+                                                                value of the label with
+                                                                key topologyKey matches
+                                                                that of any node on which
+                                                                any of the selected pods
+                                                                is running. Empty topologyKey
+                                                                is not allowed.
+                                                              type: string
+                                                        weight:
+                                                          description: weight associated
+                                                            with matching the corresponding
+                                                            podAffinityTerm, in the range
+                                                            1-100.
+                                                          type: integer
+                                                          format: int32
+                                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                                    description: If the anti-affinity
+                                                      requirements specified by this field
+                                                      are not met at scheduling time,
+                                                      the pod will not be scheduled onto
+                                                      the node. If the anti-affinity requirements
+                                                      specified by this field cease to
+                                                      be met at some point during pod
+                                                      execution (e.g. due to a pod label
+                                                      update), the system may or may not
+                                                      try to eventually evict the pod
+                                                      from its node. When there are multiple
+                                                      elements, the lists of nodes corresponding
+                                                      to each podAffinityTerm are intersected,
+                                                      i.e. all terms must be satisfied.
+                                                    type: array
+                                                    items:
+                                                      description: Defines a set of pods
+                                                        (namely those matching the labelSelector
+                                                        relative to the given namespace(s))
+                                                        that this pod should be co-located
+                                                        (affinity) or not co-located (anti-affinity)
+                                                        with, where co-located is defined
+                                                        as running on a node whose value
+                                                        of the label with key <topologyKey>
+                                                        matches that of any node on which
+                                                        a pod of the set of pods is running
+                                                      type: object
+                                                      required:
+                                                        - topologyKey
+                                                      properties:
+                                                        labelSelector:
+                                                          description: A label query over
+                                                            a set of resources, in this
+                                                            case pods.
+                                                          type: object
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions
+                                                                is a list of label selector
+                                                                requirements. The requirements
+                                                                are ANDed.
+                                                              type: array
+                                                              items:
+                                                                description: A label selector
+                                                                  requirement is a selector
+                                                                  that contains values,
+                                                                  a key, and an operator
+                                                                  that relates the key
+                                                                  and values.
+                                                                type: object
+                                                                required:
+                                                                  - key
+                                                                  - operator
+                                                                properties:
+                                                                  key:
+                                                                    description: key is
+                                                                      the label key that
+                                                                      the selector applies
+                                                                      to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: operator
+                                                                      represents a key's
+                                                                      relationship to
+                                                                      a set of values.
+                                                                      Valid operators
+                                                                      are In, NotIn, Exists
+                                                                      and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: values
+                                                                      is an array of string
+                                                                      values. If the operator
+                                                                      is In or NotIn,
+                                                                      the values array
+                                                                      must be non-empty.
+                                                                      If the operator
+                                                                      is Exists or DoesNotExist,
+                                                                      the values array
+                                                                      must be empty. This
+                                                                      array is replaced
+                                                                      during a strategic
+                                                                      merge patch.
+                                                                    type: array
+                                                                    items:
+                                                                      type: string
+                                                            matchLabels:
+                                                              description: matchLabels
+                                                                is a map of {key,value}
+                                                                pairs. A single {key,value}
+                                                                in the matchLabels map
+                                                                is equivalent to an element
+                                                                of matchExpressions, whose
+                                                                key field is "key", the
+                                                                operator is "In", and
+                                                                the values array contains
+                                                                only "value". The requirements
+                                                                are ANDed.
+                                                              type: object
+                                                              additionalProperties:
+                                                                type: string
+                                                        namespaces:
+                                                          description: namespaces specifies
+                                                            which namespaces the labelSelector
+                                                            applies to (matches against);
+                                                            null or empty list means "this
+                                                            pod's namespace"
+                                                          type: array
+                                                          items:
+                                                            type: string
+                                                        topologyKey:
+                                                          description: This pod should
+                                                            be co-located (affinity) or
+                                                            not co-located (anti-affinity)
+                                                            with the pods matching the
+                                                            labelSelector in the specified
+                                                            namespaces, where co-located
+                                                            is defined as running on a
+                                                            node whose value of the label
+                                                            with key topologyKey matches
+                                                            that of any node on which
+                                                            any of the selected pods is
+                                                            running. Empty topologyKey
+                                                            is not allowed.
+                                                          type: string
+                                          nodeSelector:
+                                            description: 'NodeSelector is a selector which
+                                                must be true for the pod to fit on a node.
+                                                Selector which must match a node''s labels
+                                                for the pod to be scheduled on that node.
+                                                More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                                            type: object
+                                            additionalProperties:
+                                              type: string
+                                          tolerations:
+                                            description: If specified, the pod's tolerations.
+                                            type: array
+                                            items:
+                                              description: The pod this Toleration is
+                                                attached to tolerates any taint that matches
+                                                the triple <key,value,effect> using the
+                                                matching operator <operator>.
+                                              type: object
+                                              properties:
+                                                effect:
+                                                  description: Effect indicates the taint
+                                                    effect to match. Empty means match
+                                                    all taint effects. When specified,
+                                                    allowed values are NoSchedule, PreferNoSchedule
+                                                    and NoExecute.
+                                                  type: string
+                                                key:
+                                                  description: Key is the taint key that
+                                                    the toleration applies to. Empty means
+                                                    match all taint keys. If the key is
+                                                    empty, operator must be Exists; this
+                                                    combination means to match all values
+                                                    and all keys.
+                                                  type: string
+                                                operator:
+                                                  description: Operator represents a key's
+                                                    relationship to the value. Valid operators
+                                                    are Exists and Equal. Defaults to
+                                                    Equal. Exists is equivalent to wildcard
+                                                    for value, so that a pod can tolerate
+                                                    all taints of a particular category.
+                                                  type: string
+                                                tolerationSeconds:
+                                                  description: TolerationSeconds represents
+                                                    the period of time the toleration
+                                                    (which must be of effect NoExecute,
+                                                    otherwise this field is ignored) tolerates
+                                                    the taint. By default, it is not set,
+                                                    which means tolerate the taint forever
+                                                    (do not evict). Zero and negative
+                                                    values will be treated as 0 (evict
+                                                    immediately) by the system.
+                                                  type: integer
+                                                  format: int64
+                                                value:
+                                                  description: Value is the taint value
+                                                    the toleration matches to. If the
+                                                    operator is Exists, the value should
+                                                    be empty, otherwise just a regular
+                                                    string.
+                                                  type: string
+                                  serviceType:
+                                    description: Optional service type for Kubernetes
+                                      solver service
+                                    type: string
+                          selector:
+                            description: Selector selects a set of DNSNames on the Certificate
+                              resource that should be solved using this challenge solver.
+                            type: object
+                            properties:
+                              dnsNames:
+                                description: List of DNSNames that this solver will be
+                                  used to solve. If specified and a match is found, a
+                                  dnsNames selector will take precedence over a dnsZones
+                                  selector. If multiple solvers match with the same dnsNames
+                                  value, the solver with the most matching labels in matchLabels
+                                  will be selected. If neither has more matches, the solver
+                                  defined earlier in the list will be selected.
+                                type: array
+                                items:
+                                  type: string
+                              dnsZones:
+                                description: List of DNSZones that this solver will be
+                                  used to solve. The most specific DNS zone match specified
+                                  here will take precedence over other DNS zone matches,
+                                  so a solver specifying sys.example.com will be selected
+                                  over one specifying example.com for the domain www.sys.example.com.
+                                  If multiple solvers match with the same dnsZones value,
+                                  the solver with the most matching labels in matchLabels
+                                  will be selected. If neither has more matches, the solver
+                                  defined earlier in the list will be selected.
+                                type: array
+                                items:
+                                  type: string
+                              matchLabels:
+                                description: A label selector that is used to refine the
+                                  set of certificate's that this challenge solver will
+                                  apply to.
+                                type: object
+                                additionalProperties:
+                                  type: string
+                ca:
+                  type: object
+                  required:
+                    - secretName
+                  properties:
+                    crlDistributionPoints:
+                      description: The CRL distribution points is an X.509 v3 certificate
+                        extension which identifies the location of the CRL from which
+                        the revocation of this certificate can be checked. If not set
+                        certificate will be issued without CDP. Values are strings.
+                      type: array
+                      items:
+                        type: string
+                    secretName:
+                      description: SecretName is the name of the secret used to sign Certificates
+                        issued by this Issuer.
+                      type: string
+                selfSigned:
+                  type: object
+                  properties:
+                    crlDistributionPoints:
+                      description: The CRL distribution points is an X.509 v3 certificate
+                        extension which identifies the location of the CRL from which
+                        the revocation of this certificate can be checked. If not set
+                        certificate will be issued without CDP. Values are strings.
+                      type: array
+                      items:
+                        type: string
+                vault:
+                  type: object
+                  required:
+                    - auth
+                    - path
+                    - server
+                  properties:
+                    auth:
+                      description: Vault authentication
+                      type: object
+                      properties:
+                        appRole:
+                          description: This Secret contains a AppRole and Secret
+                          type: object
+                          required:
+                            - path
+                            - roleId
+                            - secretRef
+                          properties:
+                            path:
+                              description: Where the authentication path is mounted in
+                                Vault.
+                              type: string
+                            roleId:
+                              type: string
+                            secretRef:
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the secret to select from. Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                                  type: string
+                        kubernetes:
+                          description: This contains a Role and Secret with a ServiceAccount
+                            token to authenticate with vault.
+                          type: object
+                          required:
+                            - role
+                            - secretRef
+                          properties:
+                            mountPath:
+                              description: The Vault mountPath here is the mount path
+                                to use when authenticating with Vault. For example, setting
+                                a value to `/v1/auth/foo`, will use the path `/v1/auth/foo/login`
+                                to authenticate with Vault. If unspecified, the default
+                                value "/v1/auth/kubernetes" will be used.
+                              type: string
+                            role:
+                              description: A required field containing the Vault Role
+                                to assume. A Role binds a Kubernetes ServiceAccount with
+                                a set of Vault policies.
+                              type: string
+                            secretRef:
+                              description: The required Secret field containing a Kubernetes
+                                ServiceAccount JWT used for authenticating with Vault.
+                                Use of 'ambient credentials' is not supported.
+                              type: object
+                              required:
+                                - name
+                              properties:
+                                key:
+                                  description: The key of the secret to select from. Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind, uid?'
+                                  type: string
+                        tokenSecretRef:
+                          description: This Secret contains the Vault token key
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            key:
+                              description: The key of the secret to select from. Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                    caBundle:
+                      description: Base64 encoded CA bundle to validate Vault server certificate.
+                        Only used if the Server URL is using HTTPS protocol. This parameter
+                        is ignored for plain HTTP protocol connection. If not set the
+                        system root certificates are used to validate the TLS connection.
+                      type: string
+                      format: byte
+                    path:
+                      description: Vault URL path to the certificate role
+                      type: string
+                    server:
+                      description: Server is the vault connection address
+                      type: string
+                venafi:
+                  description: VenafiIssuer describes issuer configuration details for
+                    Venafi Cloud.
+                  type: object
+                  required:
+                    - zone
+                  properties:
+                    cloud:
+                      description: Cloud specifies the Venafi cloud configuration settings.
+                        Only one of TPP or Cloud may be specified.
+                      type: object
+                      required:
+                        - apiTokenSecretRef
+                      properties:
+                        apiTokenSecretRef:
+                          description: APITokenSecretRef is a secret key selector for
+                            the Venafi Cloud API token.
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            key:
+                              description: The key of the secret to select from. Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                        url:
+                          description: URL is the base URL for Venafi Cloud
+                          type: string
+                    tpp:
+                      description: TPP specifies Trust Protection Platform configuration
+                        settings. Only one of TPP or Cloud may be specified.
+                      type: object
+                      required:
+                        - credentialsRef
+                        - url
+                      properties:
+                        caBundle:
+                          description: CABundle is a PEM encoded TLS certificate to use
+                            to verify connections to the TPP instance. If specified, system
+                            roots will not be used and the issuing CA for the TPP instance
+                            must be verifiable using the provided root. If not specified,
+                            the connection will be verified using the cert-manager system
+                            root certificates.
+                          type: string
+                          format: byte
+                        credentialsRef:
+                          description: CredentialsRef is a reference to a Secret containing
+                            the username and password for the TPP server. The secret must
+                            contain two keys, 'username' and 'password'.
+                          type: object
+                          required:
+                            - name
+                          properties:
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                        url:
+                          description: URL is the base URL for the Venafi TPP instance
+                          type: string
+                    zone:
+                      description: Zone is the Venafi Policy Zone to use for this issuer.
+                        All requests made to the Venafi platform will be restricted by
+                        the named zone policy. This field is required.
+                      type: string
+            status:
+              description: IssuerStatus contains status information about an Issuer
               type: object
               properties:
-                lastRegisteredEmail:
-                  description: LastRegisteredEmail is the email associated with the
-                    latest registered ACME account, in order to track changes made
-                    to registered account associated with the  Issuer
-                  type: string
-                uri:
-                  description: URI is the unique account identifier, which can also
-                    be used to retrieve account details from the CA
-                  type: string
-            conditions:
-              type: array
-              items:
-                description: IssuerCondition contains condition information for an
-                  Issuer.
-                type: object
-                required:
-                  - status
-                  - type
-                properties:
-                  lastTransitionTime:
-                    description: LastTransitionTime is the timestamp corresponding
-                      to the last status change of this condition.
-                    type: string
-                    format: date-time
-                  message:
-                    description: Message is a human readable description of the details
-                      of the last transition, complementing reason.
-                    type: string
-                  reason:
-                    description: Reason is a brief machine readable explanation for
-                      the condition's last transition.
-                    type: string
-                  status:
-                    description: Status of the condition, one of ('True', 'False',
-                      'Unknown').
-                    type: string
-                    enum:
-                      - "True"
-                      - "False"
-                      - Unknown
-                  type:
-                    description: Type of the condition, currently ('Ready').
-                    type: string
+                acme:
+                  type: object
+                  properties:
+                    lastRegisteredEmail:
+                      description: LastRegisteredEmail is the email associated with the
+                        latest registered ACME account, in order to track changes made
+                        to registered account associated with the  Issuer
+                      type: string
+                    uri:
+                      description: URI is the unique account identifier, which can also
+                        be used to retrieve account details from the CA
+                      type: string
+                conditions:
+                  type: array
+                  items:
+                    description: IssuerCondition contains condition information for an
+                      Issuer.
+                    type: object
+                    required:
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: LastTransitionTime is the timestamp corresponding
+                          to the last status change of this condition.
+                        type: string
+                        format: date-time
+                      message:
+                        description: Message is a human readable description of the details
+                          of the last transition, complementing reason.
+                        type: string
+                      reason:
+                        description: Reason is a brief machine readable explanation for
+                          the condition's last transition.
+                        type: string
+                      status:
+                        description: Status of the condition, one of ('True', 'False',
+                          'Unknown').
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      type:
+                        description: Type of the condition, currently ('Ready').
+                        type: string
+      served: true
+      storage: false
+      additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].message
+          name: Status
+          priority: 1
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          description: CreationTimestamp is a timestamp representing the server time when
+            this object was created. It is not guaranteed to be set in happens-before order
+            across separate operations. Clients may not set this value. It is represented
+            in RFC3339 form and is in UTC.
+          name: Age
+          type: date
+      subresources:
+        status: { }

--- a/config/test/crd/istio/networking.istio.io_gateway.yaml
+++ b/config/test/crd/istio/networking.istio.io_gateway.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -23,138 +23,266 @@ spec:
     singular: gateway
   preserveUnknownFields: false
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          description: 'Configuration affecting edge load balancer. See more details
-            at: https://istio.io/docs/reference/config/networking/gateway.html'
-          properties:
-            selector:
-              additionalProperties:
-                format: string
-                type: string
-              type: object
-            servers:
-              description: A list of server specifications.
-              items:
-                properties:
-                  bind:
-                    format: string
-                    type: string
-                  defaultEndpoint:
-                    format: string
-                    type: string
-                  hosts:
-                    description: One or more hosts exposed by this gateway.
-                    items:
-                      format: string
-                      type: string
-                    type: array
-                  name:
-                    description: An optional name of the server, when set must be
-                      unique across all servers.
-                    format: string
-                    type: string
-                  port:
-                    properties:
-                      name:
-                        description: Label assigned to the port.
-                        format: string
-                        type: string
-                      number:
-                        description: A valid non-negative integer port number.
-                        type: integer
-                      protocol:
-                        description: The protocol exposed on the port.
-                        format: string
-                        type: string
-                      targetPort:
-                        type: integer
-                    type: object
-                  tls:
-                    description: Set of TLS related options that govern the server's
-                      behavior.
-                    properties:
-                      caCertificates:
-                        description: REQUIRED if mode is `MUTUAL`.
-                        format: string
-                        type: string
-                      cipherSuites:
-                        description: 'Optional: If specified, only support the specified
-                          cipher list.'
-                        items:
-                          format: string
-                          type: string
-                        type: array
-                      credentialName:
-                        format: string
-                        type: string
-                      httpsRedirect:
-                        type: boolean
-                      maxProtocolVersion:
-                        description: 'Optional: Maximum TLS protocol version.'
-                        enum:
-                          - TLS_AUTO
-                          - TLSV1_0
-                          - TLSV1_1
-                          - TLSV1_2
-                          - TLSV1_3
-                        type: string
-                      minProtocolVersion:
-                        description: 'Optional: Minimum TLS protocol version.'
-                        enum:
-                          - TLS_AUTO
-                          - TLSV1_0
-                          - TLSV1_1
-                          - TLSV1_2
-                          - TLSV1_3
-                        type: string
-                      mode:
-                        enum:
-                          - PASSTHROUGH
-                          - SIMPLE
-                          - MUTUAL
-                          - AUTO_PASSTHROUGH
-                          - ISTIO_MUTUAL
-                        type: string
-                      privateKey:
-                        description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
-                        format: string
-                        type: string
-                      serverCertificate:
-                        description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
-                        format: string
-                        type: string
-                      subjectAltNames:
-                        items:
-                          format: string
-                          type: string
-                        type: array
-                      verifyCertificateHash:
-                        items:
-                          format: string
-                          type: string
-                        type: array
-                      verifyCertificateSpki:
-                        items:
-                          format: string
-                          type: string
-                        type: array
-                    type: object
-                type: object
-              type: array
-          type: object
-        status:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      type: object
   versions:
     - name: v1alpha3
+      schema:
+        openAPIV3Schema:
+          properties:
+            spec:
+              description: 'Configuration affecting edge load balancer. See more details
+                at: https://istio.io/docs/reference/config/networking/gateway.html'
+              properties:
+                selector:
+                  additionalProperties:
+                    format: string
+                    type: string
+                  type: object
+                servers:
+                  description: A list of server specifications.
+                  items:
+                    properties:
+                      bind:
+                        format: string
+                        type: string
+                      defaultEndpoint:
+                        format: string
+                        type: string
+                      hosts:
+                        description: One or more hosts exposed by this gateway.
+                        items:
+                          format: string
+                          type: string
+                        type: array
+                      name:
+                        description: An optional name of the server, when set must be
+                          unique across all servers.
+                        format: string
+                        type: string
+                      port:
+                        properties:
+                          name:
+                            description: Label assigned to the port.
+                            format: string
+                            type: string
+                          number:
+                            description: A valid non-negative integer port number.
+                            type: integer
+                          protocol:
+                            description: The protocol exposed on the port.
+                            format: string
+                            type: string
+                          targetPort:
+                            type: integer
+                        type: object
+                      tls:
+                        description: Set of TLS related options that govern the server's
+                          behavior.
+                        properties:
+                          caCertificates:
+                            description: REQUIRED if mode is `MUTUAL`.
+                            format: string
+                            type: string
+                          cipherSuites:
+                            description: 'Optional: If specified, only support the specified
+                              cipher list.'
+                            items:
+                              format: string
+                              type: string
+                            type: array
+                          credentialName:
+                            format: string
+                            type: string
+                          httpsRedirect:
+                            type: boolean
+                          maxProtocolVersion:
+                            description: 'Optional: Maximum TLS protocol version.'
+                            enum:
+                              - TLS_AUTO
+                              - TLSV1_0
+                              - TLSV1_1
+                              - TLSV1_2
+                              - TLSV1_3
+                            type: string
+                          minProtocolVersion:
+                            description: 'Optional: Minimum TLS protocol version.'
+                            enum:
+                              - TLS_AUTO
+                              - TLSV1_0
+                              - TLSV1_1
+                              - TLSV1_2
+                              - TLSV1_3
+                            type: string
+                          mode:
+                            enum:
+                              - PASSTHROUGH
+                              - SIMPLE
+                              - MUTUAL
+                              - AUTO_PASSTHROUGH
+                              - ISTIO_MUTUAL
+                            type: string
+                          privateKey:
+                            description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
+                            format: string
+                            type: string
+                          serverCertificate:
+                            description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
+                            format: string
+                            type: string
+                          subjectAltNames:
+                            items:
+                              format: string
+                              type: string
+                            type: array
+                          verifyCertificateHash:
+                            items:
+                              format: string
+                              type: string
+                            type: array
+                          verifyCertificateSpki:
+                            items:
+                              format: string
+                              type: string
+                            type: array
+                        type: object
+                    type: object
+                  type: array
+              type: object
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
       served: true
       storage: true
+      subresources:
+        status: { }
     - name: v1beta1
+      schema:
+        openAPIV3Schema:
+          properties:
+            spec:
+              description: 'Configuration affecting edge load balancer. See more details
+                at: https://istio.io/docs/reference/config/networking/gateway.html'
+              properties:
+                selector:
+                  additionalProperties:
+                    format: string
+                    type: string
+                  type: object
+                servers:
+                  description: A list of server specifications.
+                  items:
+                    properties:
+                      bind:
+                        format: string
+                        type: string
+                      defaultEndpoint:
+                        format: string
+                        type: string
+                      hosts:
+                        description: One or more hosts exposed by this gateway.
+                        items:
+                          format: string
+                          type: string
+                        type: array
+                      name:
+                        description: An optional name of the server, when set must be
+                          unique across all servers.
+                        format: string
+                        type: string
+                      port:
+                        properties:
+                          name:
+                            description: Label assigned to the port.
+                            format: string
+                            type: string
+                          number:
+                            description: A valid non-negative integer port number.
+                            type: integer
+                          protocol:
+                            description: The protocol exposed on the port.
+                            format: string
+                            type: string
+                          targetPort:
+                            type: integer
+                        type: object
+                      tls:
+                        description: Set of TLS related options that govern the server's
+                          behavior.
+                        properties:
+                          caCertificates:
+                            description: REQUIRED if mode is `MUTUAL`.
+                            format: string
+                            type: string
+                          cipherSuites:
+                            description: 'Optional: If specified, only support the specified
+                              cipher list.'
+                            items:
+                              format: string
+                              type: string
+                            type: array
+                          credentialName:
+                            format: string
+                            type: string
+                          httpsRedirect:
+                            type: boolean
+                          maxProtocolVersion:
+                            description: 'Optional: Maximum TLS protocol version.'
+                            enum:
+                              - TLS_AUTO
+                              - TLSV1_0
+                              - TLSV1_1
+                              - TLSV1_2
+                              - TLSV1_3
+                            type: string
+                          minProtocolVersion:
+                            description: 'Optional: Minimum TLS protocol version.'
+                            enum:
+                              - TLS_AUTO
+                              - TLSV1_0
+                              - TLSV1_1
+                              - TLSV1_2
+                              - TLSV1_3
+                            type: string
+                          mode:
+                            enum:
+                              - PASSTHROUGH
+                              - SIMPLE
+                              - MUTUAL
+                              - AUTO_PASSTHROUGH
+                              - ISTIO_MUTUAL
+                            type: string
+                          privateKey:
+                            description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
+                            format: string
+                            type: string
+                          serverCertificate:
+                            description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
+                            format: string
+                            type: string
+                          subjectAltNames:
+                            items:
+                              format: string
+                              type: string
+                            type: array
+                          verifyCertificateHash:
+                            items:
+                              format: string
+                              type: string
+                            type: array
+                          verifyCertificateSpki:
+                            items:
+                              format: string
+                              type: string
+                            type: array
+                        type: object
+                    type: object
+                  type: array
+              type: object
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
       served: true
       storage: false
+      subresources:
+        status: { }

--- a/config/test/crd/istio/networking.istio.io_virtualservice.yaml
+++ b/config/test/crd/istio/networking.istio.io_virtualservice.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -10,23 +10,6 @@ metadata:
     release: istio
   name: virtualservices.networking.istio.io
 spec:
-  additionalPrinterColumns:
-    - JSONPath: .spec.gateways
-      description: The names of gateways and sidecars that should apply these routes
-      name: Gateways
-      type: string
-    - JSONPath: .spec.hosts
-      description: The destination hosts to which traffic is being sent
-      name: Hosts
-      type: string
-    - JSONPath: .metadata.creationTimestamp
-      description: 'CreationTimestamp is a timestamp representing the server time when
-      this object was created. It is not guaranteed to be set in happens-before order
-      across separate operations. Clients may not set this value. It is represented
-      in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for
-      lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
-      name: Age
-      type: date
   group: networking.istio.io
   names:
     categories:
@@ -40,778 +23,1580 @@ spec:
     singular: virtualservice
   preserveUnknownFields: false
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          description: 'Configuration affecting label/content routing, sni routing,
-            etc. See more details at: https://istio.io/docs/reference/config/networking/virtual-service.html'
-          properties:
-            exportTo:
-              description: A list of namespaces to which this virtual service is exported.
-              items:
-                format: string
-                type: string
-              type: array
-            gateways:
-              description: The names of gateways and sidecars that should apply these
-                routes.
-              items:
-                format: string
-                type: string
-              type: array
-            hosts:
-              description: The destination hosts to which traffic is being sent.
-              items:
-                format: string
-                type: string
-              type: array
-            http:
-              description: An ordered list of route rules for HTTP traffic.
-              items:
-                properties:
-                  corsPolicy:
-                    description: Cross-Origin Resource Sharing policy (CORS).
-                    properties:
-                      allowCredentials:
-                        nullable: true
-                        type: boolean
-                      allowHeaders:
-                        items:
-                          format: string
-                          type: string
-                        type: array
-                      allowMethods:
-                        description: List of HTTP methods allowed to access the resource.
-                        items:
-                          format: string
-                          type: string
-                        type: array
-                      allowOrigin:
-                        description: The list of origins that are allowed to perform
-                          CORS requests.
-                        items:
-                          format: string
-                          type: string
-                        type: array
-                      allowOrigins:
-                        description: String patterns that match allowed origins.
-                        items:
-                          oneOf:
-                            - not:
-                                anyOf:
-                                  - required:
-                                      - exact
-                                  - required:
-                                      - prefix
-                                  - required:
-                                      - regex
-                            - required:
-                                - exact
-                            - required:
-                                - prefix
-                            - required:
-                                - regex
-                          properties:
-                            exact:
-                              format: string
-                              type: string
-                            prefix:
-                              format: string
-                              type: string
-                            regex:
-                              description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                              format: string
-                              type: string
-                          type: object
-                        type: array
-                      exposeHeaders:
-                        items:
-                          format: string
-                          type: string
-                        type: array
-                      maxAge:
-                        type: string
-                    type: object
-                  delegate:
-                    properties:
-                      name:
-                        description: Name specifies the name of the delegate VirtualService.
-                        format: string
-                        type: string
-                      namespace:
-                        description: Namespace specifies the namespace where the delegate
-                          VirtualService resides.
-                        format: string
-                        type: string
-                    type: object
-                  fault:
-                    description: Fault injection policy to apply on HTTP traffic at
-                      the client side.
-                    properties:
-                      abort:
-                        oneOf:
-                          - not:
-                              anyOf:
-                                - required:
-                                    - httpStatus
-                                - required:
-                                    - grpcStatus
-                                - required:
-                                    - http2Error
-                          - required:
-                              - httpStatus
-                          - required:
-                              - grpcStatus
-                          - required:
-                              - http2Error
-                        properties:
-                          grpcStatus:
-                            format: string
-                            type: string
-                          http2Error:
-                            format: string
-                            type: string
-                          httpStatus:
-                            description: HTTP status code to use to abort the Http
-                              request.
-                            format: int32
-                            type: integer
-                          percentage:
-                            description: Percentage of requests to be aborted with
-                              the error code provided.
-                            properties:
-                              value:
-                                format: double
-                                type: number
-                            type: object
-                        type: object
-                      delay:
-                        oneOf:
-                          - not:
-                              anyOf:
-                                - required:
-                                    - fixedDelay
-                                - required:
-                                    - exponentialDelay
-                          - required:
-                              - fixedDelay
-                          - required:
-                              - exponentialDelay
-                        properties:
-                          exponentialDelay:
-                            type: string
-                          fixedDelay:
-                            description: Add a fixed delay before forwarding the request.
-                            type: string
-                          percent:
-                            description: Percentage of requests on which the delay
-                              will be injected (0-100).
-                            format: int32
-                            type: integer
-                          percentage:
-                            description: Percentage of requests on which the delay
-                              will be injected.
-                            properties:
-                              value:
-                                format: double
-                                type: number
-                            type: object
-                        type: object
-                    type: object
-                  headers:
-                    properties:
-                      request:
-                        properties:
-                          add:
-                            additionalProperties:
-                              format: string
-                              type: string
-                            type: object
-                          remove:
-                            items:
-                              format: string
-                              type: string
-                            type: array
-                          set:
-                            additionalProperties:
-                              format: string
-                              type: string
-                            type: object
-                        type: object
-                      response:
-                        properties:
-                          add:
-                            additionalProperties:
-                              format: string
-                              type: string
-                            type: object
-                          remove:
-                            items:
-                              format: string
-                              type: string
-                            type: array
-                          set:
-                            additionalProperties:
-                              format: string
-                              type: string
-                            type: object
-                        type: object
-                    type: object
-                  match:
-                    items:
-                      properties:
-                        authority:
-                          oneOf:
-                            - not:
-                                anyOf:
-                                  - required:
-                                      - exact
-                                  - required:
-                                      - prefix
-                                  - required:
-                                      - regex
-                            - required:
-                                - exact
-                            - required:
-                                - prefix
-                            - required:
-                                - regex
-                          properties:
-                            exact:
-                              format: string
-                              type: string
-                            prefix:
-                              format: string
-                              type: string
-                            regex:
-                              description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                              format: string
-                              type: string
-                          type: object
-                        gateways:
-                          description: Names of gateways where the rule should be
-                            applied.
-                          items:
-                            format: string
-                            type: string
-                          type: array
-                        headers:
-                          additionalProperties:
-                            oneOf:
-                              - not:
-                                  anyOf:
-                                    - required:
-                                        - exact
-                                    - required:
-                                        - prefix
-                                    - required:
-                                        - regex
-                              - required:
-                                  - exact
-                              - required:
-                                  - prefix
-                              - required:
-                                  - regex
-                            properties:
-                              exact:
-                                format: string
-                                type: string
-                              prefix:
-                                format: string
-                                type: string
-                              regex:
-                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                                format: string
-                                type: string
-                            type: object
-                          type: object
-                        ignoreUriCase:
-                          description: Flag to specify whether the URI matching should
-                            be case-insensitive.
-                          type: boolean
-                        method:
-                          oneOf:
-                            - not:
-                                anyOf:
-                                  - required:
-                                      - exact
-                                  - required:
-                                      - prefix
-                                  - required:
-                                      - regex
-                            - required:
-                                - exact
-                            - required:
-                                - prefix
-                            - required:
-                                - regex
-                          properties:
-                            exact:
-                              format: string
-                              type: string
-                            prefix:
-                              format: string
-                              type: string
-                            regex:
-                              description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                              format: string
-                              type: string
-                          type: object
-                        name:
-                          description: The name assigned to a match.
-                          format: string
-                          type: string
-                        port:
-                          description: Specifies the ports on the host that is being
-                            addressed.
-                          type: integer
-                        queryParams:
-                          additionalProperties:
-                            oneOf:
-                              - not:
-                                  anyOf:
-                                    - required:
-                                        - exact
-                                    - required:
-                                        - prefix
-                                    - required:
-                                        - regex
-                              - required:
-                                  - exact
-                              - required:
-                                  - prefix
-                              - required:
-                                  - regex
-                            properties:
-                              exact:
-                                format: string
-                                type: string
-                              prefix:
-                                format: string
-                                type: string
-                              regex:
-                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                                format: string
-                                type: string
-                            type: object
-                          description: Query parameters for matching.
-                          type: object
-                        scheme:
-                          oneOf:
-                            - not:
-                                anyOf:
-                                  - required:
-                                      - exact
-                                  - required:
-                                      - prefix
-                                  - required:
-                                      - regex
-                            - required:
-                                - exact
-                            - required:
-                                - prefix
-                            - required:
-                                - regex
-                          properties:
-                            exact:
-                              format: string
-                              type: string
-                            prefix:
-                              format: string
-                              type: string
-                            regex:
-                              description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                              format: string
-                              type: string
-                          type: object
-                        sourceLabels:
-                          additionalProperties:
-                            format: string
-                            type: string
-                          type: object
-                        sourceNamespace:
-                          description: Source namespace constraining the applicability
-                            of a rule to workloads in that namespace.
-                          format: string
-                          type: string
-                        uri:
-                          oneOf:
-                            - not:
-                                anyOf:
-                                  - required:
-                                      - exact
-                                  - required:
-                                      - prefix
-                                  - required:
-                                      - regex
-                            - required:
-                                - exact
-                            - required:
-                                - prefix
-                            - required:
-                                - regex
-                          properties:
-                            exact:
-                              format: string
-                              type: string
-                            prefix:
-                              format: string
-                              type: string
-                            regex:
-                              description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                              format: string
-                              type: string
-                          type: object
-                        withoutHeaders:
-                          additionalProperties:
-                            oneOf:
-                              - not:
-                                  anyOf:
-                                    - required:
-                                        - exact
-                                    - required:
-                                        - prefix
-                                    - required:
-                                        - regex
-                              - required:
-                                  - exact
-                              - required:
-                                  - prefix
-                              - required:
-                                  - regex
-                            properties:
-                              exact:
-                                format: string
-                                type: string
-                              prefix:
-                                format: string
-                                type: string
-                              regex:
-                                description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
-                                format: string
-                                type: string
-                            type: object
-                          description: withoutHeader has the same syntax with the
-                            header, but has opposite meaning.
-                          type: object
-                      type: object
-                    type: array
-                  mirror:
-                    properties:
-                      host:
-                        description: The name of a service from the service registry.
-                        format: string
-                        type: string
-                      port:
-                        description: Specifies the port on the host that is being
-                          addressed.
-                        properties:
-                          number:
-                            type: integer
-                        type: object
-                      subset:
-                        description: The name of a subset within the service.
-                        format: string
-                        type: string
-                    type: object
-                  mirror_percent:
-                    description: Percentage of the traffic to be mirrored by the `mirror`
-                      field.
-                    nullable: true
-                    type: integer
-                  mirrorPercent:
-                    description: Percentage of the traffic to be mirrored by the `mirror`
-                      field.
-                    nullable: true
-                    type: integer
-                  mirrorPercentage:
-                    description: Percentage of the traffic to be mirrored by the `mirror`
-                      field.
-                    properties:
-                      value:
-                        format: double
-                        type: number
-                    type: object
-                  name:
-                    description: The name assigned to the route for debugging purposes.
-                    format: string
-                    type: string
-                  redirect:
-                    description: A HTTP rule can either redirect or forward (default)
-                      traffic.
-                    properties:
-                      authority:
-                        format: string
-                        type: string
-                      redirectCode:
-                        type: integer
-                      uri:
-                        format: string
-                        type: string
-                    type: object
-                  retries:
-                    description: Retry policy for HTTP requests.
-                    properties:
-                      attempts:
-                        description: Number of retries to be allowed for a given request.
-                        format: int32
-                        type: integer
-                      perTryTimeout:
-                        description: Timeout per retry attempt for a given request.
-                        type: string
-                      retryOn:
-                        description: Specifies the conditions under which retry takes
-                          place.
-                        format: string
-                        type: string
-                      retryRemoteLocalities:
-                        description: Flag to specify whether the retries should retry
-                          to other localities.
-                        nullable: true
-                        type: boolean
-                    type: object
-                  rewrite:
-                    description: Rewrite HTTP URIs and Authority headers.
-                    properties:
-                      authority:
-                        description: rewrite the Authority/Host header with this value.
-                        format: string
-                        type: string
-                      uri:
-                        format: string
-                        type: string
-                    type: object
-                  route:
-                    description: A HTTP rule can either redirect or forward (default)
-                      traffic.
-                    items:
-                      properties:
-                        destination:
-                          properties:
-                            host:
-                              description: The name of a service from the service
-                                registry.
-                              format: string
-                              type: string
-                            port:
-                              description: Specifies the port on the host that is
-                                being addressed.
-                              properties:
-                                number:
-                                  type: integer
-                              type: object
-                            subset:
-                              description: The name of a subset within the service.
-                              format: string
-                              type: string
-                          type: object
-                        headers:
-                          properties:
-                            request:
-                              properties:
-                                add:
-                                  additionalProperties:
-                                    format: string
-                                    type: string
-                                  type: object
-                                remove:
-                                  items:
-                                    format: string
-                                    type: string
-                                  type: array
-                                set:
-                                  additionalProperties:
-                                    format: string
-                                    type: string
-                                  type: object
-                              type: object
-                            response:
-                              properties:
-                                add:
-                                  additionalProperties:
-                                    format: string
-                                    type: string
-                                  type: object
-                                remove:
-                                  items:
-                                    format: string
-                                    type: string
-                                  type: array
-                                set:
-                                  additionalProperties:
-                                    format: string
-                                    type: string
-                                  type: object
-                              type: object
-                          type: object
-                        weight:
-                          format: int32
-                          type: integer
-                      type: object
-                    type: array
-                  timeout:
-                    description: Timeout for HTTP requests, default is disabled.
-                    type: string
-                type: object
-              type: array
-            tcp:
-              description: An ordered list of route rules for opaque TCP traffic.
-              items:
-                properties:
-                  match:
-                    items:
-                      properties:
-                        destinationSubnets:
-                          description: IPv4 or IPv6 ip addresses of destination with
-                            optional subnet.
-                          items:
-                            format: string
-                            type: string
-                          type: array
-                        gateways:
-                          description: Names of gateways where the rule should be
-                            applied.
-                          items:
-                            format: string
-                            type: string
-                          type: array
-                        port:
-                          description: Specifies the port on the host that is being
-                            addressed.
-                          type: integer
-                        sourceLabels:
-                          additionalProperties:
-                            format: string
-                            type: string
-                          type: object
-                        sourceNamespace:
-                          description: Source namespace constraining the applicability
-                            of a rule to workloads in that namespace.
-                          format: string
-                          type: string
-                        sourceSubnet:
-                          description: IPv4 or IPv6 ip address of source with optional
-                            subnet.
-                          format: string
-                          type: string
-                      type: object
-                    type: array
-                  route:
-                    description: The destination to which the connection should be
-                      forwarded to.
-                    items:
-                      properties:
-                        destination:
-                          properties:
-                            host:
-                              description: The name of a service from the service
-                                registry.
-                              format: string
-                              type: string
-                            port:
-                              description: Specifies the port on the host that is
-                                being addressed.
-                              properties:
-                                number:
-                                  type: integer
-                              type: object
-                            subset:
-                              description: The name of a subset within the service.
-                              format: string
-                              type: string
-                          type: object
-                        weight:
-                          format: int32
-                          type: integer
-                      type: object
-                    type: array
-                type: object
-              type: array
-            tls:
-              items:
-                properties:
-                  match:
-                    items:
-                      properties:
-                        destinationSubnets:
-                          description: IPv4 or IPv6 ip addresses of destination with
-                            optional subnet.
-                          items:
-                            format: string
-                            type: string
-                          type: array
-                        gateways:
-                          description: Names of gateways where the rule should be
-                            applied.
-                          items:
-                            format: string
-                            type: string
-                          type: array
-                        port:
-                          description: Specifies the port on the host that is being
-                            addressed.
-                          type: integer
-                        sniHosts:
-                          description: SNI (server name indicator) to match on.
-                          items:
-                            format: string
-                            type: string
-                          type: array
-                        sourceLabels:
-                          additionalProperties:
-                            format: string
-                            type: string
-                          type: object
-                        sourceNamespace:
-                          description: Source namespace constraining the applicability
-                            of a rule to workloads in that namespace.
-                          format: string
-                          type: string
-                      type: object
-                    type: array
-                  route:
-                    description: The destination to which the connection should be
-                      forwarded to.
-                    items:
-                      properties:
-                        destination:
-                          properties:
-                            host:
-                              description: The name of a service from the service
-                                registry.
-                              format: string
-                              type: string
-                            port:
-                              description: Specifies the port on the host that is
-                                being addressed.
-                              properties:
-                                number:
-                                  type: integer
-                              type: object
-                            subset:
-                              description: The name of a subset within the service.
-                              format: string
-                              type: string
-                          type: object
-                        weight:
-                          format: int32
-                          type: integer
-                      type: object
-                    type: array
-                type: object
-              type: array
-          type: object
-        status:
-          type: object
-          x-kubernetes-preserve-unknown-fields: true
-      type: object
   versions:
     - name: v1alpha3
+      schema:
+        openAPIV3Schema:
+          properties:
+            spec:
+              description: 'Configuration affecting label/content routing, sni routing,
+                    etc. See more details at: https://istio.io/docs/reference/config/networking/virtual-service.html'
+              properties:
+                exportTo:
+                  description: A list of namespaces to which this virtual service is exported.
+                  items:
+                    format: string
+                    type: string
+                  type: array
+                gateways:
+                  description: The names of gateways and sidecars that should apply these
+                    routes.
+                  items:
+                    format: string
+                    type: string
+                  type: array
+                hosts:
+                  description: The destination hosts to which traffic is being sent.
+                  items:
+                    format: string
+                    type: string
+                  type: array
+                http:
+                  description: An ordered list of route rules for HTTP traffic.
+                  items:
+                    properties:
+                      corsPolicy:
+                        description: Cross-Origin Resource Sharing policy (CORS).
+                        properties:
+                          allowCredentials:
+                            nullable: true
+                            type: boolean
+                          allowHeaders:
+                            items:
+                              format: string
+                              type: string
+                            type: array
+                          allowMethods:
+                            description: List of HTTP methods allowed to access the resource.
+                            items:
+                              format: string
+                              type: string
+                            type: array
+                          allowOrigin:
+                            description: The list of origins that are allowed to perform
+                              CORS requests.
+                            items:
+                              format: string
+                              type: string
+                            type: array
+                          allowOrigins:
+                            description: String patterns that match allowed origins.
+                            items:
+                              oneOf:
+                                - not:
+                                    anyOf:
+                                      - required:
+                                          - exact
+                                      - required:
+                                          - prefix
+                                      - required:
+                                          - regex
+                                - required:
+                                    - exact
+                                - required:
+                                    - prefix
+                                - required:
+                                    - regex
+                              properties:
+                                exact:
+                                  format: string
+                                  type: string
+                                prefix:
+                                  format: string
+                                  type: string
+                                regex:
+                                  description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                  format: string
+                                  type: string
+                              type: object
+                            type: array
+                          exposeHeaders:
+                            items:
+                              format: string
+                              type: string
+                            type: array
+                          maxAge:
+                            type: string
+                        type: object
+                      delegate:
+                        properties:
+                          name:
+                            description: Name specifies the name of the delegate VirtualService.
+                            format: string
+                            type: string
+                          namespace:
+                            description: Namespace specifies the namespace where the delegate
+                              VirtualService resides.
+                            format: string
+                            type: string
+                        type: object
+                      fault:
+                        description: Fault injection policy to apply on HTTP traffic at
+                          the client side.
+                        properties:
+                          abort:
+                            oneOf:
+                              - not:
+                                  anyOf:
+                                    - required:
+                                        - httpStatus
+                                    - required:
+                                        - grpcStatus
+                                    - required:
+                                        - http2Error
+                              - required:
+                                  - httpStatus
+                              - required:
+                                  - grpcStatus
+                              - required:
+                                  - http2Error
+                            properties:
+                              grpcStatus:
+                                format: string
+                                type: string
+                              http2Error:
+                                format: string
+                                type: string
+                              httpStatus:
+                                description: HTTP status code to use to abort the Http
+                                  request.
+                                format: int32
+                                type: integer
+                              percentage:
+                                description: Percentage of requests to be aborted with
+                                  the error code provided.
+                                properties:
+                                  value:
+                                    format: double
+                                    type: number
+                                type: object
+                            type: object
+                          delay:
+                            oneOf:
+                              - not:
+                                  anyOf:
+                                    - required:
+                                        - fixedDelay
+                                    - required:
+                                        - exponentialDelay
+                              - required:
+                                  - fixedDelay
+                              - required:
+                                  - exponentialDelay
+                            properties:
+                              exponentialDelay:
+                                type: string
+                              fixedDelay:
+                                description: Add a fixed delay before forwarding the request.
+                                type: string
+                              percent:
+                                description: Percentage of requests on which the delay
+                                  will be injected (0-100).
+                                format: int32
+                                type: integer
+                              percentage:
+                                description: Percentage of requests on which the delay
+                                  will be injected.
+                                properties:
+                                  value:
+                                    format: double
+                                    type: number
+                                type: object
+                            type: object
+                        type: object
+                      headers:
+                        properties:
+                          request:
+                            properties:
+                              add:
+                                additionalProperties:
+                                  format: string
+                                  type: string
+                                type: object
+                              remove:
+                                items:
+                                  format: string
+                                  type: string
+                                type: array
+                              set:
+                                additionalProperties:
+                                  format: string
+                                  type: string
+                                type: object
+                            type: object
+                          response:
+                            properties:
+                              add:
+                                additionalProperties:
+                                  format: string
+                                  type: string
+                                type: object
+                              remove:
+                                items:
+                                  format: string
+                                  type: string
+                                type: array
+                              set:
+                                additionalProperties:
+                                  format: string
+                                  type: string
+                                type: object
+                            type: object
+                        type: object
+                      match:
+                        items:
+                          properties:
+                            authority:
+                              oneOf:
+                                - not:
+                                    anyOf:
+                                      - required:
+                                          - exact
+                                      - required:
+                                          - prefix
+                                      - required:
+                                          - regex
+                                - required:
+                                    - exact
+                                - required:
+                                    - prefix
+                                - required:
+                                    - regex
+                              properties:
+                                exact:
+                                  format: string
+                                  type: string
+                                prefix:
+                                  format: string
+                                  type: string
+                                regex:
+                                  description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                  format: string
+                                  type: string
+                              type: object
+                            gateways:
+                              description: Names of gateways where the rule should be
+                                applied.
+                              items:
+                                format: string
+                                type: string
+                              type: array
+                            headers:
+                              additionalProperties:
+                                oneOf:
+                                  - not:
+                                      anyOf:
+                                        - required:
+                                            - exact
+                                        - required:
+                                            - prefix
+                                        - required:
+                                            - regex
+                                  - required:
+                                      - exact
+                                  - required:
+                                      - prefix
+                                  - required:
+                                      - regex
+                                properties:
+                                  exact:
+                                    format: string
+                                    type: string
+                                  prefix:
+                                    format: string
+                                    type: string
+                                  regex:
+                                    description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                    format: string
+                                    type: string
+                                type: object
+                              type: object
+                            ignoreUriCase:
+                              description: Flag to specify whether the URI matching should
+                                be case-insensitive.
+                              type: boolean
+                            method:
+                              oneOf:
+                                - not:
+                                    anyOf:
+                                      - required:
+                                          - exact
+                                      - required:
+                                          - prefix
+                                      - required:
+                                          - regex
+                                - required:
+                                    - exact
+                                - required:
+                                    - prefix
+                                - required:
+                                    - regex
+                              properties:
+                                exact:
+                                  format: string
+                                  type: string
+                                prefix:
+                                  format: string
+                                  type: string
+                                regex:
+                                  description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                  format: string
+                                  type: string
+                              type: object
+                            name:
+                              description: The name assigned to a match.
+                              format: string
+                              type: string
+                            port:
+                              description: Specifies the ports on the host that is being
+                                addressed.
+                              type: integer
+                            queryParams:
+                              additionalProperties:
+                                oneOf:
+                                  - not:
+                                      anyOf:
+                                        - required:
+                                            - exact
+                                        - required:
+                                            - prefix
+                                        - required:
+                                            - regex
+                                  - required:
+                                      - exact
+                                  - required:
+                                      - prefix
+                                  - required:
+                                      - regex
+                                properties:
+                                  exact:
+                                    format: string
+                                    type: string
+                                  prefix:
+                                    format: string
+                                    type: string
+                                  regex:
+                                    description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                    format: string
+                                    type: string
+                                type: object
+                              description: Query parameters for matching.
+                              type: object
+                            scheme:
+                              oneOf:
+                                - not:
+                                    anyOf:
+                                      - required:
+                                          - exact
+                                      - required:
+                                          - prefix
+                                      - required:
+                                          - regex
+                                - required:
+                                    - exact
+                                - required:
+                                    - prefix
+                                - required:
+                                    - regex
+                              properties:
+                                exact:
+                                  format: string
+                                  type: string
+                                prefix:
+                                  format: string
+                                  type: string
+                                regex:
+                                  description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                  format: string
+                                  type: string
+                              type: object
+                            sourceLabels:
+                              additionalProperties:
+                                format: string
+                                type: string
+                              type: object
+                            sourceNamespace:
+                              description: Source namespace constraining the applicability
+                                of a rule to workloads in that namespace.
+                              format: string
+                              type: string
+                            uri:
+                              oneOf:
+                                - not:
+                                    anyOf:
+                                      - required:
+                                          - exact
+                                      - required:
+                                          - prefix
+                                      - required:
+                                          - regex
+                                - required:
+                                    - exact
+                                - required:
+                                    - prefix
+                                - required:
+                                    - regex
+                              properties:
+                                exact:
+                                  format: string
+                                  type: string
+                                prefix:
+                                  format: string
+                                  type: string
+                                regex:
+                                  description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                  format: string
+                                  type: string
+                              type: object
+                            withoutHeaders:
+                              additionalProperties:
+                                oneOf:
+                                  - not:
+                                      anyOf:
+                                        - required:
+                                            - exact
+                                        - required:
+                                            - prefix
+                                        - required:
+                                            - regex
+                                  - required:
+                                      - exact
+                                  - required:
+                                      - prefix
+                                  - required:
+                                      - regex
+                                properties:
+                                  exact:
+                                    format: string
+                                    type: string
+                                  prefix:
+                                    format: string
+                                    type: string
+                                  regex:
+                                    description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                    format: string
+                                    type: string
+                                type: object
+                              description: withoutHeader has the same syntax with the
+                                header, but has opposite meaning.
+                              type: object
+                          type: object
+                        type: array
+                      mirror:
+                        properties:
+                          host:
+                            description: The name of a service from the service registry.
+                            format: string
+                            type: string
+                          port:
+                            description: Specifies the port on the host that is being
+                              addressed.
+                            properties:
+                              number:
+                                type: integer
+                            type: object
+                          subset:
+                            description: The name of a subset within the service.
+                            format: string
+                            type: string
+                        type: object
+                      mirror_percent:
+                        description: Percentage of the traffic to be mirrored by the `mirror`
+                          field.
+                        nullable: true
+                        type: integer
+                      mirrorPercent:
+                        description: Percentage of the traffic to be mirrored by the `mirror`
+                          field.
+                        nullable: true
+                        type: integer
+                      mirrorPercentage:
+                        description: Percentage of the traffic to be mirrored by the `mirror`
+                          field.
+                        properties:
+                          value:
+                            format: double
+                            type: number
+                        type: object
+                      name:
+                        description: The name assigned to the route for debugging purposes.
+                        format: string
+                        type: string
+                      redirect:
+                        description: A HTTP rule can either redirect or forward (default)
+                          traffic.
+                        properties:
+                          authority:
+                            format: string
+                            type: string
+                          redirectCode:
+                            type: integer
+                          uri:
+                            format: string
+                            type: string
+                        type: object
+                      retries:
+                        description: Retry policy for HTTP requests.
+                        properties:
+                          attempts:
+                            description: Number of retries to be allowed for a given request.
+                            format: int32
+                            type: integer
+                          perTryTimeout:
+                            description: Timeout per retry attempt for a given request.
+                            type: string
+                          retryOn:
+                            description: Specifies the conditions under which retry takes
+                              place.
+                            format: string
+                            type: string
+                          retryRemoteLocalities:
+                            description: Flag to specify whether the retries should retry
+                              to other localities.
+                            nullable: true
+                            type: boolean
+                        type: object
+                      rewrite:
+                        description: Rewrite HTTP URIs and Authority headers.
+                        properties:
+                          authority:
+                            description: rewrite the Authority/Host header with this value.
+                            format: string
+                            type: string
+                          uri:
+                            format: string
+                            type: string
+                        type: object
+                      route:
+                        description: A HTTP rule can either redirect or forward (default)
+                          traffic.
+                        items:
+                          properties:
+                            destination:
+                              properties:
+                                host:
+                                  description: The name of a service from the service
+                                    registry.
+                                  format: string
+                                  type: string
+                                port:
+                                  description: Specifies the port on the host that is
+                                    being addressed.
+                                  properties:
+                                    number:
+                                      type: integer
+                                  type: object
+                                subset:
+                                  description: The name of a subset within the service.
+                                  format: string
+                                  type: string
+                              type: object
+                            headers:
+                              properties:
+                                request:
+                                  properties:
+                                    add:
+                                      additionalProperties:
+                                        format: string
+                                        type: string
+                                      type: object
+                                    remove:
+                                      items:
+                                        format: string
+                                        type: string
+                                      type: array
+                                    set:
+                                      additionalProperties:
+                                        format: string
+                                        type: string
+                                      type: object
+                                  type: object
+                                response:
+                                  properties:
+                                    add:
+                                      additionalProperties:
+                                        format: string
+                                        type: string
+                                      type: object
+                                    remove:
+                                      items:
+                                        format: string
+                                        type: string
+                                      type: array
+                                    set:
+                                      additionalProperties:
+                                        format: string
+                                        type: string
+                                      type: object
+                                  type: object
+                              type: object
+                            weight:
+                              format: int32
+                              type: integer
+                          type: object
+                        type: array
+                      timeout:
+                        description: Timeout for HTTP requests, default is disabled.
+                        type: string
+                    type: object
+                  type: array
+                tcp:
+                  description: An ordered list of route rules for opaque TCP traffic.
+                  items:
+                    properties:
+                      match:
+                        items:
+                          properties:
+                            destinationSubnets:
+                              description: IPv4 or IPv6 ip addresses of destination with
+                                optional subnet.
+                              items:
+                                format: string
+                                type: string
+                              type: array
+                            gateways:
+                              description: Names of gateways where the rule should be
+                                applied.
+                              items:
+                                format: string
+                                type: string
+                              type: array
+                            port:
+                              description: Specifies the port on the host that is being
+                                addressed.
+                              type: integer
+                            sourceLabels:
+                              additionalProperties:
+                                format: string
+                                type: string
+                              type: object
+                            sourceNamespace:
+                              description: Source namespace constraining the applicability
+                                of a rule to workloads in that namespace.
+                              format: string
+                              type: string
+                            sourceSubnet:
+                              description: IPv4 or IPv6 ip address of source with optional
+                                subnet.
+                              format: string
+                              type: string
+                          type: object
+                        type: array
+                      route:
+                        description: The destination to which the connection should be
+                          forwarded to.
+                        items:
+                          properties:
+                            destination:
+                              properties:
+                                host:
+                                  description: The name of a service from the service
+                                    registry.
+                                  format: string
+                                  type: string
+                                port:
+                                  description: Specifies the port on the host that is
+                                    being addressed.
+                                  properties:
+                                    number:
+                                      type: integer
+                                  type: object
+                                subset:
+                                  description: The name of a subset within the service.
+                                  format: string
+                                  type: string
+                              type: object
+                            weight:
+                              format: int32
+                              type: integer
+                          type: object
+                        type: array
+                    type: object
+                  type: array
+                tls:
+                  items:
+                    properties:
+                      match:
+                        items:
+                          properties:
+                            destinationSubnets:
+                              description: IPv4 or IPv6 ip addresses of destination with
+                                optional subnet.
+                              items:
+                                format: string
+                                type: string
+                              type: array
+                            gateways:
+                              description: Names of gateways where the rule should be
+                                applied.
+                              items:
+                                format: string
+                                type: string
+                              type: array
+                            port:
+                              description: Specifies the port on the host that is being
+                                addressed.
+                              type: integer
+                            sniHosts:
+                              description: SNI (server name indicator) to match on.
+                              items:
+                                format: string
+                                type: string
+                              type: array
+                            sourceLabels:
+                              additionalProperties:
+                                format: string
+                                type: string
+                              type: object
+                            sourceNamespace:
+                              description: Source namespace constraining the applicability
+                                of a rule to workloads in that namespace.
+                              format: string
+                              type: string
+                          type: object
+                        type: array
+                      route:
+                        description: The destination to which the connection should be
+                          forwarded to.
+                        items:
+                          properties:
+                            destination:
+                              properties:
+                                host:
+                                  description: The name of a service from the service
+                                    registry.
+                                  format: string
+                                  type: string
+                                port:
+                                  description: Specifies the port on the host that is
+                                    being addressed.
+                                  properties:
+                                    number:
+                                      type: integer
+                                  type: object
+                                subset:
+                                  description: The name of a subset within the service.
+                                  format: string
+                                  type: string
+                              type: object
+                            weight:
+                              format: int32
+                              type: integer
+                          type: object
+                        type: array
+                    type: object
+                  type: array
+              type: object
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
       served: true
       storage: true
+      additionalPrinterColumns:
+        - jsonPath: .spec.gateways
+          description: The names of gateways and sidecars that should apply these routes
+          name: Gateways
+          type: string
+        - jsonPath: .spec.hosts
+          description: The destination hosts to which traffic is being sent
+          name: Hosts
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          description: 'CreationTimestamp is a timestamp representing the server time when
+            this object was created. It is not guaranteed to be set in happens-before order
+            across separate operations. Clients may not set this value. It is represented
+            in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for
+            lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+          name: Age
+          type: date
+      subresources:
+        status: { }
     - name: v1beta1
+      schema:
+        openAPIV3Schema:
+          properties:
+            spec:
+              description: 'Configuration affecting label/content routing, sni routing,
+                    etc. See more details at: https://istio.io/docs/reference/config/networking/virtual-service.html'
+              properties:
+                exportTo:
+                  description: A list of namespaces to which this virtual service is exported.
+                  items:
+                    format: string
+                    type: string
+                  type: array
+                gateways:
+                  description: The names of gateways and sidecars that should apply these
+                    routes.
+                  items:
+                    format: string
+                    type: string
+                  type: array
+                hosts:
+                  description: The destination hosts to which traffic is being sent.
+                  items:
+                    format: string
+                    type: string
+                  type: array
+                http:
+                  description: An ordered list of route rules for HTTP traffic.
+                  items:
+                    properties:
+                      corsPolicy:
+                        description: Cross-Origin Resource Sharing policy (CORS).
+                        properties:
+                          allowCredentials:
+                            nullable: true
+                            type: boolean
+                          allowHeaders:
+                            items:
+                              format: string
+                              type: string
+                            type: array
+                          allowMethods:
+                            description: List of HTTP methods allowed to access the resource.
+                            items:
+                              format: string
+                              type: string
+                            type: array
+                          allowOrigin:
+                            description: The list of origins that are allowed to perform
+                              CORS requests.
+                            items:
+                              format: string
+                              type: string
+                            type: array
+                          allowOrigins:
+                            description: String patterns that match allowed origins.
+                            items:
+                              oneOf:
+                                - not:
+                                    anyOf:
+                                      - required:
+                                          - exact
+                                      - required:
+                                          - prefix
+                                      - required:
+                                          - regex
+                                - required:
+                                    - exact
+                                - required:
+                                    - prefix
+                                - required:
+                                    - regex
+                              properties:
+                                exact:
+                                  format: string
+                                  type: string
+                                prefix:
+                                  format: string
+                                  type: string
+                                regex:
+                                  description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                  format: string
+                                  type: string
+                              type: object
+                            type: array
+                          exposeHeaders:
+                            items:
+                              format: string
+                              type: string
+                            type: array
+                          maxAge:
+                            type: string
+                        type: object
+                      delegate:
+                        properties:
+                          name:
+                            description: Name specifies the name of the delegate VirtualService.
+                            format: string
+                            type: string
+                          namespace:
+                            description: Namespace specifies the namespace where the delegate
+                              VirtualService resides.
+                            format: string
+                            type: string
+                        type: object
+                      fault:
+                        description: Fault injection policy to apply on HTTP traffic at
+                          the client side.
+                        properties:
+                          abort:
+                            oneOf:
+                              - not:
+                                  anyOf:
+                                    - required:
+                                        - httpStatus
+                                    - required:
+                                        - grpcStatus
+                                    - required:
+                                        - http2Error
+                              - required:
+                                  - httpStatus
+                              - required:
+                                  - grpcStatus
+                              - required:
+                                  - http2Error
+                            properties:
+                              grpcStatus:
+                                format: string
+                                type: string
+                              http2Error:
+                                format: string
+                                type: string
+                              httpStatus:
+                                description: HTTP status code to use to abort the Http
+                                  request.
+                                format: int32
+                                type: integer
+                              percentage:
+                                description: Percentage of requests to be aborted with
+                                  the error code provided.
+                                properties:
+                                  value:
+                                    format: double
+                                    type: number
+                                type: object
+                            type: object
+                          delay:
+                            oneOf:
+                              - not:
+                                  anyOf:
+                                    - required:
+                                        - fixedDelay
+                                    - required:
+                                        - exponentialDelay
+                              - required:
+                                  - fixedDelay
+                              - required:
+                                  - exponentialDelay
+                            properties:
+                              exponentialDelay:
+                                type: string
+                              fixedDelay:
+                                description: Add a fixed delay before forwarding the request.
+                                type: string
+                              percent:
+                                description: Percentage of requests on which the delay
+                                  will be injected (0-100).
+                                format: int32
+                                type: integer
+                              percentage:
+                                description: Percentage of requests on which the delay
+                                  will be injected.
+                                properties:
+                                  value:
+                                    format: double
+                                    type: number
+                                type: object
+                            type: object
+                        type: object
+                      headers:
+                        properties:
+                          request:
+                            properties:
+                              add:
+                                additionalProperties:
+                                  format: string
+                                  type: string
+                                type: object
+                              remove:
+                                items:
+                                  format: string
+                                  type: string
+                                type: array
+                              set:
+                                additionalProperties:
+                                  format: string
+                                  type: string
+                                type: object
+                            type: object
+                          response:
+                            properties:
+                              add:
+                                additionalProperties:
+                                  format: string
+                                  type: string
+                                type: object
+                              remove:
+                                items:
+                                  format: string
+                                  type: string
+                                type: array
+                              set:
+                                additionalProperties:
+                                  format: string
+                                  type: string
+                                type: object
+                            type: object
+                        type: object
+                      match:
+                        items:
+                          properties:
+                            authority:
+                              oneOf:
+                                - not:
+                                    anyOf:
+                                      - required:
+                                          - exact
+                                      - required:
+                                          - prefix
+                                      - required:
+                                          - regex
+                                - required:
+                                    - exact
+                                - required:
+                                    - prefix
+                                - required:
+                                    - regex
+                              properties:
+                                exact:
+                                  format: string
+                                  type: string
+                                prefix:
+                                  format: string
+                                  type: string
+                                regex:
+                                  description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                  format: string
+                                  type: string
+                              type: object
+                            gateways:
+                              description: Names of gateways where the rule should be
+                                applied.
+                              items:
+                                format: string
+                                type: string
+                              type: array
+                            headers:
+                              additionalProperties:
+                                oneOf:
+                                  - not:
+                                      anyOf:
+                                        - required:
+                                            - exact
+                                        - required:
+                                            - prefix
+                                        - required:
+                                            - regex
+                                  - required:
+                                      - exact
+                                  - required:
+                                      - prefix
+                                  - required:
+                                      - regex
+                                properties:
+                                  exact:
+                                    format: string
+                                    type: string
+                                  prefix:
+                                    format: string
+                                    type: string
+                                  regex:
+                                    description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                    format: string
+                                    type: string
+                                type: object
+                              type: object
+                            ignoreUriCase:
+                              description: Flag to specify whether the URI matching should
+                                be case-insensitive.
+                              type: boolean
+                            method:
+                              oneOf:
+                                - not:
+                                    anyOf:
+                                      - required:
+                                          - exact
+                                      - required:
+                                          - prefix
+                                      - required:
+                                          - regex
+                                - required:
+                                    - exact
+                                - required:
+                                    - prefix
+                                - required:
+                                    - regex
+                              properties:
+                                exact:
+                                  format: string
+                                  type: string
+                                prefix:
+                                  format: string
+                                  type: string
+                                regex:
+                                  description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                  format: string
+                                  type: string
+                              type: object
+                            name:
+                              description: The name assigned to a match.
+                              format: string
+                              type: string
+                            port:
+                              description: Specifies the ports on the host that is being
+                                addressed.
+                              type: integer
+                            queryParams:
+                              additionalProperties:
+                                oneOf:
+                                  - not:
+                                      anyOf:
+                                        - required:
+                                            - exact
+                                        - required:
+                                            - prefix
+                                        - required:
+                                            - regex
+                                  - required:
+                                      - exact
+                                  - required:
+                                      - prefix
+                                  - required:
+                                      - regex
+                                properties:
+                                  exact:
+                                    format: string
+                                    type: string
+                                  prefix:
+                                    format: string
+                                    type: string
+                                  regex:
+                                    description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                    format: string
+                                    type: string
+                                type: object
+                              description: Query parameters for matching.
+                              type: object
+                            scheme:
+                              oneOf:
+                                - not:
+                                    anyOf:
+                                      - required:
+                                          - exact
+                                      - required:
+                                          - prefix
+                                      - required:
+                                          - regex
+                                - required:
+                                    - exact
+                                - required:
+                                    - prefix
+                                - required:
+                                    - regex
+                              properties:
+                                exact:
+                                  format: string
+                                  type: string
+                                prefix:
+                                  format: string
+                                  type: string
+                                regex:
+                                  description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                  format: string
+                                  type: string
+                              type: object
+                            sourceLabels:
+                              additionalProperties:
+                                format: string
+                                type: string
+                              type: object
+                            sourceNamespace:
+                              description: Source namespace constraining the applicability
+                                of a rule to workloads in that namespace.
+                              format: string
+                              type: string
+                            uri:
+                              oneOf:
+                                - not:
+                                    anyOf:
+                                      - required:
+                                          - exact
+                                      - required:
+                                          - prefix
+                                      - required:
+                                          - regex
+                                - required:
+                                    - exact
+                                - required:
+                                    - prefix
+                                - required:
+                                    - regex
+                              properties:
+                                exact:
+                                  format: string
+                                  type: string
+                                prefix:
+                                  format: string
+                                  type: string
+                                regex:
+                                  description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                  format: string
+                                  type: string
+                              type: object
+                            withoutHeaders:
+                              additionalProperties:
+                                oneOf:
+                                  - not:
+                                      anyOf:
+                                        - required:
+                                            - exact
+                                        - required:
+                                            - prefix
+                                        - required:
+                                            - regex
+                                  - required:
+                                      - exact
+                                  - required:
+                                      - prefix
+                                  - required:
+                                      - regex
+                                properties:
+                                  exact:
+                                    format: string
+                                    type: string
+                                  prefix:
+                                    format: string
+                                    type: string
+                                  regex:
+                                    description: RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).
+                                    format: string
+                                    type: string
+                                type: object
+                              description: withoutHeader has the same syntax with the
+                                header, but has opposite meaning.
+                              type: object
+                          type: object
+                        type: array
+                      mirror:
+                        properties:
+                          host:
+                            description: The name of a service from the service registry.
+                            format: string
+                            type: string
+                          port:
+                            description: Specifies the port on the host that is being
+                              addressed.
+                            properties:
+                              number:
+                                type: integer
+                            type: object
+                          subset:
+                            description: The name of a subset within the service.
+                            format: string
+                            type: string
+                        type: object
+                      mirror_percent:
+                        description: Percentage of the traffic to be mirrored by the `mirror`
+                          field.
+                        nullable: true
+                        type: integer
+                      mirrorPercent:
+                        description: Percentage of the traffic to be mirrored by the `mirror`
+                          field.
+                        nullable: true
+                        type: integer
+                      mirrorPercentage:
+                        description: Percentage of the traffic to be mirrored by the `mirror`
+                          field.
+                        properties:
+                          value:
+                            format: double
+                            type: number
+                        type: object
+                      name:
+                        description: The name assigned to the route for debugging purposes.
+                        format: string
+                        type: string
+                      redirect:
+                        description: A HTTP rule can either redirect or forward (default)
+                          traffic.
+                        properties:
+                          authority:
+                            format: string
+                            type: string
+                          redirectCode:
+                            type: integer
+                          uri:
+                            format: string
+                            type: string
+                        type: object
+                      retries:
+                        description: Retry policy for HTTP requests.
+                        properties:
+                          attempts:
+                            description: Number of retries to be allowed for a given request.
+                            format: int32
+                            type: integer
+                          perTryTimeout:
+                            description: Timeout per retry attempt for a given request.
+                            type: string
+                          retryOn:
+                            description: Specifies the conditions under which retry takes
+                              place.
+                            format: string
+                            type: string
+                          retryRemoteLocalities:
+                            description: Flag to specify whether the retries should retry
+                              to other localities.
+                            nullable: true
+                            type: boolean
+                        type: object
+                      rewrite:
+                        description: Rewrite HTTP URIs and Authority headers.
+                        properties:
+                          authority:
+                            description: rewrite the Authority/Host header with this value.
+                            format: string
+                            type: string
+                          uri:
+                            format: string
+                            type: string
+                        type: object
+                      route:
+                        description: A HTTP rule can either redirect or forward (default)
+                          traffic.
+                        items:
+                          properties:
+                            destination:
+                              properties:
+                                host:
+                                  description: The name of a service from the service
+                                    registry.
+                                  format: string
+                                  type: string
+                                port:
+                                  description: Specifies the port on the host that is
+                                    being addressed.
+                                  properties:
+                                    number:
+                                      type: integer
+                                  type: object
+                                subset:
+                                  description: The name of a subset within the service.
+                                  format: string
+                                  type: string
+                              type: object
+                            headers:
+                              properties:
+                                request:
+                                  properties:
+                                    add:
+                                      additionalProperties:
+                                        format: string
+                                        type: string
+                                      type: object
+                                    remove:
+                                      items:
+                                        format: string
+                                        type: string
+                                      type: array
+                                    set:
+                                      additionalProperties:
+                                        format: string
+                                        type: string
+                                      type: object
+                                  type: object
+                                response:
+                                  properties:
+                                    add:
+                                      additionalProperties:
+                                        format: string
+                                        type: string
+                                      type: object
+                                    remove:
+                                      items:
+                                        format: string
+                                        type: string
+                                      type: array
+                                    set:
+                                      additionalProperties:
+                                        format: string
+                                        type: string
+                                      type: object
+                                  type: object
+                              type: object
+                            weight:
+                              format: int32
+                              type: integer
+                          type: object
+                        type: array
+                      timeout:
+                        description: Timeout for HTTP requests, default is disabled.
+                        type: string
+                    type: object
+                  type: array
+                tcp:
+                  description: An ordered list of route rules for opaque TCP traffic.
+                  items:
+                    properties:
+                      match:
+                        items:
+                          properties:
+                            destinationSubnets:
+                              description: IPv4 or IPv6 ip addresses of destination with
+                                optional subnet.
+                              items:
+                                format: string
+                                type: string
+                              type: array
+                            gateways:
+                              description: Names of gateways where the rule should be
+                                applied.
+                              items:
+                                format: string
+                                type: string
+                              type: array
+                            port:
+                              description: Specifies the port on the host that is being
+                                addressed.
+                              type: integer
+                            sourceLabels:
+                              additionalProperties:
+                                format: string
+                                type: string
+                              type: object
+                            sourceNamespace:
+                              description: Source namespace constraining the applicability
+                                of a rule to workloads in that namespace.
+                              format: string
+                              type: string
+                            sourceSubnet:
+                              description: IPv4 or IPv6 ip address of source with optional
+                                subnet.
+                              format: string
+                              type: string
+                          type: object
+                        type: array
+                      route:
+                        description: The destination to which the connection should be
+                          forwarded to.
+                        items:
+                          properties:
+                            destination:
+                              properties:
+                                host:
+                                  description: The name of a service from the service
+                                    registry.
+                                  format: string
+                                  type: string
+                                port:
+                                  description: Specifies the port on the host that is
+                                    being addressed.
+                                  properties:
+                                    number:
+                                      type: integer
+                                  type: object
+                                subset:
+                                  description: The name of a subset within the service.
+                                  format: string
+                                  type: string
+                              type: object
+                            weight:
+                              format: int32
+                              type: integer
+                          type: object
+                        type: array
+                    type: object
+                  type: array
+                tls:
+                  items:
+                    properties:
+                      match:
+                        items:
+                          properties:
+                            destinationSubnets:
+                              description: IPv4 or IPv6 ip addresses of destination with
+                                optional subnet.
+                              items:
+                                format: string
+                                type: string
+                              type: array
+                            gateways:
+                              description: Names of gateways where the rule should be
+                                applied.
+                              items:
+                                format: string
+                                type: string
+                              type: array
+                            port:
+                              description: Specifies the port on the host that is being
+                                addressed.
+                              type: integer
+                            sniHosts:
+                              description: SNI (server name indicator) to match on.
+                              items:
+                                format: string
+                                type: string
+                              type: array
+                            sourceLabels:
+                              additionalProperties:
+                                format: string
+                                type: string
+                              type: object
+                            sourceNamespace:
+                              description: Source namespace constraining the applicability
+                                of a rule to workloads in that namespace.
+                              format: string
+                              type: string
+                          type: object
+                        type: array
+                      route:
+                        description: The destination to which the connection should be
+                          forwarded to.
+                        items:
+                          properties:
+                            destination:
+                              properties:
+                                host:
+                                  description: The name of a service from the service
+                                    registry.
+                                  format: string
+                                  type: string
+                                port:
+                                  description: Specifies the port on the host that is
+                                    being addressed.
+                                  properties:
+                                    number:
+                                      type: integer
+                                  type: object
+                                subset:
+                                  description: The name of a subset within the service.
+                                  format: string
+                                  type: string
+                              type: object
+                            weight:
+                              format: int32
+                              type: integer
+                          type: object
+                        type: array
+                    type: object
+                  type: array
+              type: object
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
       served: true
       storage: false
+      additionalPrinterColumns:
+        - jsonPath: .spec.gateways
+          description: The names of gateways and sidecars that should apply these routes
+          name: Gateways
+          type: string
+        - jsonPath: .spec.hosts
+          description: The destination hosts to which traffic is being sent
+          name: Hosts
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          description: 'CreationTimestamp is a timestamp representing the server time when
+                  this object was created. It is not guaranteed to be set in happens-before order
+                  across separate operations. Clients may not set this value. It is represented
+                  in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for
+                  lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+          name: Age
+          type: date
+      subresources:
+        status: { }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no|
| New feature?    | no|
| API breaks?     | no|
| Deprecations?   | no|
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
This PR moves away from deprecated k8s apis. All the necessary resources CRDs and RBAC related objects are now using version v1.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
