### PR TITLE
Fixing downscale alert

### DIFF
--- a/config/samples/kafkacluster-prometheus.yaml
+++ b/config/samples/kafkacluster-prometheus.yaml
@@ -122,7 +122,7 @@ spec:
         # brokerAnnotations: '{ "sidecar.istio.io/logLevel": "trace", "sidecar.istio.io/proxyCPULimit": "50m" }'
         command: 'upScale'
     - alert: PartitionCountLow
-      expr: min(kafka_server_replicamanager_partitioncount)  by (namespace, kafka_cr) < 40
+      expr: bottomk(1, kafka_server_replicamanager_partitioncount) by (namespace, kafka_cr) < 40
       for: 3m
       labels:
         severity: alert


### PR DESCRIPTION
| Q               | A      |
| --------------- | ------ |
| Bug fix?        | yes |
| New feature?    | no |
| API breaks?     | no |
| Deprecations?   | no |
| Related tickets | fixes #628 |
| License         | Apache 2.0 |

### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
This PR contains a fix in the prometheus settings to resolve #628.

Replaced the `min()` Prometheus aggregation operator with `bottomk(1, )` (while `min` provides you with the value of the minimum, `bottomk` returns the minimum record where the minimum is - thus broker with the whole labelset).

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
See the issue for more details.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->
Tested on the 9-node setup - successfully downscaled to 7 without human intervention.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/developer-guide/blob/master/docs/coding-style/error-handling-guide.md)
- [x] Logging code meets the guideline