### PR TITLE
Fix validation webhook Connection/Memory leak

### DIFF
--- a/controllers/controller_common.go
+++ b/controllers/controller_common.go
@@ -68,25 +68,6 @@ func clusterLabelString(cluster *v1beta1.KafkaCluster) string {
 	return fmt.Sprintf("%s.%s", cluster.Name, cluster.Namespace)
 }
 
-// newBrokerConnection is a convenience wrapper for creating a broker connection
-// and creating a safer close function
-func newBrokerConnection(log logr.Logger, client client.Client, cluster *v1beta1.KafkaCluster) (broker kafkaclient.KafkaClient, close func(), err error) {
-	// Get a kafka connection
-	log.Info(fmt.Sprintf("Retrieving Kafka client for %s/%s", cluster.Namespace, cluster.Name))
-	broker, err = newKafkaFromCluster(client, cluster)
-	if err != nil {
-		return
-	}
-	close = func() {
-		if err := broker.Close(); err != nil {
-			log.Error(err, "Error closing Kafka client")
-		} else {
-			log.Info("Kafka client closed cleanly")
-		}
-	}
-	return
-}
-
 // checkBrokerConnectionError is a convenience wrapper for returning from common
 // broker connection errors
 func checkBrokerConnectionError(logger logr.Logger, err error) (ctrl.Result, error) {
@@ -128,6 +109,6 @@ func applyClusterRefLabel(cluster *v1beta1.KafkaCluster, labels map[string]strin
 	return labels
 }
 
-func SetNewKafkaFromCluster(f func(k8sclient client.Client, cluster *v1beta1.KafkaCluster) (kafkaclient.KafkaClient, error)) {
+func SetNewKafkaFromCluster(f func(k8sclient client.Client, cluster *v1beta1.KafkaCluster) (kafkaclient.KafkaClient, func(), error)) {
 	newKafkaFromCluster = f
 }

--- a/controllers/controller_common_test.go
+++ b/controllers/controller_common_test.go
@@ -95,7 +95,7 @@ func TestNewBrokerConnection(t *testing.T) {
 	// overwrite the var in controller_common to point kafka connections at mock
 	SetNewKafkaFromCluster(kafkaclient.NewMockFromCluster)
 
-	_, close, err := newBrokerConnection(log, client, cluster)
+	_, close, err := newKafkaFromCluster(client, cluster)
 	if err != nil {
 		t.Error("Expected no error got:", err)
 	}
@@ -104,7 +104,7 @@ func TestNewBrokerConnection(t *testing.T) {
 	// reset the newKafkaFromCluster var - will attempt to connect to a cluster
 	// that doesn't exist
 	SetNewKafkaFromCluster(kafkaclient.NewFromCluster)
-	if _, _, err = newBrokerConnection(log, client, cluster); err == nil {
+	if _, _, err = newKafkaFromCluster(client, cluster); err == nil {
 		t.Error("Expected error got nil")
 	} else if !emperrors.As(err, &errorfactory.BrokersUnreachable{}) {
 		t.Error("Expected brokers unreachable error, got:", err)

--- a/controllers/kafkatopic_controller.go
+++ b/controllers/kafkatopic_controller.go
@@ -114,7 +114,7 @@ func (r *KafkaTopicReconciler) Reconcile(request reconcile.Request) (reconcile.R
 	}
 
 	// Get a kafka connection
-	broker, close, err := newBrokerConnection(reqLogger, r.Client, cluster)
+	broker, close, err := newKafkaFromCluster(r.Client, cluster)
 	if err != nil {
 		return checkBrokerConnectionError(reqLogger, err)
 	}

--- a/controllers/kafkauser_controller.go
+++ b/controllers/kafkauser_controller.go
@@ -218,7 +218,7 @@ func (r *KafkaUserReconciler) Reconcile(request reconcile.Request) (reconcile.Re
 
 	// If topic grants supplied, grab a broker connection and set ACLs
 	if len(instance.Spec.TopicGrants) > 0 {
-		broker, close, err := newBrokerConnection(reqLogger, r.Client, cluster)
+		broker, close, err := newKafkaFromCluster(r.Client, cluster)
 		if err != nil {
 			return checkBrokerConnectionError(reqLogger, err)
 		}
@@ -305,7 +305,7 @@ func (r *KafkaUserReconciler) finalizeKafkaUserACLs(reqLogger logr.Logger, clust
 	}
 	var err error
 	reqLogger.Info("Deleting user ACLs from kafka")
-	broker, close, err := newBrokerConnection(reqLogger, r.Client, cluster)
+	broker, close, err := newKafkaFromCluster(r.Client, cluster)
 	if err != nil {
 		return err
 	}

--- a/controllers/tests/kafkatopic_controller_test.go
+++ b/controllers/tests/kafkatopic_controller_test.go
@@ -116,7 +116,7 @@ var _ = Describe("KafkaTopic", func() {
 				return topic.Status.State, nil
 			}, 5*time.Second, 100*time.Millisecond).Should(Equal(v1alpha1.TopicStateCreated))
 
-			mockKafkaClient := getMockedKafkaClientForCluster(kafkaCluster)
+			mockKafkaClient, _ := getMockedKafkaClientForCluster(kafkaCluster)
 			detail, err := mockKafkaClient.GetTopic(topicName)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(detail).To(Equal(&sarama.TopicDetail{
@@ -143,7 +143,7 @@ var _ = Describe("KafkaTopic", func() {
 		var topicName = "already-created-topic"
 
 		JustBeforeEach(func() {
-			mockKafkaClient := getMockedKafkaClientForCluster(kafkaCluster)
+			mockKafkaClient, _ := getMockedKafkaClientForCluster(kafkaCluster)
 
 			err := mockKafkaClient.CreateTopic(&kafkaclient.CreateTopicOptions{
 				Name:              topicName,
@@ -194,7 +194,7 @@ var _ = Describe("KafkaTopic", func() {
 				return topic.Status.State, nil
 			}, 5*time.Second, 100*time.Millisecond).Should(Equal(v1alpha1.TopicStateCreated))
 
-			mockKafkaClient := getMockedKafkaClientForCluster(kafkaCluster)
+			mockKafkaClient, _ := getMockedKafkaClientForCluster(kafkaCluster)
 			detail, err := mockKafkaClient.GetTopic(topicName)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(detail).To(Equal(&sarama.TopicDetail{

--- a/controllers/tests/kafkauser_controller_test.go
+++ b/controllers/tests/kafkauser_controller_test.go
@@ -129,7 +129,7 @@ var _ = Describe("KafkaTopic", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(user.Labels).To(HaveKeyWithValue("kafkaCluster", fmt.Sprintf("%s.%s", kafkaClusterCRName, namespace)))
 
-		mockKafkaClient := getMockedKafkaClientForCluster(kafkaCluster)
+		mockKafkaClient, _ := getMockedKafkaClientForCluster(kafkaCluster)
 		acls, _ := mockKafkaClient.ListUserACLs()
 		Expect(acls).To(ContainElements(
 			sarama.ResourceAcls{

--- a/controllers/tests/suite_test.go
+++ b/controllers/tests/suite_test.go
@@ -141,8 +141,9 @@ var _ = BeforeSuite(func(done Done) {
 
 	// mock the creation of Kafka clients
 	controllers.SetNewKafkaFromCluster(
-		func(k8sclient client.Client, cluster *banzaicloudv1beta1.KafkaCluster) (kafkaclient.KafkaClient, error) {
-			return getMockedKafkaClientForCluster(cluster), nil
+		func(k8sclient client.Client, cluster *banzaicloudv1beta1.KafkaCluster) (kafkaclient.KafkaClient, func(), error) {
+			client, close := getMockedKafkaClientForCluster(cluster)
+			return client, close, nil
 		})
 
 	kafkaClusterReconciler := controllers.KafkaClusterReconciler{

--- a/pkg/kafkaclient/client.go
+++ b/pkg/kafkaclient/client.go
@@ -111,16 +111,23 @@ func (k *kafkaClient) Close() error {
 }
 
 // NewFromCluster is a convenience wrapper around New() and ClusterConfig()
-func NewFromCluster(k8sclient client.Client, cluster *v1beta1.KafkaCluster) (KafkaClient, error) {
+func NewFromCluster(k8sclient client.Client, cluster *v1beta1.KafkaCluster) (KafkaClient, func(), error) {
 	var client KafkaClient
 	var err error
 	opts, err := ClusterConfig(k8sclient, cluster)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	client = New(opts)
 	err = client.Open()
-	return client, err
+	close := func() {
+		if err := client.Close(); err != nil {
+			log.Error(err, "Error closing Kafka client")
+		} else {
+			log.Info("Kafka client closed cleanly")
+		}
+	}
+	return client, close, err
 }
 
 func (k *kafkaClient) Brokers() map[int32]string {

--- a/pkg/kafkaclient/mock_client.go
+++ b/pkg/kafkaclient/mock_client.go
@@ -33,8 +33,9 @@ type mockClusterAdmin struct {
 	mockACLs   map[sarama.Resource]*sarama.ResourceAcls
 }
 
-func NewMockFromCluster(client client.Client, cluster *v1beta1.KafkaCluster) (KafkaClient, error) {
-	return newOpenedMockClient(), nil
+func NewMockFromCluster(client client.Client, cluster *v1beta1.KafkaCluster) (KafkaClient, func(), error) {
+	cl := newOpenedMockClient()
+	return cl, func() { cl.Close() }, nil
 }
 
 func newEmptyMockClusterAdmin(failOps bool) *mockClusterAdmin {

--- a/pkg/kafkaclient/provider.go
+++ b/pkg/kafkaclient/provider.go
@@ -21,7 +21,7 @@ import (
 )
 
 type Provider interface {
-	NewFromCluster(client client.Client, cluster *v1beta1.KafkaCluster) (KafkaClient, error)
+	NewFromCluster(client client.Client, cluster *v1beta1.KafkaCluster) (KafkaClient, func(), error)
 }
 
 type mockProvider struct {
@@ -31,7 +31,7 @@ func NewMockProvider() Provider {
 	return &mockProvider{}
 }
 
-func (mp *mockProvider) NewFromCluster(client client.Client, cluster *v1beta1.KafkaCluster) (KafkaClient, error) {
+func (mp *mockProvider) NewFromCluster(client client.Client, cluster *v1beta1.KafkaCluster) (KafkaClient, func(), error) {
 	return NewMockFromCluster(client, cluster)
 }
 
@@ -42,6 +42,6 @@ func NewDefaultProvider() Provider {
 	return &defaultProvider{}
 }
 
-func (dp *defaultProvider) NewFromCluster(client client.Client, cluster *v1beta1.KafkaCluster) (KafkaClient, error) {
+func (dp *defaultProvider) NewFromCluster(client client.Client, cluster *v1beta1.KafkaCluster) (KafkaClient, func(), error) {
 	return NewFromCluster(client, cluster)
 }

--- a/pkg/resources/kafka/configs.go
+++ b/pkg/resources/kafka/configs.go
@@ -33,15 +33,11 @@ import (
 )
 
 func (r *Reconciler) reconcilePerBrokerDynamicConfig(brokerId int32, brokerConfig *v1beta1.BrokerConfig, configMap *corev1.ConfigMap, log logr.Logger) error {
-	kClient, err := r.kafkaClientProvider.NewFromCluster(r.Client, r.KafkaCluster)
+	kClient, close, err := r.kafkaClientProvider.NewFromCluster(r.Client, r.KafkaCluster)
 	if err != nil {
 		return errorfactory.New(errorfactory.BrokersUnreachable{}, err, "could not connect to kafka brokers")
 	}
-	defer func() {
-		if err := kClient.Close(); err != nil {
-			log.Error(err, "could not close client")
-		}
-	}()
+	defer close()
 
 	fullPerBrokerConfig, err := properties.NewFromString(brokerConfig.Config)
 	if err != nil {
@@ -123,15 +119,11 @@ func (r *Reconciler) reconcilePerBrokerDynamicConfig(brokerId int32, brokerConfi
 }
 
 func (r *Reconciler) reconcileClusterWideDynamicConfig(log logr.Logger) error {
-	kClient, err := r.kafkaClientProvider.NewFromCluster(r.Client, r.KafkaCluster)
+	kClient, close, err := r.kafkaClientProvider.NewFromCluster(r.Client, r.KafkaCluster)
 	if err != nil {
 		return errorfactory.New(errorfactory.BrokersUnreachable{}, err, "could not connect to kafka brokers")
 	}
-	defer func() {
-		if err := kClient.Close(); err != nil {
-			log.Error(err, "could not close client")
-		}
-	}()
+	defer close()
 
 	currentConfig, err := kClient.DescribeClusterWideConfig()
 	if err != nil {

--- a/pkg/webhook/server.go
+++ b/pkg/webhook/server.go
@@ -37,7 +37,7 @@ type webhookServer struct {
 	deserializer runtime.Decoder
 
 	// For mocking - use kafkaclient.NewMockFromCluster
-	newKafkaFromCluster func(client.Client, *v1beta1.KafkaCluster) (kafkaclient.KafkaClient, error)
+	newKafkaFromCluster func(client.Client, *v1beta1.KafkaCluster) (kafkaclient.KafkaClient, func(), error)
 }
 
 func newWebHookServer(client client.Client, scheme *runtime.Scheme) *webhookServer {

--- a/pkg/webhook/server_test.go
+++ b/pkg/webhook/server_test.go
@@ -38,7 +38,7 @@ func newMockServer() (*webhookServer, error) {
 }
 
 func newMockServerWithClients(c client.Client, kafkaClientProvider func(client client.Client,
-	cluster *v1beta1.KafkaCluster) (kafkaclient.KafkaClient, error)) (*webhookServer, error) {
+	cluster *v1beta1.KafkaCluster) (kafkaclient.KafkaClient, func(), error)) (*webhookServer, error) {
 	if err := certv1.AddToScheme(scheme.Scheme); err != nil {
 		return nil, err
 	}

--- a/pkg/webhook/topic_validator.go
+++ b/pkg/webhook/topic_validator.go
@@ -74,12 +74,13 @@ func (s *webhookServer) validateKafkaTopic(topic *v1alpha1.KafkaTopic) (res *adm
 	}
 
 	// retrieve an admin client for the cluster
-	broker, err := s.newKafkaFromCluster(s.client, cluster)
+	broker, close, err := s.newKafkaFromCluster(s.client, cluster)
 	if err != nil {
 		// Log as info to not cause stack traces when making CC topic
 		log.Info(cantConnectErrorMsg, "error", err.Error())
 		return notAllowed(fmt.Sprintf("%s: %s", cantConnectErrorMsg, topic.Spec.ClusterRef.Name), metav1.StatusReasonServiceUnavailable)
 	}
+	defer close()
 
 	existing, err := broker.GetTopic(topic.Spec.Name)
 	if err != nil {

--- a/pkg/webhook/topic_validator_test.go
+++ b/pkg/webhook/topic_validator_test.go
@@ -54,9 +54,9 @@ func newMockTopic() *v1alpha1.KafkaTopic {
 
 func newMockServerForTopicValidator(cluster *v1beta1.KafkaCluster) (*webhookServer, kafkaclient.KafkaClient, error) {
 	client := fake.NewFakeClientWithScheme(scheme.Scheme)
-	kafkaClient, _ := kafkaclient.NewMockFromCluster(client, cluster)
-	returnMockedKafkaClient := func(client runtimeClient.Client, cluster *v1beta1.KafkaCluster) (kafkaclient.KafkaClient, error) {
-		return kafkaClient, nil
+	kafkaClient, _, _ := kafkaclient.NewMockFromCluster(client, cluster)
+	returnMockedKafkaClient := func(client runtimeClient.Client, cluster *v1beta1.KafkaCluster) (kafkaclient.KafkaClient, func(), error) {
+		return kafkaClient, func() { kafkaClient.Close() }, nil
 	}
 	mockServerWithClients, err := newMockServerWithClients(client, returnMockedKafkaClient)
 	return mockServerWithClients, kafkaClient, err


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
`NewFromCluster` function from `pkg/kafkaclient` package now returns `close` function to clean/close resources used by connection opened inside.

### Why?
Kafka connection leak in validation web hook causing memory leak.


### Additional context

During reconciliation of 1-5K KafkaTopics we're getting OOMKill. Some memory usage:

Before fix:
<img width="626" alt="Screen Shot 2021-05-24 at 15 33 07" src="https://user-images.githubusercontent.com/34862826/119486263-bbc9b280-bd60-11eb-8ee4-917b4623cdce.png">

After fix:
<img width="462" alt="Screen Shot 2021-05-24 at 16 30 09" src="https://user-images.githubusercontent.com/34862826/119486304-c6844780-bd60-11eb-8560-08932d62c097.png">

### Checklist

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
- [ ] User guide and development docs updated (if needed)

### To Do
