### PR TITLE
Add kafka broker version to status field and update jmx exporter version

### DIFF
--- a/controllers/tests/kafkacluster_controller_cruisecontrol_test.go
+++ b/controllers/tests/kafkacluster_controller_cruisecontrol_test.go
@@ -256,8 +256,8 @@ func expectCruiseControlDeployment(kafkaCluster *v1beta1.KafkaCluster) {
 	Expect(deployment.Spec.Template.Spec.InitContainers).To(HaveLen(1))
 	initContainer := deployment.Spec.Template.Spec.InitContainers[0]
 	Expect(initContainer.Name).To(Equal("jmx-exporter"))
-	Expect(initContainer.Image).To(Equal("ghcr.io/banzaicloud/jmx-javaagent:0.14.0"))
-	Expect(initContainer.Command).To(Equal([]string{"cp", "/opt/jmx_exporter/jmx_prometheus_javaagent-0.14.0.jar", "/opt/jmx-exporter/jmx_prometheus.jar"}))
+	Expect(initContainer.Image).To(Equal("ghcr.io/banzaicloud/jmx-javaagent:0.15.0"))
+	Expect(initContainer.Command).To(Equal([]string{"cp", "/jmx_prometheus_javaagent.jar", "/opt/jmx-exporter/jmx_prometheus.jar"}))
 	Expect(initContainer.VolumeMounts).To(ConsistOf(corev1.VolumeMount{
 		Name:      "jmx-jar-data",
 		MountPath: "/opt/jmx-exporter/",

--- a/controllers/tests/kafkacluster_controller_kafka_test.go
+++ b/controllers/tests/kafkacluster_controller_kafka_test.go
@@ -434,4 +434,8 @@ func expectKafkaCRStatus(kafkaCluster *v1beta1.KafkaCluster) {
 			},
 		},
 	}))
+	for _, brokerState := range kafkaCluster.Status.BrokersState {
+		Expect(brokerState.Version).To(Equal("2.7.0"))
+		Expect(brokerState.Image).To(Equal(kafkaCluster.Spec.GetClusterImage()))
+	}
 }

--- a/controllers/tests/suite_test.go
+++ b/controllers/tests/suite_test.go
@@ -62,6 +62,7 @@ import (
 	banzaicloudv1alpha1 "github.com/banzaicloud/kafka-operator/api/v1alpha1"
 	banzaicloudv1beta1 "github.com/banzaicloud/kafka-operator/api/v1beta1"
 	"github.com/banzaicloud/kafka-operator/controllers"
+	"github.com/banzaicloud/kafka-operator/pkg/jmxextractor"
 	"github.com/banzaicloud/kafka-operator/pkg/kafkaclient"
 	"github.com/banzaicloud/kafka-operator/pkg/scale"
 	// +kubebuilder:scaffold:imports
@@ -134,6 +135,7 @@ var _ = BeforeSuite(func(done Done) {
 	Expect(mgr).ToNot(BeNil())
 
 	scale.MockNewCruiseControlScaler()
+	jmxextractor.NewMockJMXExtractor()
 
 	mockKafkaClients = make(map[types.NamespacedName]kafkaclient.KafkaClient)
 

--- a/pkg/jmxextractor/extractor.go
+++ b/pkg/jmxextractor/extractor.go
@@ -1,0 +1,112 @@
+// Copyright © 2021 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jmxextractor
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"regexp"
+
+	"github.com/banzaicloud/kafka-operator/api/v1beta1"
+	"github.com/banzaicloud/kafka-operator/pkg/errorfactory"
+	"github.com/banzaicloud/kafka-operator/pkg/util"
+	"github.com/banzaicloud/kafka-operator/pkg/util/kafka"
+
+	"github.com/go-logr/logr"
+)
+
+const (
+	headlessServiceJMXTemplate = "http://%s-%d." + kafka.HeadlessServiceTemplate + ".%s.svc.%s:%d"
+	serviceJMXTemplate         = "http://%s-%d.%s.svc.%s:%d"
+	versionRegexGroup          = "version"
+)
+
+var newJMXExtractor = createNewJMXExtractor
+var jmxMetricRegex = regexp.MustCompile(
+	fmt.Sprintf(`kafka_server_app_info_version{broker_id=\"[0-9]+\",version=\"(?P<%s>[0-9]+.[0-9]+.[0-9]+)\"`, versionRegexGroup))
+
+type JMXExtractor interface {
+	ExtractDockerImageAndVersion(brokerId int32, brokerConfig *v1beta1.BrokerConfig,
+		clusterImage string, headlessServiceEnabled bool) (*v1beta1.KafkaVersion, error)
+}
+
+type jmxExtractor struct {
+	JMXExtractor
+	clusterNamespace        string
+	kubernetesClusterDomain string
+	clusterName             string
+	log                     logr.Logger
+}
+
+func createNewJMXExtractor(namespace, kubernetesClusterDomain, clusterName string, log logr.Logger) JMXExtractor {
+	return &jmxExtractor{
+		clusterNamespace:        namespace,
+		kubernetesClusterDomain: kubernetesClusterDomain,
+		clusterName:             clusterName,
+		log:                     log,
+	}
+}
+func createMockJMXExtractor(namespace, kubernetesClusterDomain, clusterName string, log logr.Logger) JMXExtractor {
+	return &mockJmxExtractor{}
+}
+
+func NewJMXExtractor(namespace, kubernetesClusterDomain, clusterName string, log logr.Logger) JMXExtractor {
+	return newJMXExtractor(namespace, kubernetesClusterDomain, clusterName, log)
+}
+
+func NewMockJMXExtractor() {
+	newJMXExtractor = createMockJMXExtractor
+}
+
+func (exp *jmxExtractor) ExtractDockerImageAndVersion(brokerId int32, brokerConfig *v1beta1.BrokerConfig,
+	clusterImage string, headlessServiceEnabled bool) (*v1beta1.KafkaVersion, error) {
+	var requestURL string
+	if headlessServiceEnabled {
+		requestURL =
+			fmt.Sprintf(headlessServiceJMXTemplate,
+				exp.clusterName, brokerId, exp.clusterName, exp.clusterNamespace,
+				exp.kubernetesClusterDomain, 9020)
+	} else {
+		requestURL = fmt.Sprintf(serviceJMXTemplate, exp.clusterName, brokerId,
+			exp.clusterNamespace, exp.kubernetesClusterDomain, 9020)
+	}
+	rsp, err := http.Get(requestURL)
+	if err != nil {
+		exp.log.Error(err, fmt.Sprintf("error during talking to broker-%d", brokerId))
+		return nil, errorfactory.New(errorfactory.BrokersNotReady{}, err, "unable to talk to ...")
+	}
+	defer func() {
+		closeErr := rsp.Body.Close()
+		if closeErr != nil {
+			exp.log.Error(closeErr, "could not close client")
+		}
+	}()
+
+	body, err := ioutil.ReadAll(rsp.Body)
+	if err != nil {
+		return nil, err
+	}
+	index := jmxMetricRegex.SubexpIndex(versionRegexGroup)
+	var version string
+	if index > -1 {
+		if metrics := jmxMetricRegex.FindStringSubmatch(string(body)); len(metrics) > index {
+			version = metrics[index]
+		}
+	}
+
+	brokerImage := util.GetBrokerImage(brokerConfig, clusterImage)
+	return &v1beta1.KafkaVersion{Version: version, Image: brokerImage}, nil
+}

--- a/pkg/jmxextractor/mock_extractor.go
+++ b/pkg/jmxextractor/mock_extractor.go
@@ -1,0 +1,24 @@
+// Copyright © 2021 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jmxextractor
+
+import "github.com/banzaicloud/kafka-operator/api/v1beta1"
+
+type mockJmxExtractor struct{}
+
+func (exp *mockJmxExtractor) ExtractDockerImageAndVersion(brokerId int32, brokerConfig *v1beta1.BrokerConfig,
+	clusterImage string, headlessServiceEnabled bool) (*v1beta1.KafkaVersion, error) {
+	return &v1beta1.KafkaVersion{Image: clusterImage, Version: "2.7.0"}, nil
+}

--- a/pkg/scale/mock_scaler.go
+++ b/pkg/scale/mock_scaler.go
@@ -18,13 +18,7 @@ import (
 	"github.com/banzaicloud/kafka-operator/api/v1beta1"
 )
 
-type mockCruiseControlScaler struct {
-	CruiseControlScaler
-	//namespace               string
-	//kubernetesClusterDomain string
-	//endpoint                string
-	//clusterName             string
-}
+type mockCruiseControlScaler struct{}
 
 func (mc *mockCruiseControlScaler) GetLiveKafkaBrokersFromCruiseControl(brokerIds []string) ([]string, error) {
 	return nil, nil

--- a/pkg/sdk/v1beta1/kafkacluster_types.go
+++ b/pkg/sdk/v1beta1/kafkacluster_types.go
@@ -819,7 +819,7 @@ func (mConfig *MonitoringConfig) GetPathToJar() string {
 	if mConfig.PathToJar != "" {
 		return mConfig.PathToJar
 	}
-	return "/opt/jmx_exporter/jmx_prometheus_javaagent-0.15.0.jar"
+	return "/jmx_prometheus_javaagent.jar"
 }
 
 // GetKafkaJMXExporterConfig returns the config for Kafka Prometheus JMX exporter

--- a/pkg/sdk/v1beta1/kafkacluster_types.go
+++ b/pkg/sdk/v1beta1/kafkacluster_types.go
@@ -811,7 +811,7 @@ func (mConfig *MonitoringConfig) GetImage() string {
 	if mConfig.JmxImage != "" {
 		return mConfig.JmxImage
 	}
-	return "ghcr.io/banzaicloud/jmx-javaagent:0.14.0"
+	return "ghcr.io/banzaicloud/jmx-javaagent:0.15.0"
 }
 
 // GetPathToJar returns the path in the used Image for Prometheus JMX exporter
@@ -819,7 +819,7 @@ func (mConfig *MonitoringConfig) GetPathToJar() string {
 	if mConfig.PathToJar != "" {
 		return mConfig.PathToJar
 	}
-	return "/opt/jmx_exporter/jmx_prometheus_javaagent-0.14.0.jar"
+	return "/opt/jmx_exporter/jmx_prometheus_javaagent-0.15.0.jar"
 }
 
 // GetKafkaJMXExporterConfig returns the config for Kafka Prometheus JMX exporter
@@ -831,11 +831,13 @@ func (mConfig *MonitoringConfig) GetKafkaJMXExporterConfig() string {
 	return `lowercaseOutputName: true
 rules:
 # Special cases and very specific rules
-- pattern : 'kafka.server<type=app-info><>version: (.*)'
-  name: kafka_server_app_info
-  value: 1.0
+- pattern: 'kafka.server<type=(app-info), id=(\d+)><>(Version): ([-.~+\w\d]+)'
+  name: kafka_server_$1_$3
+  type: COUNTER
   labels:
-    version: "$1"
+    broker_id: $2
+    version: $4
+  value: 1.0
 - pattern : kafka.server<type=(.+), name=(.+), clientId=(.+), topic=(.+), partition=(.*)><>Value
   name: kafka_server_$1_$2
   type: GAUGE


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no|
| New feature?    |yes|
| API breaks?     | no|
| Deprecations?   | no|
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
This PR adds broker version to the kafka cluster cr.
It also updates the jmx exporter to version 0.15.0 instead of 0.14.0.
And slightly modifies the jmx exporter config to be able to parse the version properly.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested
- [X] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [X] Logging code meets the guideline
- [X] User guide and development docs updated (if needed)
