### PR TITLE
Adding sidecar features to kafka-operator

### DIFF
--- a/charts/kafka-operator/README.md
+++ b/charts/kafka-operator/README.md
@@ -82,3 +82,6 @@ Parameter | Description | Default
 `webhook.enabled` | Operator will activate the admission webhooks for custom resources | `true`
 `webhook.certs.generate` | Helm chart will generate cert for the webhook | `true`
 `webhook.certs.secret` | Helm chart will use the secret name applied here for the cert | `kafka-operator-serving-cert`
+`additionalEnv` | Additional Environment Variables | `[]`
+`additionalSidecars` | Additional Sidecars Configuration | `[]`
+`additionalVolumes` | Additional volumes required for sidecars | `[]`

--- a/charts/kafka-operator/templates/_helpers.tpl
+++ b/charts/kafka-operator/templates/_helpers.tpl
@@ -52,3 +52,17 @@ Compute operator prometheus metrics auth proxy service account
 {{ default "default" .Values.prometheusMetrics.authProxy.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Sidecar implementation details
+*/}}
+{{- define "chart.additionalSidecars"}}
+{{ toYaml .Values.additionalSidecars }}
+{{- end}}
+
+{{/*
+Sidecar volume implementation details
+*/}}
+{{- define "chart.additionalVolumes"}}
+{{ toYaml .Values.additionalVolumes }}
+{{- end}}

--- a/charts/kafka-operator/templates/operator-deployment-with-webhook.yaml
+++ b/charts/kafka-operator/templates/operator-deployment-with-webhook.yaml
@@ -127,6 +127,9 @@ spec:
           secret:
             secretName: {{ .Values.operator.vaultSecret }}
       {{- end }}
+      {{- if .Values.additionalVolumes }}
+      {{- include "chart.additionalVolumes" . | indent 8 }}
+      {{- end }}
       containers:
       {{- if and .Values.prometheusMetrics.enabled .Values.prometheusMetrics.authProxy.enabled }}
         - name: kube-rbac-proxy
@@ -167,6 +170,9 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+          {{- if .Values.additionalEnv }}
+{{ toYaml .Values.additionalEnv | indent 12 }}
+          {{- end }}
           {{- if .Values.operator.vaultAddress }}
             - name: VAULT_ADDR
               value: {{ .Values.operator.vaultAddress }}
@@ -200,6 +206,9 @@ spec:
           {{- end }}
           resources:
 {{ toYaml .Values.operator.resources | nindent 12 }}
+{{- if .Values.additionalSidecars }}
+{{- include "chart.additionalSidecars" . | indent 8 }}
+{{- end }}
 {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/charts/kafka-operator/values.yaml
+++ b/charts/kafka-operator/values.yaml
@@ -72,3 +72,18 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+## Additional Sidecars Configuration.
+additionalSidecars: {}
+# - name: nginx
+#   image: nginx:latest
+
+## Additional Environment Variables.
+additionalEnv: {}
+
+## Additional volumes required for sidecars.
+additionalVolumes: {}
+# - name: volume1
+#   emptyDir: {}
+# - name: volume2
+#   emptyDir: {}


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | no |
| New feature?    | yes |
| API breaks?     | no |
| Deprecations?   | no |
| Related tickets |  |
| License         | Apache 2.0 |


### What's in this PR?
Adding sidecar features to kafka operator.
Enabling the required volumes and environment variables.


### Why?
Better to have Sidecar enabling feature.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ x] Implementation tested
- [x ] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [ x] Logging code meets the guideline
- [x ] User guide and development docs updated (if needed)

