### PR TITLE
Do not allow to add uppercase listener name

### DIFF
--- a/charts/kafka-operator/templates/crds.yaml
+++ b/charts/kafka-operator/templates/crds.yaml
@@ -7602,6 +7602,7 @@ spec:
                           description: 'In case of external listeners using LoadBalancer access method the value of this field is used to advertise the Kafka broker external listener instead of the public IP of the provisioned LoadBalancer service (e.g. can be used to advertise the listener using a URL recorded in DNS instead of public IP). In case of external listeners using NodePort access method the broker instead of node public IP (see "brokerConfig.nodePortExternalIP") is advertised on the address having the following format: <kafka-cluster-name>-<broker-id>.<namespace><value-specified-in-hostnameOverride-field>'
                           type: string
                         name:
+                          pattern: ^[a-z0-9\-]+
                           type: string
                         serviceAnnotations:
                           additionalProperties:
@@ -7634,6 +7635,7 @@ spec:
                           format: int32
                           type: integer
                         name:
+                          pattern: ^[a-z0-9\-]+
                           type: string
                         type:
                           description: 'SecurityProtocol is the protocol used to communicate with brokers. Valid values are: plaintext, ssl, sasl_plaintext, sasl_ssl.'

--- a/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
+++ b/config/base/crds/kafka.banzaicloud.io_kafkaclusters.yaml
@@ -7601,6 +7601,7 @@ spec:
                           description: 'In case of external listeners using LoadBalancer access method the value of this field is used to advertise the Kafka broker external listener instead of the public IP of the provisioned LoadBalancer service (e.g. can be used to advertise the listener using a URL recorded in DNS instead of public IP). In case of external listeners using NodePort access method the broker instead of node public IP (see "brokerConfig.nodePortExternalIP") is advertised on the address having the following format: <kafka-cluster-name>-<broker-id>.<namespace><value-specified-in-hostnameOverride-field>'
                           type: string
                         name:
+                          pattern: ^[a-z0-9\-]+
                           type: string
                         serviceAnnotations:
                           additionalProperties:
@@ -7633,6 +7634,7 @@ spec:
                           format: int32
                           type: integer
                         name:
+                          pattern: ^[a-z0-9\-]+
                           type: string
                         type:
                           description: 'SecurityProtocol is the protocol used to communicate with brokers. Valid values are: plaintext, ssl, sasl_plaintext, sasl_ssl.'

--- a/pkg/sdk/v1beta1/kafkacluster_types.go
+++ b/pkg/sdk/v1beta1/kafkacluster_types.go
@@ -416,9 +416,10 @@ type InternalListenerConfig struct {
 // CommonListenerSpec defines the common building block for Listener type
 type CommonListenerSpec struct {
 	// +kubebuilder:validation:Enum=ssl;plaintext;sasl_ssl;sasl_plaintext
-	Type          SecurityProtocol `json:"type"`
-	Name          string           `json:"name"`
-	ContainerPort int32            `json:"containerPort"`
+	Type SecurityProtocol `json:"type"`
+	// +kubebuilder:validation:Pattern=^[a-z0-9\-]+
+	Name          string `json:"name"`
+	ContainerPort int32  `json:"containerPort"`
 }
 
 // ListenerStatuses holds information about the statuses of the configured listeners.


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        |yes |
| New feature?    |yes |
| API breaks?     |yes |
| Deprecations?   |yes |
| License         | Apache 2.0 |


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
This PR adds validation to the listener names since uppercase listener names are not allowed. We are using those names as a port name and only valid dns names can be used.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested
- [X] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [X] Logging code meets the guideline
- [X] User guide and development docs updated (if needed)
