### PR TITLE
fix: KafkaCluster name is not propagated to the podAntiAffinity rule

### DIFF
--- a/pkg/resources/kafka/pod.go
+++ b/pkg/resources/kafka/pod.go
@@ -315,7 +315,7 @@ func getVolumes(brokerConfigVolumes, dataVolume []corev1.Volume, kafkaClusterNam
 // or if there is any user Affinity definition provided by the user the latter will be used ignoring the value of `OneBrokerPerNode`
 func getAffinity(bc *v1beta1.BrokerConfig, cluster *v1beta1.KafkaCluster) *corev1.Affinity {
 	if bc.Affinity == nil {
-		return &corev1.Affinity{PodAntiAffinity: generatePodAntiAffinity(cluster.ClusterName, cluster.Spec.OneBrokerPerNode)}
+		return &corev1.Affinity{PodAntiAffinity: generatePodAntiAffinity(cluster.Name, cluster.Spec.OneBrokerPerNode)}
 	}
 	return bc.Affinity
 }

--- a/pkg/resources/kafka/pod_test.go
+++ b/pkg/resources/kafka/pod_test.go
@@ -46,7 +46,7 @@ func TestGetAffinity(t *testing.T) {
 
 	cluster := v1beta1.KafkaCluster{
 		ObjectMeta: metav1.ObjectMeta{
-			ClusterName: "name",
+			Name: "name",
 		},
 		Spec: v1beta1.KafkaClusterSpec{
 			BrokerConfigGroups: map[string]v1beta1.BrokerConfig{


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | yes |
| New feature?    | no |
| API breaks?     | no |
| Deprecations?   | no |
| Related tickets | fixes #629  |
| License         | Apache 2.0 |



### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)

