### PR TITLE
Do not trigger admission check if not needed

### DIFF
--- a/controllers/kafkatopic_controller.go
+++ b/controllers/kafkatopic_controller.go
@@ -47,7 +47,7 @@ func SetupKafkaTopicWithManager(mgr ctrl.Manager) error {
 		Log:    ctrl.Log.WithName("controllers").WithName("KafkaTopic"),
 	}
 
-	c, err := controller.New("kafkatopic", mgr, controller.Options{Reconciler: r})
+	c, err := controller.New("kafkatopic", mgr, controller.Options{Reconciler: r, MaxConcurrentReconciles: 10})
 	if err != nil {
 		return err
 	}

--- a/controllers/kafkatopic_controller.go
+++ b/controllers/kafkatopic_controller.go
@@ -39,7 +39,7 @@ import (
 var topicFinalizer = "finalizer.kafkatopics.kafka.banzaicloud.io"
 
 // SetupKafkaTopicWithManager registers kafka topic controller with manager
-func SetupKafkaTopicWithManager(mgr ctrl.Manager) error {
+func SetupKafkaTopicWithManager(mgr ctrl.Manager, maxConcurrentReconciles int) error {
 	// Create a new controller
 	r := &KafkaTopicReconciler{
 		Client: mgr.GetClient(),
@@ -47,7 +47,7 @@ func SetupKafkaTopicWithManager(mgr ctrl.Manager) error {
 		Log:    ctrl.Log.WithName("controllers").WithName("KafkaTopic"),
 	}
 
-	c, err := controller.New("kafkatopic", mgr, controller.Options{Reconciler: r, MaxConcurrentReconciles: 10})
+	c, err := controller.New("kafkatopic", mgr, controller.Options{Reconciler: r, MaxConcurrentReconciles: maxConcurrentReconciles})
 	if err != nil {
 		return err
 	}

--- a/controllers/kafkatopic_controller.go
+++ b/controllers/kafkatopic_controller.go
@@ -170,17 +170,17 @@ func (r *KafkaTopicReconciler) Reconcile(request reconcile.Request) (reconcile.R
 	if !util.StringSliceContains(instance.GetFinalizers(), topicFinalizer) {
 		reqLogger.Info("Adding Finalizer for the KafkaTopic")
 		instance.SetFinalizers(append(instance.GetFinalizers(), topicFinalizer))
-	}
-
-	// push any changes
-	if instance, err = r.updateAndFetchLatest(ctx, instance); err != nil {
-		return requeueWithError(reqLogger, "failed to update KafkaTopic", err)
+		if instance, err = r.updateAndFetchLatest(ctx, instance); err != nil {
+			return requeueWithError(reqLogger, "failed to add Finalizer to KafakTopic", err)
+		}
 	}
 
 	// set topic status as created
-	instance.Status = v1alpha1.KafkaTopicStatus{State: v1alpha1.TopicStateCreated}
-	if err := r.Client.Status().Update(ctx, instance); err != nil {
-		return requeueWithError(reqLogger, "failed to update kafkatopic status", err)
+	if instance.Status.State != v1alpha1.TopicStateCreated {
+		instance.Status = v1alpha1.KafkaTopicStatus{State: v1alpha1.TopicStateCreated}
+		if err := r.Client.Status().Update(ctx, instance); err != nil {
+			return requeueWithError(reqLogger, "failed to update kafkatopic status", err)
+		}
 	}
 
 	reqLogger.Info("Ensured topic")

--- a/controllers/kafkatopic_controller.go
+++ b/controllers/kafkatopic_controller.go
@@ -171,7 +171,7 @@ func (r *KafkaTopicReconciler) Reconcile(request reconcile.Request) (reconcile.R
 		reqLogger.Info("Adding Finalizer for the KafkaTopic")
 		instance.SetFinalizers(append(instance.GetFinalizers(), topicFinalizer))
 		if instance, err = r.updateAndFetchLatest(ctx, instance); err != nil {
-			return requeueWithError(reqLogger, "failed to add Finalizer to KafakTopic", err)
+			return requeueWithError(reqLogger, "failed to add Finalizer to KafkaTopic", err)
 		}
 	}
 

--- a/controllers/tests/suite_test.go
+++ b/controllers/tests/suite_test.go
@@ -157,7 +157,7 @@ var _ = BeforeSuite(func(done Done) {
 	err = controllers.SetupKafkaClusterWithManager(mgr, kafkaClusterReconciler.Log).Complete(&kafkaClusterReconciler)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = controllers.SetupKafkaTopicWithManager(mgr)
+	err = controllers.SetupKafkaTopicWithManager(mgr, 10)
 	Expect(err).NotTo(HaveOccurred())
 
 	err = controllers.SetupKafkaUserWithManager(mgr, true)

--- a/main.go
+++ b/main.go
@@ -75,14 +75,15 @@ func init() {
 
 func main() {
 	var (
-		namespaces           string
-		metricsAddr          string
-		enableLeaderElection bool
-		webhookCertDir       string
-		webhookDisabled      bool
-		developmentLogging   bool
-		verboseLogging       bool
-		certManagerEnabled   bool
+		namespaces                        string
+		metricsAddr                       string
+		enableLeaderElection              bool
+		webhookCertDir                    string
+		webhookDisabled                   bool
+		developmentLogging                bool
+		verboseLogging                    bool
+		certManagerEnabled                bool
+		maxKafkaTopicConcurrentReconciles int
 	)
 
 	flag.StringVar(&namespaces, "namespaces", "", "Comma separated list of namespaces where operator listens for resources")
@@ -94,6 +95,7 @@ func main() {
 	flag.BoolVar(&developmentLogging, "development", false, "Enable development logging")
 	flag.BoolVar(&verboseLogging, "verbose", false, "Enable verbose logging")
 	flag.BoolVar(&certManagerEnabled, "cert-manager-enabled", false, "Enable cert-manager integration")
+	flag.IntVar(&maxKafkaTopicConcurrentReconciles, "max-kafka-topic-concurrent-reconciles", 10, "Define max amount of concurrent KafkaTopic reconciles")
 	flag.Parse()
 
 	ctrl.SetLogger(util.CreateLogger(verboseLogging, developmentLogging))
@@ -150,7 +152,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err = controllers.SetupKafkaTopicWithManager(mgr); err != nil {
+	if err = controllers.SetupKafkaTopicWithManager(mgr, maxKafkaTopicConcurrentReconciles); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "KafkaTopic")
 		os.Exit(1)
 	}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Do not try to update `KafkaTopic` CRD if nothing to update. Every update ends up in validation check.
Increase concurrency for `KafkaTopic` reconciler. Every KafkaTopic reconciliation process is pretty independent without side effects.


### Why?

During operator init all `KafkaTopic` CRDs need to be reconciled. Having many of them (~3-5K) might take a lot of time (a few hours) as it checks topic configuration against Kafka cluster.


### Checklist

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
