### PR TITLE
Fix admissionReviewVersion from v1alpha1 to v1beta1

### DIFF
--- a/charts/kafka-operator/templates/operator-deployment-with-webhook.yaml
+++ b/charts/kafka-operator/templates/operator-deployment-with-webhook.yaml
@@ -31,7 +31,7 @@ metadata:
   name: {{ include "kafka-operator.name" . }}-validating-webhook
 webhooks:
 - admissionReviewVersions:
-  - v1alpha1
+  - v1beta1
   clientConfig:
     caBundle: {{ $caCrt }}
     service:

--- a/config/base/webhook/manifests.yaml
+++ b/config/base/webhook/manifests.yaml
@@ -7,7 +7,7 @@ metadata:
   name: validating-webhook-configuration
 webhooks:
 - admissionReviewVersions:
-  - v1
+  - v1beta1
   clientConfig:
     service:
       name: webhook-service

--- a/pkg/sdk/v1alpha1/kafkatopic_types.go
+++ b/pkg/sdk/v1alpha1/kafkatopic_types.go
@@ -37,7 +37,7 @@ type KafkaTopicStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // +k8s:openapi-gen=true
-// +kubebuilder:webhook:failurePolicy="fail",sideEffects="None",name="kafkatopics.kafka.banzaicloud.io",path="/validate",mutating=false,resources={"kafkatopics"},verbs={"create","update"},groups={"kafka.banzaicloud.io"},versions={"v1alpha1"},admissionReviewVersions={"v1"}
+// +kubebuilder:webhook:failurePolicy="fail",sideEffects="None",name="kafkatopics.kafka.banzaicloud.io",path="/validate",mutating=false,resources={"kafkatopics"},verbs={"create","update"},groups={"kafka.banzaicloud.io"},versions={"v1alpha1"},admissionReviewVersions={"v1beta1"}
 
 // KafkaTopic is the Schema for the kafkatopics API
 // +kubebuilder:object:root=true


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |yes|
| New feature?    | no|
| API breaks?     | no|
| Deprecations?   | no|
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
This PR fixes the admissionReviewVersion. It changes v1alpha1 and v1 to v1beta1. V1beta1 is used in the webhook implementation.