### PR TITLE
Generate coordination.k8s.io/leases RBACs for operator

### DIFF
--- a/charts/kafka-operator/templates/operator-rbac.yaml
+++ b/charts/kafka-operator/templates/operator-rbac.yaml
@@ -205,6 +205,18 @@ rules:
   - update
   - watch
 - apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - policy
   resources:
   - poddisruptionbudgets

--- a/config/base/rbac/role.yaml
+++ b/config/base/rbac/role.yaml
@@ -138,6 +138,18 @@ rules:
   - update
   - watch
 - apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - istio.banzaicloud.io
   resources:
   - meshgateways

--- a/controllers/kafkacluster_controller.go
+++ b/controllers/kafkacluster_controller.go
@@ -80,6 +80,7 @@ type KafkaClusterReconciler struct {
 // +kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
 // +kubebuilder:rbac:groups="policy",resources=poddisruptionbudgets,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=kafka.banzaicloud.io,resources=kafkaclusters,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=kafka.banzaicloud.io,resources=kafkaclusters/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=istio.banzaicloud.io,resources=meshgateways,verbs=get;list;watch;create;update;patch;delete


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | yes |
| New feature?    | no|
| API breaks?     | no |
| Deprecations?   | no |
| License         | Apache 2.0 |


### What's in this PR?

Add a new kubebuilder annotation to generate the required RBAC for manipulating coordination.k8s.io/leases 


### Why?

Using the latest operator version we get this:
```
E0622 09:28:06.247115 1 leaderelection.go:325] error retrieving resource lock ns-team-aep-pipeline-mgmt-2-cicd/controller-leader-election-helper: leases.coordination.k8s.io "controller-leader-election-helper" is forbidden: User "system:serviceaccount:ns-team-aep-pipeline-mgmt-2-cicd:kafka-operator" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "ns-team-aep-pipeline-mgmt-2-cicd"
````

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)

