### PR TITLE
Update helm chart version to prepare release v0.18.0

### DIFF
--- a/charts/kafka-operator/Chart.yaml
+++ b/charts/kafka-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: kafka-operator
-version: 0.4.9
+version: 0.4.10
 description: kafka-operator manages Kafka deployments on Kubernetes
 sources:
   - https://github.com/banzaicloud/kafka-operator
-appVersion: v0.17.0
+appVersion: v0.18.0


### PR DESCRIPTION
This PR bumps the helm chart and the operator version to prepare the release v0.18.0