### PR TITLE
Propagate KafkaCluster envoy ingress annotations to envoy pods

### DIFF
--- a/controllers/tests/kafkacluster_controller_envoy_test.go
+++ b/controllers/tests/kafkacluster_controller_envoy_test.go
@@ -34,6 +34,10 @@ func expectEnvoyIngressLabels(labels map[string]string, eListenerName, crName st
 	Expect(labels).To(HaveKeyWithValue("kafka_cr", crName))
 }
 
+func expectEnvoyIngressAnnotations(annotations map[string]string) {
+	Expect(annotations).To(HaveKeyWithValue("envoy-annotation-key", "envoy-annotation-value"))
+}
+
 func expectEnvoyLoadBalancer(kafkaCluster *v1beta1.KafkaCluster, eListenerTemplate string) {
 	var loadBalancer corev1.Service
 	lbName := fmt.Sprintf("envoy-loadbalancer-%s-%s", eListenerTemplate, kafkaCluster.Name)
@@ -179,6 +183,8 @@ func expectEnvoyDeployment(kafkaCluster *v1beta1.KafkaCluster, eListenerTemplate
 	Expect(deployment.Spec.Replicas).NotTo(BeNil())
 	Expect(*deployment.Spec.Replicas).To(BeEquivalentTo(1))
 	expectEnvoyIngressLabels(deployment.Spec.Template.Labels, eListenerTemplate, kafkaCluster.Name)
+	expectEnvoyIngressAnnotations(deployment.Annotations)
+	expectEnvoyIngressAnnotations(deployment.Spec.Template.Annotations)
 	templateSpec := deployment.Spec.Template.Spec
 	Expect(templateSpec.ServiceAccountName).To(Equal("default"))
 	Expect(templateSpec.Containers).To(HaveLen(1))

--- a/controllers/tests/kafkacluster_controller_test.go
+++ b/controllers/tests/kafkacluster_controller_test.go
@@ -111,6 +111,9 @@ var _ = Describe("KafkaCluster", func() {
 		kafkaCluster.Spec.CruiseControlConfig.SecurityContext = &corev1.SecurityContext{
 			Privileged: util.BoolPointer(true),
 		}
+		kafkaCluster.Spec.EnvoyConfig.Annotations = map[string]string{
+			"envoy-annotation-key": "envoy-annotation-value",
+		}
 	})
 
 	JustBeforeEach(func() {

--- a/pkg/resources/envoy/deployment.go
+++ b/pkg/resources/envoy/deployment.go
@@ -146,5 +146,5 @@ func generatePodAnnotations(kafkaCluster *v1beta1.KafkaCluster,
 	annotations := map[string]string{
 		"envoy.yaml.hash": hex.EncodeToString(hashedEnvoyConfig[:]),
 	}
-	return annotations
+	return util.MergeAnnotations(ingressConfig.EnvoyConfig.GetAnnotations(), annotations)
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | N/A
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Propagate KafkaCluster `envoyConfig.annotations` to envoy pods.


### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

In our environment pods annotations are used to drive pod sizing so we need a way to annotate those
from KafkaCluster CR

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)