### PR TITLE
Handle when nodeport is not allocated yet

### DIFF
--- a/pkg/resources/kafka/kafka.go
+++ b/pkg/resources/kafka/kafka.go
@@ -933,6 +933,10 @@ func (r *Reconciler) getK8sAssignedNodeport(log logr.Logger, eListenerName strin
 			break
 		}
 	}
+	if nodePort == 0 {
+		return nodePort, errorfactory.New(errorfactory.ResourceNotReady{},
+			errors.New("nodeport port number is not allocated"), "nodeport number is still 0")
+	}
 	return nodePort, nil
 }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes|
| New feature?    | no|
| API breaks?     | no|
| Deprecations?   | no|
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
This PR handles the case when nodeport is not allocated by the Kubernetes reconciler. We are going to wait one more cycle if that happens.

- [X] Implementation tested
- [X] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [X] Logging code meets the guideline
- [X] User guide and development docs updated (if needed)
