### PR TITLE
Update cluster image version to 2.7.0-bzc.2

### DIFF
--- a/config/samples/banzaicloud_v1beta1_kafkacluster.yaml
+++ b/config/samples/banzaicloud_v1beta1_kafkacluster.yaml
@@ -28,7 +28,7 @@ spec:
   oneBrokerPerNode: false
   # Specify the Kafka Broker related settings
   # clusterImage can specify the whole kafkacluster image in one place
-  #clusterImage: "ghcr.io/banzaicloud/kafka:2.13-2.7.0-bzc.1"
+  #clusterImage: "ghcr.io/banzaicloud/kafka:2.13-2.7.0-bzc.2"
   # readOnlyConfig specifies the read-only type kafka config cluster wide, all these will be merged with broker specified
   # readOnly configurations, so it can be overwritten per broker.
   #clusterWideConfig specifies the cluster-wide kafka config cluster wide, all these can be overridden per-broker
@@ -68,7 +68,7 @@ spec:
         cruise.control.metrics.topic.replication.factor=2
       brokerConfig:
         # Docker image used by the operator to create the Broker with id 0
-        #image: "ghcr.io/banzaicloud/kafka:2.13-2.7.0-bzc.1"
+        #image: "ghcr.io/banzaicloud/kafka:2.13-2.7.0-bzc.2"
         # resourceRequirements works exactly like Container resources, the user can specify the limit and the requests
         # through this property
         #resourceRequirements:
@@ -131,7 +131,7 @@ spec:
         #volumeMounts:
         #  - mountPath: "/opt/kafka/libs/extra-jars"
         #    name: "jars"
-    - image: "ghcr.io/banzaicloud/kafka:2.13-2.7.0-bzc.1"
+    - image: "ghcr.io/banzaicloud/kafka:2.13-2.7.0-bzc.2"
       id: 1
       config: |
         auto.create.topics.enable=false
@@ -153,7 +153,7 @@ spec:
       readOnlyConfig: |
         auto.create.topics.enable=false
       brokerConfig:
-        image: "ghcr.io/banzaicloud/kafka:2.13-2.7.0-bzc.1"
+        image: "ghcr.io/banzaicloud/kafka:2.13-2.7.0-bzc.2"
         storageConfigs:
           - mountPath: "/kafka-logs"
             pvcSpec:

--- a/config/samples/kafkacluster-prometheus.yaml
+++ b/config/samples/kafkacluster-prometheus.yaml
@@ -85,7 +85,7 @@ spec:
         storageClass: 'gp2'
         mountPath: '/kafkalog'
         diskSize: '10G'
-        image: 'ghcr.io/banzaicloud/kafka:2.13-2.7.0-bzc.1'
+        image: 'ghcr.io/banzaicloud/kafka:2.13-2.7.0-bzc.2'
         # annotations to be applied onto the broker pod
         # brokerAnnotations: '{ "sidecar.istio.io/logLevel": "trace", "sidecar.istio.io/proxyCPULimit": "50m" }'
         command: 'upScale'
@@ -101,7 +101,7 @@ spec:
         storageClass: 'gp2'
         mountPath: '/kafkalog'
         diskSize: '10G'
-        image: 'ghcr.io/banzaicloud/kafka:2.13-2.7.0-bzc.1'
+        image: 'ghcr.io/banzaicloud/kafka:2.13-2.7.0-bzc.2'
         # annotations to be applied onto the broker pod
         # brokerAnnotations: '{ "sidecar.istio.io/logLevel": "trace", "sidecar.istio.io/proxyCPULimit": "50m" }'
         command: 'upScale'
@@ -117,7 +117,7 @@ spec:
         storageClass: 'gp2'
         mountPath: '/kafkalog'
         diskSize: '10G'
-        image: 'ghcr.io/banzaicloud/kafka:2.13-2.7.0-bzc.1'
+        image: 'ghcr.io/banzaicloud/kafka:2.13-2.7.0-bzc.2'
         # annotations to be applied onto the broker pod
         # brokerAnnotations: '{ "sidecar.istio.io/logLevel": "trace", "sidecar.istio.io/proxyCPULimit": "50m" }'
         command: 'upScale'

--- a/config/samples/kafkacluster-with-istio.yaml
+++ b/config/samples/kafkacluster-with-istio.yaml
@@ -13,7 +13,7 @@ spec:
   zkAddresses:
     - "zookeeper-client.zookeeper:2181"
   oneBrokerPerNode: false
-  clusterImage: "ghcr.io/banzaicloud/kafka:2.13-2.7.0-bzc.1"
+  clusterImage: "ghcr.io/banzaicloud/kafka:2.13-2.7.0-bzc.2"
   readOnlyConfig: |
     auto.create.topics.enable=false
     cruise.control.metrics.topic.auto.create=true

--- a/config/samples/kafkacluster_with_external_ssl.yaml
+++ b/config/samples/kafkacluster_with_external_ssl.yaml
@@ -9,7 +9,7 @@ spec:
   zkAddresses:
     - "zookeeper-client.zookeeper:2181"
   oneBrokerPerNode: false
-  clusterImage: "ghcr.io/banzaicloud/kafka:2.13-2.7.0-bzc.1"
+  clusterImage: "ghcr.io/banzaicloud/kafka:2.13-2.7.0-bzc.2"
   readOnlyConfig: |
     auto.create.topics.enable=false
     cruise.control.metrics.topic.auto.create=true

--- a/config/samples/kafkacluster_with_internal_ssl_vault.yaml
+++ b/config/samples/kafkacluster_with_internal_ssl_vault.yaml
@@ -9,7 +9,7 @@ spec:
   zkAddresses:
     - "zookeeper-client.zookeeper:2181"
   oneBrokerPerNode: false
-  clusterImage: "banzaicloud/kafka:2.13-2.7.0-bzc.1"
+  clusterImage: "banzaicloud/kafka:2.13-2.7.0-bzc.2"
   readOnlyConfig: |
     auto.create.topics.enable=false
     cruise.control.metrics.topic.auto.create=true

--- a/config/samples/kafkacluster_with_ssl_groups.yaml
+++ b/config/samples/kafkacluster_with_ssl_groups.yaml
@@ -14,7 +14,7 @@ spec:
       - "failure-domain.beta.kubernetes.io/region"
       - "failure-domain.beta.kubernetes.io/zone"
   oneBrokerPerNode: false
-  clusterImage: "ghcr.io/banzaicloud/kafka:2.13-2.7.0-bzc.1"
+  clusterImage: "ghcr.io/banzaicloud/kafka:2.13-2.7.0-bzc.2"
   readOnlyConfig: |
     auto.create.topics.enable=false
     cruise.control.metrics.topic.auto.create=true

--- a/config/samples/kafkacluster_without_ssl.yaml
+++ b/config/samples/kafkacluster_without_ssl.yaml
@@ -9,7 +9,7 @@ spec:
   zkAddresses:
     - "zookeeper-client.zookeeper:2181"
   oneBrokerPerNode: false
-  clusterImage: "ghcr.io/banzaicloud/kafka:2.13-2.7.0-bzc.1"
+  clusterImage: "ghcr.io/banzaicloud/kafka:2.13-2.7.0-bzc.2"
   readOnlyConfig: |
     auto.create.topics.enable=false
     cruise.control.metrics.topic.auto.create=true

--- a/config/samples/kafkacluster_without_ssl_groups.yaml
+++ b/config/samples/kafkacluster_without_ssl_groups.yaml
@@ -9,7 +9,7 @@ spec:
   zkAddresses:
     - "zookeeper-client.zookeeper:2181"
   oneBrokerPerNode: false
-  clusterImage: "ghcr.io/banzaicloud/kafka:2.13-2.7.0-bzc.1"
+  clusterImage: "ghcr.io/banzaicloud/kafka:2.13-2.7.0-bzc.2"
   readOnlyConfig: |
     auto.create.topics.enable=false
     cruise.control.metrics.topic.auto.create=true

--- a/config/samples/simplekafkacluster-with-brokerbindings.yaml
+++ b/config/samples/simplekafkacluster-with-brokerbindings.yaml
@@ -10,7 +10,7 @@ spec:
     - "zookeeper-client.zookeeper:2181"
   propagateLabels: false
   oneBrokerPerNode: false
-  clusterImage: "ghcr.io/banzaicloud/kafka:2.13-2.7.0-bzc.1"
+  clusterImage: "ghcr.io/banzaicloud/kafka:2.13-2.7.0-bzc.2"
   readOnlyConfig: |
     auto.create.topics.enable=false
     cruise.control.metrics.topic.auto.create=true

--- a/config/samples/simplekafkacluster-with-nodeport-external.yaml
+++ b/config/samples/simplekafkacluster-with-nodeport-external.yaml
@@ -10,7 +10,7 @@ spec:
     - "zookeeper-client.zookeeper:2181"
   propagateLabels: false
   oneBrokerPerNode: false
-  clusterImage: "ghcr.io/banzaicloud/kafka:2.13-2.7.0-bzc.1"
+  clusterImage: "ghcr.io/banzaicloud/kafka:2.13-2.7.0-bzc.2"
   readOnlyConfig: |
     auto.create.topics.enable=false
     cruise.control.metrics.topic.auto.create=true

--- a/config/samples/simplekafkacluster.yaml
+++ b/config/samples/simplekafkacluster.yaml
@@ -10,7 +10,7 @@ spec:
     - "zookeeper-client.zookeeper:2181"
   propagateLabels: false
   oneBrokerPerNode: false
-  clusterImage: "ghcr.io/banzaicloud/kafka:2.13-2.7.0-bzc.1"
+  clusterImage: "ghcr.io/banzaicloud/kafka:2.13-2.7.0-bzc.2"
   readOnlyConfig: |
     auto.create.topics.enable=false
     cruise.control.metrics.topic.auto.create=true

--- a/config/samples/simplekafkacluster_affinity.yaml
+++ b/config/samples/simplekafkacluster_affinity.yaml
@@ -12,7 +12,7 @@ spec:
   # If true OneBrokerPerNode ensures that each kafka broker will be placed on a different node unless a custom
   # Affinity definition overrides this behavior either set in brokerConfigGroups or in one specific brokerConfig
   oneBrokerPerNode: false
-  clusterImage: "ghcr.io/banzaicloud/kafka:2.13-2.7.0-bzc.1"
+  clusterImage: "ghcr.io/banzaicloud/kafka:2.13-2.7.0-bzc.2"
   readOnlyConfig: |
     auto.create.topics.enable=false
     cruise.control.metrics.topic.auto.create=true

--- a/config/samples/simplekafkacluster_ebs_csi.yaml
+++ b/config/samples/simplekafkacluster_ebs_csi.yaml
@@ -15,7 +15,7 @@ spec:
   zkPath: "/kafka"
   propagateLabels: true
   oneBrokerPerNode: false
-  clusterImage: "ghcr.io/banzaicloud/kafka:2.13-2.7.0-bzc.1"
+  clusterImage: "ghcr.io/banzaicloud/kafka:2.13-2.7.0-bzc.2"
   readOnlyConfig: |
     auto.create.topics.enable=false
     cruise.control.metrics.topic.auto.create=true

--- a/config/samples/simplekafkacluster_with_k8s_provided_nodeport.yaml
+++ b/config/samples/simplekafkacluster_with_k8s_provided_nodeport.yaml
@@ -10,7 +10,7 @@ spec:
     - "zookeeper-client.zookeeper:2181"
   propagateLabels: false
   oneBrokerPerNode: false
-  clusterImage: "ghcr.io/banzaicloud/kafka:2.13-2.7.0-bzc.1"
+  clusterImage: "ghcr.io/banzaicloud/kafka:2.13-2.7.0-bzc.2"
   readOnlyConfig: |
     auto.create.topics.enable=false
     cruise.control.metrics.topic.auto.create=true

--- a/config/samples/simplekafkacluster_with_sasl.yaml
+++ b/config/samples/simplekafkacluster_with_sasl.yaml
@@ -10,7 +10,7 @@ spec:
     - "zookeeper-client.zookeeper:2181"
   propagateLabels: false
   oneBrokerPerNode: false
-  clusterImage: "ghcr.io/banzaicloud/kafka:2.13-2.7.0-bzc.1"
+  clusterImage: "ghcr.io/banzaicloud/kafka:2.13-2.7.0-bzc.2"
   readOnlyConfig: |
     auto.create.topics.enable=false
     cruise.control.metrics.topic.auto.create=true

--- a/controllers/tests/common_test.go
+++ b/controllers/tests/common_test.go
@@ -105,7 +105,7 @@ func createMinimalKafkaClusterCR(name, namespace string) *v1beta1.KafkaCluster {
 					BrokerConfigGroup: defaultBrokerConfigGroup,
 				},
 			},
-			ClusterImage: "ghcr.io/banzaicloud/kafka:2.13-2.7.0-bzc.1",
+			ClusterImage: "ghcr.io/banzaicloud/kafka:2.13-2.7.0-bzc.2",
 			ZKAddresses:  []string{},
 			MonitoringConfig: v1beta1.MonitoringConfig{
 				CCJMXExporterConfig: "custom_property: custom_value",

--- a/controllers/tests/kafkacluster_controller_kafka_test.go
+++ b/controllers/tests/kafkacluster_controller_kafka_test.go
@@ -250,7 +250,7 @@ func expectKafkaBrokerPod(kafkaCluster *v1beta1.KafkaCluster, broker v1beta1.Bro
 	Expect(pod.Spec.Containers).To(HaveLen(1))
 	container := pod.Spec.Containers[0]
 	Expect(container.Name).To(Equal("kafka"))
-	Expect(container.Image).To(Equal("ghcr.io/banzaicloud/kafka:2.13-2.7.0-bzc.1"))
+	Expect(container.Image).To(Equal("ghcr.io/banzaicloud/kafka:2.13-2.7.0-bzc.2"))
 	Expect(container.Lifecycle).NotTo(BeNil())
 	Expect(container.Lifecycle.PreStop).NotTo(BeNil())
 	getEnvName := func(c corev1.EnvVar) string { return c.Name }

--- a/docs/benchmarks/infrastructure/kafka.yaml
+++ b/docs/benchmarks/infrastructure/kafka.yaml
@@ -9,7 +9,7 @@ spec:
   zkAddresses:
     - "zookeeper-client.zookeeper:2181"
   oneBrokerPerNode: true
-  clusterImage: "ghcr.io/banzaicloud/kafka:2.13-2.7.0-bzc.1"
+  clusterImage: "ghcr.io/banzaicloud/kafka:2.13-2.7.0-bzc.2"
   readOnlyConfig: |
     auto.create.topics.enable=false
   rackAwareness:

--- a/docs/benchmarks/infrastructure/kafka_202001_3brokers.yaml
+++ b/docs/benchmarks/infrastructure/kafka_202001_3brokers.yaml
@@ -65,7 +65,7 @@ spec:
   zkAddresses:
     - "zookeeper-client.zookeeper:2181"
   oneBrokerPerNode: true
-  clusterImage: "ghcr.io/banzaicloud/kafka:2.13-2.7.0-bzc.1"
+  clusterImage: "ghcr.io/banzaicloud/kafka:2.13-2.7.0-bzc.2"
   readOnlyConfig: |
     auto.create.topics.enable=false
     min.insync.replicas=3

--- a/pkg/sdk/v1beta1/kafkacluster_types.go
+++ b/pkg/sdk/v1beta1/kafkacluster_types.go
@@ -537,7 +537,7 @@ func (kSpec *KafkaClusterSpec) GetClusterImage() string {
 	if kSpec.ClusterImage != "" {
 		return kSpec.ClusterImage
 	}
-	return "ghcr.io/banzaicloud/kafka:2.13-2.7.0-bzc.1"
+	return "ghcr.io/banzaicloud/kafka:2.13-2.7.0-bzc.2"
 }
 
 func (cTaskSpec *CruiseControlTaskSpec) GetDurationMinutes() float64 {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no|
| New feature?    | no|
| API breaks?     | no|
| Deprecations?   | no|
| License         | Apache 2.0


### What's in this PR?
This Pr updates the kafka cluster image to the latest available.
